### PR TITLE
Cert/inspect/stdin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -72,6 +72,14 @@
   revision = "2b8494104d86337cdd41d0a49cbed8e4583c0ab4"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "UT"
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
+
+[[projects]]
   branch = "master"
   digest = "1:4ee452f8994700dcab9e816aef1cb9eb2317218734c6ccf5135746e6c19f3dce"
   name = "github.com/golang/lint"
@@ -163,6 +171,14 @@
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = "UT"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:6c7a3f738e37a1c7ad3d56122a34932140654d51a57e01f8613cdf3eaf050911"
   name = "github.com/pquerna/otp"
   packages = [
@@ -230,6 +246,17 @@
   ]
   pruneopts = "UT"
   revision = "d84eaafe274f9dc1f811ebfbb073e18c466e2a44"
+
+[[projects]]
+  digest = "1:c40d65817cdd41fac9aa7af8bed56927bb2d6d47e4fea566a74880f5c2b1c41e"
+  name = "github.com/stretchr/testify"
+  packages = [
+    "assert",
+    "require",
+  ]
+  pruneopts = "UT"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   branch = "master"
@@ -398,6 +425,7 @@
     "github.com/smallstep/certinfo",
     "github.com/smallstep/zcrypto/x509",
     "github.com/smallstep/zlint",
+    "github.com/stretchr/testify/require",
     "github.com/tsenart/deadcode",
     "github.com/urfave/cli",
     "golang.org/x/crypto/argon2",

--- a/command/certificate/inspect.go
+++ b/command/certificate/inspect.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/smallstep/cli/crypto/x509util"
 	"github.com/smallstep/cli/errs"
 	x509 "github.com/smallstep/cli/pkg/x509"
+	"github.com/smallstep/cli/utils"
 	zx509 "github.com/smallstep/zcrypto/x509"
 	"github.com/urfave/cli"
 )
@@ -39,7 +39,7 @@ print all certificates in the order in which they appear in the bundle.
 ## POSITIONAL ARGUMENTS
 
 <crt_file>
-:  Path to a certificate or certificate signing request (CSR) to inspect.
+:  Path to a certificate or certificate signing request (CSR) to inspect. A hyphen ("-") indicates STDIN as <crt_file>.
 
 ## EXIT CODES
 
@@ -195,7 +195,7 @@ func inspectAction(ctx *cli.Context) error {
 				})
 			}
 		} else {
-			crtBytes, err := ioutil.ReadFile(crtFile)
+			crtBytes, err := utils.ReadFile(crtFile)
 			if err != nil {
 				return errs.FileError(err, crtFile)
 			}
@@ -261,7 +261,7 @@ func inspectAction(ctx *cli.Context) error {
 				Bytes: peerCertificates[0].Raw,
 			}
 		} else {
-			crtBytes, err := ioutil.ReadFile(crtFile)
+			crtBytes, err := utils.ReadFile(crtFile)
 			if err != nil {
 				return errs.FileError(err, crtFile)
 			}

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -249,13 +249,13 @@ func FileError(err error, filename string) error {
 	if err == nil {
 		return nil
 	}
-	switch e := errors.Cause(err).(type) {
+	switch e := err.(type) {
 	case *os.PathError:
 		return errors.Errorf("%s %s failed: %v", e.Op, e.Path, e.Err)
 	case *os.LinkError:
-		return errors.Errorf("%s %s %s failed %v:", e.Op, e.Old, e.New, e.Err)
+		return errors.Errorf("%s %s %s failed: %v", e.Op, e.Old, e.New, e.Err)
 	case *os.SyscallError:
-		return errors.Errorf("%s failed %v:", e.Syscall, e.Err)
+		return errors.Errorf("%s failed: %v", e.Syscall, e.Err)
 	default:
 		return Wrap(err, "unexpected error on %s", filename)
 	}

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -1,0 +1,44 @@
+package errs
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"errors"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileError(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected string
+	}{
+		{
+			err:      os.NewSyscallError("open", errors.New("out of file descriptors")),
+			expected: "open failed: out of file descriptors",
+		},
+		{
+			err: func() error {
+				_, err := ioutil.ReadFile("im-fairly-certain-this-file-doesnt-exist")
+				require.Error(t, err)
+				return err
+			}(),
+			expected: "open im-fairly-certain-this-file-doesnt-exist failed",
+		},
+		{
+			err: func() error {
+				err := os.Link("im-fairly-certain-this-file-doesnt-exist", "neither-does-this")
+				require.Error(t, err)
+				return err
+			}(),
+			expected: "link im-fairly-certain-this-file-doesnt-exist neither-does-this failed",
+		},
+	}
+	for _, tt := range tests {
+		err := FileError(tt.err, "myfile")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), tt.expected)
+	}
+}

--- a/utils/read.go
+++ b/utils/read.go
@@ -10,8 +10,13 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
+	"github.com/smallstep/cli/errs"
 	"golang.org/x/crypto/ssh/terminal"
 )
+
+// In command line utilities, it is a de facto standard that a hyphen "-"
+// indicates STDIN as a file to be read.
+const stdinFilename = "-"
 
 // ReadAll returns a slice of bytes with the content of the given reader.
 func ReadAll(r io.Reader) ([]byte, error) {
@@ -68,4 +73,21 @@ func ReadInput(prompt string) ([]byte, error) {
 	}
 
 	return ReadPassword(prompt)
+}
+
+var _osStdin = os.Stdin
+
+// ReadFile returns the contents of the file identified by name. It reads from
+// STDIN if name is a hyphen ("-").
+func ReadFile(name string) (b []byte, err error) {
+	if name == stdinFilename {
+		name = "/dev/stdin"
+		b, err = ioutil.ReadAll(_osStdin)
+	} else {
+		b, err = ioutil.ReadFile(name)
+	}
+	if err != nil {
+		return nil, errs.FileError(err, name)
+	}
+	return b, nil
 }

--- a/utils/read_test.go
+++ b/utils/read_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Helper function for setting os.Stdin for mocking in tests.
+func setStdin(new *os.File) (cleanup func()) {
+	old := _osStdin
+	_osStdin = new
+	return func() { _osStdin = old }
+}
+
+func TestReadFile(t *testing.T) {
+	content := []byte("my file content")
+	f, cleanup := newFile(t, content)
+	defer cleanup()
+
+	b, err := ReadFile(f.Name())
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(content, b), "expected %s to equal %s", b, content)
+}
+
+func TestReadFileStdin(t *testing.T) {
+	content := []byte("my file content")
+	mockStdin, cleanup := newFile(t, content)
+	defer cleanup()
+	defer setStdin(mockStdin)()
+
+	b, err := ReadFile(stdinFilename)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(content, b), "expected %s to equal %s", b, content)
+}
+
+// Returns a temp file and a cleanup function to delete it.
+func newFile(t *testing.T, data []byte) (file *os.File, cleanup func()) {
+	f, err := ioutil.TempFile("" /* dir */, "utils-read-test")
+	require.NoError(t, err)
+	// write to temp file and reset read cursor to beginning of file
+	_, err = f.Write(data)
+	require.NoError(t, err)
+	_, err = f.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	return f, func() { os.Remove(f.Name()) }
+}


### PR DESCRIPTION
This started as simply wanting to allow for `step certificate inspect -` as a synonym for `step certificate inspect /dev/stdin`, which is a fairly common convention in CLI tools. It allows for more ergonomic shell piping.

Example:

```
cat /etc/ssl/certs/ca-certificates.crt | step certificate inspect -
```
This PR includes a few changes:

#### errs
One thing I noticed was that `errs.FileError` wasn't properly interpreting `os` errors, so I fixed that and added tests to validate its behavior.

#### utils
Next, I added `utils.ReadFile`, which returns all of the data from the named file, but allows for `-` for reading from stdin. This enables us to re-use the same behavior across the project.

#### command/certificate/inspect
Finally, I incorporated the new `utils.ReadFile` function into the `inspect` command, and added docs to reflect its usage.

Let me know what you think, thanks! :smile: 
