### PR TITLE
Log invalid http requests into oauth server

### DIFF
--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -562,6 +562,9 @@ func (o *oauth) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if code == "" || state == "" {
 		fmt.Printf("Invalid request received from: %v%v\n\n", req.RemoteAddr, req.RequestURI)
+		if req.RequestURI == "/robots.txt" {
+			fmt.Printf("** You may have an app or browser plugin that needs to be turned off **\n\n")
+		}
 	}
 
 	if code == "" {

--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -558,13 +558,17 @@ func (o *oauth) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	code := q.Get("code")
+	code, state := q.Get("code"), q.Get("state")
+
+	if code == "" || state == "" {
+		fmt.Printf("Invalid request received from: %v%v\n\n", req.RemoteAddr, req.RequestURI)
+	}
+
 	if code == "" {
 		o.badRequest(w, "Failed to authenticate: missing or invalid code")
 		return
 	}
 
-	state := q.Get("state")
 	if state == "" || state != o.state {
 		o.badRequest(w, "Failed to authenticate: missing or invalid state")
 		return


### PR DESCRIPTION
Log HTTP requests to OAuth HTTP server #29

### Description
This PR will provide more logging around invalid http requests into the oauth server. 

Currently, if any 3rd party apps or plugins, such as wappalyzer, make the first request into oauth server the redirect cannot be handled and there are no logs indicating what is happening or how to fix.

In the case of wappalyzer it's sending a request to /robots.txt, which can be used to give users a useful debugging suggestion.