### PR TITLE
Rename debian package to step-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ uninstall:
 
 debian:
 	$Q mkdir -p $(RELEASE); \
-	OUTPUT=../step_*.deb; \
+	OUTPUT=../step-cli_*.deb; \
 	rm $$OUTPUT; \
 	dpkg-buildpackage -b -rfakeroot -us -uc && cp $$OUTPUT $(RELEASE)/
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-step-cli (0.0.2-rc.9) UNRELEASED; urgency=medium
+step-cli (0.0.2-rc.11) UNRELEASED; urgency=medium
 
   [ max furman ]
   * add unfurl gif to README
@@ -33,7 +33,7 @@ step-cli (0.0.2-rc.9) UNRELEASED; urgency=medium
   [ Mariano Cano ]
   * Fixes #26: rename debian package to step-cli.
 
- -- Smallstep Labs, Inc. <techadmin@smallstep.com>  Mon, 20 Aug 2018 23:46:20 +0000
+ -- Smallstep Labs, Inc. <techadmin@smallstep.com>  Tue, 21 Aug 2018 01:20:49 +0000
 
 step-cli (0.0.1) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-step (0.0.1) UNRELEASED; urgency=medium
+step-cli (0.0.1) UNRELEASED; urgency=medium
 
   * Initial release
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,41 @@
-step-cli (0.0.1) UNRELEASED; urgency=medium
+step-cli (0.0.2-rc.9) UNRELEASED; urgency=medium
+
+  [ max furman ]
+  * add unfurl gif to README
+
+  [ Mariano Cano ]
+  * Make version overwritable using the environment.
+
+  [ Mike Malone ]
+  * added examples to README
+
+  [ max furman ]
+  * Makefil VERSION remove prefix from override
+
+  [ Tyler Julian ]
+  * command/certificate: Make file names in docs more consistent
+
+  [ max furman ]
+  * add --bundle option to certificate inspect
+  * add --bundle to changelog
+  * add a bit of documentation describing cert/lint
+
+  [ Tyler Julian ]
+  * Allow certificate inspect command to read from stdin
+
+  [ max furman ]
+  * add travis artifact upload on successful tagged build
+  * add pemutil serialization for x509/realx509 certificates
+  * remove x509util.WriteCertificate -- unused
+  * add ReadPasswordGenerate
+  * remove extra new line char
+
+  [ Mariano Cano ]
+  * Fixes #26: rename debian package to step-cli.
+
+ -- Smallstep Labs, Inc. <techadmin@smallstep.com>  Mon, 20 Aug 2018 23:46:20 +0000
+
+step-cli (0.0.1) unstable; urgency=medium
 
   * Initial release
 

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: step
+Source: step-cli
 Section: utils
 Priority: optional
 Maintainer: Smallstep Labs, Inc. <techadmin@smallstep.com>
@@ -8,7 +8,7 @@ Homepage: https://github.com/smallstep/cli
 Vcs-Browser: https://github.com/smallstep/cli.git
 Vcs-Git: https://github.com/smallstep/cli.git
 
-Package: step
+Package: step-cli
 Architecture: any
 Depends: ${misc:Depends}
 Description: Zero trust swiss army knife

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,13 @@
 #!/usr/bin/make -f
 
-%:
+override_dh_install-arch:
+	dh_install --arch
+	# Rename step to step-cli.
+	mv debian/step-cli/usr/bin/step debian/step-cli/usr/bin/step-cli
+
+build:
 	make bootstrap
+	dh build
+
+%:
 	dh $@ --with bash-completion

--- a/debian/step-cli.bash-completion
+++ b/debian/step-cli.bash-completion
@@ -1,0 +1,1 @@
+autocomplete/bash_autocomplete step-cli

--- a/debian/step-cli.postinst
+++ b/debian/step-cli.postinst
@@ -1,7 +1,14 @@
 #!/bin/sh
 
 if [ "$1" = "configure" ]; then
-    update-alternatives \
-        --install /usr/bin/step step /usr/bin/step-cli 50 \
-        --slave /usr/share/bash-completion/completions/step step.bash-completion /usr/share/bash-completion/completions/step-cli
+	if [ -f /usr/share/bash-completion/completions/step-cli ]; then
+		update-alternatives \
+			--install /usr/bin/step step /usr/bin/step-cli 50 \
+			--slave /usr/share/bash-completion/completions/step step.bash-completion /usr/share/bash-completion/completions/step-cli
+	fi
+	if [ -f /etc/bash_completion.d/step-cli ]; then
+		update-alternatives \
+			--install /usr/bin/step step /usr/bin/step-cli 50 \
+			--slave /etc/bash_completion.d/step step.bash-completion /etc/bash_completion.d/step-cli
+	fi
 fi

--- a/debian/step-cli.postinst
+++ b/debian/step-cli.postinst
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "$1" = "configure" ]; then
+    update-alternatives \
+        --install /usr/bin/step step /usr/bin/step-cli 50 \
+        --slave /usr/share/bash-completion/completions/step step.bash-completion /usr/share/bash-completion/completions/step-cli
+fi

--- a/debian/step-cli.prerm
+++ b/debian/step-cli.prerm
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "$1" = "remove" ]; then
+	update-alternatives --remove step /usr/bin/step-cli
+fi

--- a/debian/step.bash-completion
+++ b/debian/step.bash-completion
@@ -1,1 +1,0 @@
-autocomplete/bash_autocomplete step


### PR DESCRIPTION
### Description
This PR Fixes #26 and renames the step debian package as step-cli