### PR TITLE
Allow to add custom validity in `step certificate create`

### DIFF
--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -208,11 +208,11 @@ func signCertificateTokenFlow(ctx *cli.Context, subject string) (string, error) 
 	}
 
 	// parse times or durations
-	notBefore, ok := parseTimeOrDuration(ctx.String("not-before"))
+	notBefore, ok := flags.ParseTimeOrDuration(ctx.String("not-before"))
 	if !ok {
 		return "", errs.InvalidFlagValue(ctx, "not-before", ctx.String("not-before"), "")
 	}
-	notAfter, ok := parseTimeOrDuration(ctx.String("not-after"))
+	notAfter, ok := flags.ParseTimeOrDuration(ctx.String("not-after"))
 	if !ok {
 		return "", errs.InvalidFlagValue(ctx, "not-after", ctx.String("not-after"), "")
 	}
@@ -232,11 +232,11 @@ func signCertificateRequest(ctx *cli.Context, token string, csr api.CertificateR
 	caURL := ctx.String("ca-url")
 
 	// parse times or durations
-	notBefore, ok := parseTimeOrDuration(ctx.String("not-before"))
+	notBefore, ok := flags.ParseTimeOrDuration(ctx.String("not-before"))
 	if !ok {
 		return errs.InvalidFlagValue(ctx, "not-before", ctx.String("not-before"), "")
 	}
-	notAfter, ok := parseTimeOrDuration(ctx.String("not-after"))
+	notAfter, ok := flags.ParseTimeOrDuration(ctx.String("not-after"))
 	if !ok {
 		return errs.InvalidFlagValue(ctx, "not-after", ctx.String("not-after"), "")
 	}

--- a/command/ca/token.go
+++ b/command/ca/token.go
@@ -151,11 +151,11 @@ func newTokenAction(ctx *cli.Context) error {
 	}
 
 	// parse times or durations
-	notBefore, ok := parseTimeOrDuration(ctx.String("not-before"))
+	notBefore, ok := flags.ParseTimeOrDuration(ctx.String("not-before"))
 	if !ok {
 		return errs.InvalidFlagValue(ctx, "not-before", ctx.String("not-before"), "")
 	}
-	notAfter, ok := parseTimeOrDuration(ctx.String("not-after"))
+	notAfter, ok := flags.ParseTimeOrDuration(ctx.String("not-after"))
 	if !ok {
 		return errs.InvalidFlagValue(ctx, "not-after", ctx.String("not-after"), "")
 	}
@@ -358,22 +358,6 @@ func newTokenFlow(ctx *cli.Context, subject, caURL, root, kid, issuer, passwordF
 	}
 
 	return generateToken(subject, kid, issuer, audience, root, notBefore, notAfter, jwk)
-}
-
-func parseTimeOrDuration(s string) (time.Time, bool) {
-	if s == "" {
-		return time.Time{}, true
-	}
-
-	var t time.Time
-	if err := t.UnmarshalText([]byte(s)); err != nil {
-		d, err := time.ParseDuration(s)
-		if err != nil {
-			return time.Time{}, false
-		}
-		t = time.Now().Add(d)
-	}
-	return t, true
 }
 
 // provisionerFilter returns a slice of provisioners that pass the given filter.

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -1,6 +1,8 @@
 package flags
 
 import (
+	"time"
+
 	"github.com/urfave/cli"
 )
 
@@ -18,4 +20,22 @@ var Insecure = cli.BoolFlag{
 var Force = cli.BoolFlag{
 	Name:  "f,force",
 	Usage: "Force the overwrite of files without asking.",
+}
+
+// ParseTimeOrDuration is a helper that returns the time or the current time
+// with an extra duration. It's used in flags like --not-before, --not-after.
+func ParseTimeOrDuration(s string) (time.Time, bool) {
+	if s == "" {
+		return time.Time{}, true
+	}
+
+	var t time.Time
+	if err := t.UnmarshalText([]byte(s)); err != nil {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return time.Time{}, false
+		}
+		t = time.Now().Add(d)
+	}
+	return t, true
 }


### PR DESCRIPTION
### Description
Add support for --not-before and --not-after flags in `step certificate create`. Fixes #51
