### PR TITLE
Audit of default key usage for root and intermediate certs

### DIFF
--- a/crypto/x509util/intermediateProfile.go
+++ b/crypto/x509util/intermediateProfile.go
@@ -8,7 +8,7 @@ import (
 	"github.com/smallstep/cli/pkg/x509"
 )
 
-// DefaultIntermediateCertValidity is the default validity of a root certificate in the step PKI.
+// DefaultIntermediateCertValidity is the default validity of a intermediate certificate in the step PKI.
 var DefaultIntermediateCertValidity = time.Hour * 24 * 365 * 10
 
 // Intermediate implements the Profile for a intermediate certificate.

--- a/crypto/x509util/intermediateProfile.go
+++ b/crypto/x509util/intermediateProfile.go
@@ -30,16 +30,10 @@ func NewIntermediateProfile(name string, iss *x509.Certificate, issPriv crypto.P
 func defaultIntermediateTemplate(name string) *x509.Certificate {
 	notBefore := time.Now()
 	return &x509.Certificate{
-		IsCA:      true,
-		NotBefore: notBefore,
-		// 10 year intermediate certificate validity.
-		NotAfter: notBefore.Add(DefaultIntermediateCertValidity),
-		KeyUsage: x509.KeyUsageKeyEncipherment |
-			x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-		ExtKeyUsage: []x509.ExtKeyUsage{
-			x509.ExtKeyUsageServerAuth,
-			x509.ExtKeyUsageClientAuth,
-		},
+		IsCA:                  true,
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.Add(DefaultIntermediateCertValidity),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		BasicConstraintsValid: true,
 		MaxPathLen:            0,
 		MaxPathLenZero:        true,

--- a/crypto/x509util/leafProfile.go
+++ b/crypto/x509util/leafProfile.go
@@ -57,9 +57,8 @@ func defaultLeafTemplate(sub pkix.Name, iss pkix.Name) *x509.Certificate {
 	return &x509.Certificate{
 		IsCA:      false,
 		NotBefore: notBefore,
-		// 1 Day Leaf Certificate validity.
-		NotAfter: notBefore.Add(DefaultCertValidity),
-		KeyUsage: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		NotAfter:  notBefore.Add(DefaultCertValidity),
+		KeyUsage:  x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage: []x509.ExtKeyUsage{
 			x509.ExtKeyUsageServerAuth,
 			x509.ExtKeyUsageClientAuth,

--- a/crypto/x509util/rootProfile.go
+++ b/crypto/x509util/rootProfile.go
@@ -41,13 +41,10 @@ func NewRootProfileWithTemplate(crt *x509.Certificate, withOps ...WithOption) (P
 func defaultRootTemplate(cn string) *x509.Certificate {
 	notBefore := time.Now()
 	return &x509.Certificate{
-		IsCA:      true,
-		NotBefore: notBefore,
-		// 10 year root certificate validity.
-		NotAfter: notBefore.Add(DefaultRootCertValidity),
-		KeyUsage: x509.KeyUsageKeyEncipherment |
-			x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign |
-			x509.KeyUsageCRLSign,
+		IsCA:                  true,
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.Add(DefaultRootCertValidity),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		BasicConstraintsValid: true,
 		MaxPathLen:            1,
 		MaxPathLenZero:        false,


### PR DESCRIPTION
* root and intermediate certs only require the CertSign key usage.
do not need key encipherment or digital signature by default.
* intermediate certificate should not have client/server auth extended
key usage.
