### PR TITLE
command/crypto/jwk/create: Add initial x5c support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 coverage.txt
 output
 vendor
+step

--- a/command/crypto/jwk/create.go
+++ b/command/crypto/jwk/create.go
@@ -398,12 +398,10 @@ key material will be written to disk unencrypted. This is not
 recommended. Requires **--insecure** flag.`,
 			},
 			cli.BoolFlag{
-				Name:   "subtle",
-				Hidden: true,
+				Name: "subtle",
 			},
 			cli.BoolFlag{
-				Name:   "insecure",
-				Hidden: true,
+				Name: "insecure",
 			},
 		},
 	}
@@ -483,7 +481,7 @@ func createAction(ctx *cli.Context) error {
 	var jwk *jose.JSONWebKey
 	switch {
 	case pemFile != "":
-		jwk, err = jose.GenerateJWKFromPEM(pemFile)
+		jwk, err = jose.GenerateJWKFromPEM(pemFile, ctx.Bool("subtle"))
 	default:
 		jwk, err = jose.GenerateJWK(kty, crv, alg, use, kid, size)
 	}

--- a/command/crypto/jwk/create.go
+++ b/command/crypto/jwk/create.go
@@ -3,14 +3,12 @@ package jwk
 import (
 	"bytes"
 	gocrypto "crypto"
-	realx509 "crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
-	"github.com/smallstep/cli/crypto/pemutil"
 	"github.com/smallstep/cli/crypto/randutil"
 	"github.com/smallstep/cli/errs"
 	"github.com/smallstep/cli/jose"
@@ -388,11 +386,6 @@ multiple algorithms.
 '--subtle' flag is required as you must verify that the operations are
 related.`,
 			},
-			cli.StringSliceFlag{
-				Name:   "from-certificate",
-				Usage:  `TODO: usage is missing.`,
-				Hidden: true,
-			},
 			cli.StringFlag{
 				Name: "from-pem",
 				Usage: `Create a JWK representing the key encoded in an
@@ -519,22 +512,6 @@ func createAction(ctx *cli.Context) error {
 
 	if err := jose.ValidateJWK(jwk); err != nil {
 		return err
-	}
-
-	// Add x5c (X.509 Certificate Chain) parameter
-	crtFiles := ctx.StringSlice("from-certificate")
-	for _, name := range crtFiles {
-		_crt, err := pemutil.ReadCertificate(name)
-		if err != nil {
-			return err
-		}
-		// have: step-cli x509 Certificate
-		// want: crypto/x509 Certificate
-		crt, err := realx509.ParseCertificate(_crt.Raw)
-		if err != nil {
-			return err
-		}
-		jwk.Certificates = append(jwk.Certificates, crt)
 	}
 
 	var jwkPub jose.JSONWebKey

--- a/jose/generate.go
+++ b/jose/generate.go
@@ -67,9 +67,10 @@ func GenerateJWKFromPEM(filename string, subtle bool) (*JSONWebKey, error) {
 		if err != nil {
 			return nil, err
 		}
-		use, err := keyUsageForCert(crt)
-		if err != nil {
-			if !subtle {
+		var use string
+		if !subtle {
+			use, err = keyUsageForCert(crt)
+			if err != nil {
 				return nil, err
 			}
 		}

--- a/jose/generate.go
+++ b/jose/generate.go
@@ -44,7 +44,7 @@ func GenerateJWK(kty, crv, alg, use, kid string, size int) (jwk *JSONWebKey, err
 
 // GenerateJWKFromPEM returns an incomplete JSONWebKey using the key from a
 // PEM file.
-func GenerateJWKFromPEM(filename string) (*JSONWebKey, error) {
+func GenerateJWKFromPEM(filename string, subtle bool) (*JSONWebKey, error) {
 	key, err := pemutil.Read(filename)
 	if err != nil {
 		return nil, err
@@ -69,7 +69,9 @@ func GenerateJWKFromPEM(filename string) (*JSONWebKey, error) {
 		}
 		use, err := keyUsageForCert(crt)
 		if err != nil {
-			return nil, err
+			if !subtle {
+				return nil, err
+			}
 		}
 		return &JSONWebKey{
 			Key:          key.PublicKey,

--- a/jose/generate.go
+++ b/jose/generate.go
@@ -21,8 +21,8 @@ const (
 )
 
 var (
-	ErrAmbiguousCertKeyUsage = errors.New("jose/generate: certificate's key usage is ambiguous, it should be for signature or encipherment, but not both (use --subtle to ignore usage field)")
-	ErrNoCertKeyUsage        = errors.New("jose/generate: certificate doesn't contain any key usage (use --subtle to ignore usage field)")
+	errAmbiguousCertKeyUsage = errors.New("jose/generate: certificate's key usage is ambiguous, it should be for signature or encipherment, but not both (use --subtle to ignore usage field)")
+	errNoCertKeyUsage        = errors.New("jose/generate: certificate doesn't contain any key usage (use --subtle to ignore usage field)")
 )
 
 // GenerateJWK generates a JWK given the key type, curve, alg, use, kid and
@@ -112,7 +112,7 @@ func keyUsageForCert(cert *realx509.Certificate) (string, error) {
 		realx509.KeyUsageDecipherOnly,
 	)
 	if isDigitalSignature && isEncipherment {
-		return "", ErrAmbiguousCertKeyUsage
+		return "", errAmbiguousCertKeyUsage
 	}
 	if isDigitalSignature {
 		return jwksUsageSig, nil
@@ -120,7 +120,7 @@ func keyUsageForCert(cert *realx509.Certificate) (string, error) {
 	if isEncipherment {
 		return jwksUsageEnc, nil
 	}
-	return "", ErrNoCertKeyUsage
+	return "", errNoCertKeyUsage
 }
 
 func containsUsage(usage realx509.KeyUsage, queries ...realx509.KeyUsage) bool {

--- a/jose/generate.go
+++ b/jose/generate.go
@@ -41,7 +41,11 @@ func GenerateJWKFromPEM(filename string) (*JSONWebKey, error) {
 	}
 
 	switch key := key.(type) {
-	case *rsa.PrivateKey, *rsa.PublicKey, *ecdsa.PrivateKey, *ecdsa.PublicKey, ed25519.PrivateKey, ed25519.PublicKey:
+	case *rsa.PrivateKey, *rsa.PublicKey:
+		return &JSONWebKey{
+			Key: key,
+		}, nil
+	case *ecdsa.PrivateKey, *ecdsa.PublicKey, ed25519.PrivateKey, ed25519.PublicKey:
 		return &JSONWebKey{
 			Key:       key,
 			Algorithm: algForKey(key),

--- a/jose/generate_test.go
+++ b/jose/generate_test.go
@@ -122,13 +122,13 @@ func TestKeyUsageForCert(t *testing.T) {
 		},
 		{
 			Cert:      &realx509.Certificate{},
-			ExpectErr: ErrNoCertKeyUsage,
+			ExpectErr: errNoCertKeyUsage,
 		},
 		{
 			Cert: &realx509.Certificate{
 				KeyUsage: realx509.KeyUsageDigitalSignature | realx509.KeyUsageDataEncipherment,
 			},
-			ExpectErr: ErrAmbiguousCertKeyUsage,
+			ExpectErr: errAmbiguousCertKeyUsage,
 		},
 	}
 


### PR DESCRIPTION
### Background
Opening this to start a bit of conversation on `x5c` support with JWKs (`step crypto jwk create`).

First, I think that re-using `--from-pem` is the right way to go, as opposed to creating a `--from-certificate` flag. Certificates behave much like public keys, with the added benefit that the key is signed and attested by some authority. Since the `--from-pem` flag already supports pubkeys, adding certificate support here makes some sense.

### Proposed Changes
This PR refactors some of the code in `jose/generate.go` and adds a switch case to allow for a JWK to be generated from a `*x509.Certificate` type.

### Example
Usage:
```
$ step crypto jwk create foo-jwks.json nopriv --from-pem path/to/foo-bundle.crt
```
Output:
```
$ cat foo-jwks.json 
{
  "use": "sig",
  "kty": "EC",
  "kid": "VX4i6RnH4axV_b9TIyPluPZCnligoiJ7rEuN5Wj5Un8",
  "crv": "P-256",
  "alg": "ES256",
  "x": "oltVQwlQoGgzKudo3yhloiZc2yPiwS2-MU4-ATTqOfk",
  "y": "0gcN9AYe5n9txmNKHEdshaXiT1VUGguCJ5cB0GpT4Ds",
  "x5c": [
    "MIIBlzCCAT2gAwIBAgIQc8XmPQaefVFuO2wRNrb/pjAKBggqhkjOPQQDAjAaMRgwFgYDVQQDEw9pbnRlcm1lZGlhdGUtY2EwHhcNMTgwODE0MDQzOTMyWhcNMTgwODE1MDQzOTMyWjAOMQwwCgYDVQQDEwNmb28wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASiW1VDCVCgaDMq52jfKGWiJlzbI+LBLb4xTj4BNOo5+dIHDfQGHuZ/bcZjShxHbIWl4k9VVBoLgieXAdBqU+A7o3EwbzAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB0GA1UdDgQWBBRfZtG6POzQqzguPOZ6Js3ZW2EN4DAfBgNVHSMEGDAWgBTMny0YJ7oJDdhF9s1tEi2GPY/GHTAKBggqhkjOPQQDAgNIADBFAiBVVd58gE7vqK5yuZ77dMSgANzDeXt1u2hWgK2vB/EK7QIhAPyz0FD2zL6O0QCfO3stEgaPhcpWGWxmHBtpM5QdLQET",
  ]
}
```

### Limitations
No support for certificate chains. `jose.GenerateJWKFromPEM()` uses `pemutil.Read()` to parse a named file into its private key, public key, or certificate form. The `pemutil.Read()` function currently returns an error if more than one PEM block exists in the file (as is the case with certificate chains). This will be addressed in a subsequent PR.

### Open Questions
The JWK creation command takes two required arguments, the private and public JWK files:
```
$ step crypto jwk create <public-jwk-file> <private-jwk-file>
```
In the case of public keys and certificates, the `<private-jwk-file>` param is simply discarded, and no file is generated. This may also be a good time to talk about whether that API is the right one. I don't know if I have a good answer, but since encrypting the private JWK file requires a user prompt, maybe prompting for a filename (with a reasonable default) is also acceptable.

EDIT: added example usage