### PR TITLE
HTML Styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ announcing step.
 ### Table of Contents
 
 - [Installing](#installing)
+- [Documentation](#documentation)
 - [Examples](#examples)
 - [Getting Started with Development](#getting-started-with-development)
 - [How to add a new Command](./command/README.md)
@@ -63,6 +64,16 @@ Test:
 ```
 step certificate inspect https://smallstep.com
 ```
+
+## Documentation
+
+Documentation can be found in three places:
+
+1. On the command line with `step help xxx` where `xxx` is the subcommand you are interested in. Ex: `step help crypto jwk`
+
+2. On the web at https://smallstep.com/docs/cli
+
+3. In your browser with `step help --http :8080` and visiting http://localhost:8080
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more information and docs see [the step website](https://smallstep.com/cli/)
 and the [blog post](https://smallstep.com/blog/zero-trust-swiss-army-knife.html)
 announcing step.
 
-![Alt Text](https://smallstep.com/images/blog/2018-08-07-unfurl.gif)
+![Animated terminal showing step in practice](https://smallstep.com/images/blog/2018-08-07-unfurl.gif)
 
 ### Table of Contents
 

--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -581,9 +581,9 @@ func (o *oauth) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
-	w.Write([]byte(`<html><head><title>OAuth Request Successfulh</title>`))
-	w.Write([]byte(`</head><body><p style='font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; font-size: 22px; color: #222; width: 400px; margin: 0 auto; text-align: center; line-height: 1.5; padding: 20px;'>`))
-	w.Write([]byte(`<strong>Success!</strong><br />Look for the token on the command line`))
+	w.Write([]byte(`<html><head><title>OAuth Request Successful</title>`))
+	w.Write([]byte(`</head><body><p style='font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; font-size: 22px; color: #333; width: 400px; margin: 0 auto; text-align: center; line-height: 1.7; padding: 20px;'>`))
+	w.Write([]byte(`<strong style='font-size: 28px; color: #000;'>Success</strong><br />Look for the token on the command line`))
 	w.Write([]byte(`</p></body></html>`))
 	o.tokCh <- tok
 }
@@ -637,8 +637,9 @@ func (o *oauth) Exchange(tokenEndpoint, code string) (*token, error) {
 func (o *oauth) badRequest(w http.ResponseWriter, msg string) {
 	w.WriteHeader(http.StatusBadRequest)
 	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
-	w.Write([]byte(`<html><head><title>OAuth Request Successfulh</title>`))
-	w.Write([]byte(`</head><body><p style='font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; font-size: 22px; color: red; width: 400px; margin: 0 auto; text-align: center; line-height: 1.5; padding: 20px;'>`))
+	w.Write([]byte(`<html><head><title>OAuth Request Unsuccessful</title>`))
+	w.Write([]byte(`</head><body><p style='font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; font-size: 22px; color: #333; width: 400px; margin: 0 auto; text-align: center; line-height: 1.7; padding: 20px;'>`))
+	w.Write([]byte(`<strong style='font-size: 28px; color: red;'>Failure</strong><br />`))
 	w.Write([]byte(msg))
 	w.Write([]byte(`</p></body></html>`))
 	o.errCh <- errors.New(msg)

--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -581,7 +581,10 @@ func (o *oauth) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
-	w.Write([]byte("Success: look for the token on the command line"))
+	w.Write([]byte(`<html><head><title>OAuth Request Successfulh</title>`))
+	w.Write([]byte(`</head><body><p style='font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; font-size: 22px; color: #222; width: 400px; margin: 0 auto; text-align: center; line-height: 1.5; padding: 20px;'>`))
+	w.Write([]byte(`<strong>Success!</strong><br />Look for the token on the command line`))
+	w.Write([]byte(`</p></body></html>`))
 	o.tokCh <- tok
 }
 
@@ -634,6 +637,9 @@ func (o *oauth) Exchange(tokenEndpoint, code string) (*token, error) {
 func (o *oauth) badRequest(w http.ResponseWriter, msg string) {
 	w.WriteHeader(http.StatusBadRequest)
 	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
+	w.Write([]byte(`<html><head><title>OAuth Request Successfulh</title>`))
+	w.Write([]byte(`</head><body><p style='font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; font-size: 22px; color: red; width: 400px; margin: 0 auto; text-align: center; line-height: 1.5; padding: 20px;'>`))
 	w.Write([]byte(msg))
+	w.Write([]byte(`</p></body></html>`))
 	o.errCh <- errors.New(msg)
 }

--- a/usage/css.go
+++ b/usage/css.go
@@ -8,6 +8,12 @@ var css = `@font-face {
   src: url(data:font/woff;charset=utf-8;base64,d09GRgABAAAAAAZwABAAAAAACFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEU0lHAAAGaAAAAAgAAAAIAAAAAUdTVUIAAAZcAAAACgAAAAoAAQAAT1MvMgAAAyQAAABJAAAAYFYEU3RjbWFwAAADcAAAAEUAAACAAJThvmN2dCAAAATkAAAABAAAAAQAAAAAZnBnbQAAA7gAAACyAAABCUM+8IhnYXNwAAAGTAAAABAAAAAQABoAI2dseWYAAAFsAAABPAAAAZwcEq9taGVhZAAAAsgAAAA0AAAANgh4a91oaGVhAAADCAAAABoAAAAkCA8DRGhtdHgAAAL8AAAADAAAAAwGAACfbG9jYQAAAsAAAAAIAAAACABiATBtYXhwAAACqAAAABgAAAAgAA8ASm5hbWUAAAToAAABQgAAAlXu73sOcG9zdAAABiwAAAAeAAAAME3QpOBwcmVwAAAEbAAAAHYAAAB/aFGpk3jaTY6xa8JAGMW/O62BDi0tJLYQincXEypYIiGJjSgHniQ6umTsUEyLm5BV6NDBP8Tpts6F0v+k/0an2i+itHDw3v2+9+DBKTzsJNnWJNTgHEy4BgG3EMI9DCEDOGEXzDADU5hBKMIgNPZqoD3SilVaXZCER3/I7AtxEJLtzzuZfI+VVkprxTlXShWKb3TBecG11rwoNlmmn1P2WYcJczl32etSpKnziC7lQyWe1smVPy/Lt7Kc+0vWY/gAgIIEqAN9we0pwKXreiMasxvabDQMM4riO+qxM2ogwDGOZTXxwxDiycQIcoYFBLj5K3EIaSctAq2kTYiw+ymhce7vwM9jSqO8JyVd5RH9gyTt2+J/yUmYlIR0s04n6+7Vm1ozezUeLEaUjhaDSuXHwVRgvLJn1tQ7xiuVv/ocTRF42mNgZGBgYGbwZOBiAAFGJBIMAAizAFoAAABiAGIAznjaY2BkYGAA4in8zwXi+W2+MjCzMIDApSwvXzC97Z4Ig8N/BxYGZgcgl52BCSQKAA3jCV8CAABfAAAAAAQAAEB42mNgZGBg4f3vACQZQABIMjKgAmYAKEgBXgAAeNpjYGY6wTiBgZWBg2kmUxoDA4MPhGZMYzBi1AHygVLYQUCaawqDA4PChxhmh/8ODDEsvAwHgMKMIDnGL0x7gJQCAwMAJd4MFwAAAHjaY2BgYGaA4DAGRgYQkAHyGMF8NgYrIM3JIAGVYYDT+AEjAwuDFpBmA9KMDEwMCh9i/v8H8sH0/4dQc1iAmAkALaUKLgAAAHjaTY9LDsIgEIbtgqHUPpDi3gPoBVyRTmTddOmqTXThEXqrob2gQ1FjwpDvfwCBdmdXC5AVKFu3e5MfNFJ29KTQT48Ob9/lqYwOGZxeUelN2U2R6+cArgtCJpauW7UQBqnFkUsjAY/kOU1cP+DAgvxwn1chZDwUbd6CFimGXwzwF6tPbFIcjEl+vvmM/byA48e6tWrKArm4ZJlCbdsrxksL1AwWn/yBSJKpYbq8AXaaTb8AAHja28jAwOC00ZrBeQNDQOWO//sdBBgYGRiYWYAEELEwMTE4uzo5Zzo5b2BxdnFOcALxNjA6b2ByTswC8jYwg0VlNuoCTWAMqNzMzsoK1rEhNqByEyerg5PMJlYuVueETKcd/89uBpnpvIEVomeHLoMsAAe1Id4AAAAAAAB42oWQT07CQBTGv0JBhagk7HQzKxca2sJCE1hDt4QF+9JOS0nbaaYDCQfwCJ7Au3AHj+LO13FMmm6cl7785vven0kBjHCBhfpYuNa5Ph1c0e2Xu3jEvWG7UdPDLZ4N92nOm+EBXuAbHmIMSRMs+4aUEd4Nd3CHD8NdvOLTsA2GL8M9PODbcL+hD7C1xoaHeLJSEao0FEW14ckxC+TU8TxvsY6X0eLPmRhry2WVioLpkrbp84LLQPGI7c6sOiUzpWIWS5GzlSgUzzLBSikOPFTOXqly7rqx0Z1Q5BAIoZBSFihQYQOOBEdkCOgXTOHA07HAGjGWiIjaPZNW13/+lm6S9FT7rLHFJ6fQbkATOG1j2OFMucKJJsxIVfQORl+9Jyda6Sl1dUYhSCm1dyClfoeDve4qMYdLEbfqHf3O/AdDumsjAAB42mNgYoAAZQYjBmyAGYQZmdhL8zLdDEydARfoAqIAAAABAAMABwAKABMAB///AA8AAQAAAAAAAAAAAAAAAAABAAAAAA==) format('woff');
 }
 
+.wrapper {
+  margin: 0 auto;
+  max-width: 700px;
+  padding: 20px 10px;
+}
+
 .markdown-body {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -697,4 +703,62 @@ var css = `@font-face {
 
 .markdown-body hr {
   border-bottom-color: #eee;
-}`
+}
+
+.command {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
+  monospace;
+  font-size: 16px;
+  padding-left: 40px;
+
+}
+
+.command h1 {
+  border: none;
+  margin-left: -40px;
+}
+
+.command h2 {
+  border: none;
+  margin-top: 2em;
+  margin-left: -40px;
+  font-size: 18px;
+}
+
+.command>ul {
+  padding-left: 0;
+}
+
+.command ul {
+  list-style-type: none;
+}
+
+.command table {
+  margin: 2em 0 1em;
+  display: block;
+  width: 100%;
+  overflow: auto;
+  border-collapse: collapse;
+}
+
+.command table th {
+  font-weight: 600;
+}
+
+.command table th,
+.command table td {
+  padding: 6px 13px;
+  border: 1px solid #dfe2e5;
+}
+
+.command table tr {
+  background-color: #fff;
+  border-top: 1px solid #c6cbd1;
+}
+
+.command table tr:nth-child(2n) {
+  background-color: #f6f8fa;
+}
+
+
+`

--- a/usage/html.go
+++ b/usage/html.go
@@ -239,7 +239,7 @@ FOO BAR BAZ
 
 ## ONLINE
 
-This documentation is available online at https://smallstep.com/documentation
+This documentation is available online at https://smallstep.com/docs/cli
 
 ## PRINTING
 

--- a/usage/printer.go
+++ b/usage/printer.go
@@ -24,11 +24,11 @@ func HelpPrinter(w io.Writer, templ string, data interface{}) {
 
 func htmlHelpPrinter(w io.Writer, templ string, data interface{}) {
 	b := helpPreprocessor(w, templ, data)
-	w.Write([]byte(`<html><head><title>Step</title>`))
+	w.Write([]byte(`<html><head><title>step command line documentation</title>`))
 	w.Write([]byte(`<link href="/style.css" rel="stylesheet" type="text/css">`))
-	w.Write([]byte(`</head><body class="markdown-body">`))
+	w.Write([]byte(`</head><body><div class="wrapper markdown-body command">`))
 	w.Write(md.Run(b))
-	w.Write([]byte(`<br></body></html>`))
+	w.Write([]byte(`</div></body></html>`))
 }
 
 func markdownHelpPrinter(w io.Writer, templ string, data interface{}) {


### PR DESCRIPTION
This adds some styles to the OAuth HTML pages:

<img width="745" alt="screen shot 2018-08-16 at 2 38 33 pm" src="https://user-images.githubusercontent.com/1354/44236548-3140d700-a162-11e8-9346-335b1d7e0af5.png">

And imports smallstep.com styles for the HTML docs:

<img width="1033" alt="screen shot 2018-08-16 at 2 39 01 pm" src="https://user-images.githubusercontent.com/1354/44236564-40278980-a162-11e8-8cdd-f1dfee4484fd.png">

And adds links to documentation in the README.

I'd love a one-over to make sure I haven't done something unpleasant in the Go code. It does add two fairly long lines of in-line CSS to command/oauth/cmd.go