### PR TITLE
Add support for multiple roots and federation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -299,8 +299,8 @@
   revision = "de77670473b5492f5d0bce155b5c01534c2d13f7"
 
 [[projects]]
-  branch = "mariano/multiroot"
-  digest = "1:081bc9dc6339b1a005c63e4e836a313602d911f4247161f898df7d95e8310d31"
+  branch = "master"
+  digest = "1:255580ce60f7bd8ebd57ebb64161248fecb116fe9244ecbf27886d54ffc4268e"
   name = "github.com/smallstep/certificates"
   packages = [
     "api",
@@ -311,7 +311,7 @@
     "server",
   ]
   pruneopts = "UT"
-  revision = "7dc61bf2338df98dd1a45b0767a35b0517976408"
+  revision = "d0e0217955e035530ae5c6b128de133433262214"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -299,8 +299,8 @@
   revision = "de77670473b5492f5d0bce155b5c01534c2d13f7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:90239c0862142dad5e4341750f79c3422de9f1dad381570d1c43edc1c34bb71a"
+  branch = "mariano/multiroot"
+  digest = "1:584b8d2f862e6a7d6367707a75d888a176b298a3c3817cc593cb7587ee97c509"
   name = "github.com/smallstep/certificates"
   packages = [
     "api",
@@ -311,7 +311,7 @@
     "server",
   ]
   pruneopts = "UT"
-  revision = "5d92735594c77405d4134d0d55d192ecb8a5acd6"
+  revision = "61165230556d12a6b681f36864ef19749a8db261"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -300,7 +300,7 @@
 
 [[projects]]
   branch = "mariano/multiroot"
-  digest = "1:584b8d2f862e6a7d6367707a75d888a176b298a3c3817cc593cb7587ee97c509"
+  digest = "1:081bc9dc6339b1a005c63e4e836a313602d911f4247161f898df7d95e8310d31"
   name = "github.com/smallstep/certificates"
   packages = [
     "api",
@@ -311,7 +311,7 @@
     "server",
   ]
   pruneopts = "UT"
-  revision = "61165230556d12a6b681f36864ef19749a8db261"
+  revision = "7dc61bf2338df98dd1a45b0767a35b0517976408"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,5 +64,5 @@ required = [
   unused-packages = true
 
 [[constraint]]
-  branch = "mariano/multiroot"
+  branch = "master"
   name = "github.com/smallstep/certificates"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,5 +64,5 @@ required = [
   unused-packages = true
 
 [[constraint]]
-  branch = "master"
+  branch = "mariano/multiroot"
   name = "github.com/smallstep/certificates"

--- a/command/ca/ca.go
+++ b/command/ca/ca.go
@@ -71,9 +71,11 @@ $ step ca renew internal.crt internal.key \
 			newTokenCommand(),
 			newCertificateCommand(),
 			renewCertificateCommand(),
-			rootComand(),
 			provisioner.Command(),
 			signCertificateCommand(),
+			rootComand(),
+			rootsCommand(),
+			federationCommand(),
 		},
 	}
 

--- a/command/ca/federation.go
+++ b/command/ca/federation.go
@@ -1,0 +1,196 @@
+package ca
+
+import (
+	"context"
+	"encoding/pem"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/smallstep/certificates/api"
+	"github.com/smallstep/certificates/ca"
+	"github.com/smallstep/cli/command"
+	"github.com/smallstep/cli/crypto/pemutil"
+	"github.com/smallstep/cli/crypto/pki"
+	"github.com/smallstep/cli/errs"
+	"github.com/smallstep/cli/flags"
+	"github.com/smallstep/cli/jose"
+	"github.com/smallstep/cli/ui"
+	"github.com/smallstep/cli/utils"
+	"github.com/urfave/cli"
+)
+
+type flowType int
+
+const (
+	rootsFlow flowType = iota
+	federationFlow
+)
+
+func rootsCommand() cli.Command {
+	return cli.Command{
+		Name:   "roots",
+		Action: command.ActionFunc(rootsAction),
+		Usage:  "download all the root certificates",
+		UsageText: `**step ca roots** <roots-file>
+		[**--token**=<token>]`,
+		Description: `**step ca roots** downloads a certificate bundle with all the root
+certificates. The request to download the bundle requires
+a mTLS connection with the certificate authority, the command creates a 
+temporal certificate using the token and then does a mTLS request to the 
+CA.
+
+## POSITIONAL ARGUMENTS
+
+<roots-file>
+:  File to write all the root certificates (PEM format)`,
+		Flags: []cli.Flag{
+			tokenFlag,
+			flags.Force,
+		},
+	}
+}
+
+func federationCommand() cli.Command {
+	return cli.Command{
+		Name:   "federation",
+		Action: command.ActionFunc(federationAction),
+		Usage:  "download all the federated certificates",
+		UsageText: `**step ca federation** <federation-file>
+		[**--token**=<token>]`,
+		Description: `**step ca federation** downloads a certificate bundle with all the root
+certificates in the federation. The request to download the bundle requires
+a mTLS connection with the certificate authority, the command creates a 
+temporal certificate using the token and then does a mTLS request to the 
+CA.
+
+## POSITIONAL ARGUMENTS
+
+<federation-file>
+:  File to write federation certificates (PEM format)`,
+		Flags: []cli.Flag{
+			tokenFlag,
+			flags.Force,
+		},
+	}
+}
+
+func rootsAction(ctx *cli.Context) error {
+	return rootsAndFederationFlow(ctx, rootsFlow)
+}
+
+func federationAction(ctx *cli.Context) error {
+	return rootsAndFederationFlow(ctx, federationFlow)
+}
+
+func getMTLSTransport(client *ca.Client, token string) (*http.Transport, error) {
+	// Create a certificate for temporal use
+	req, pk, err := ca.CreateSignRequest(token)
+	if err != nil {
+		return nil, err
+	}
+	sign, err := client.Sign(req)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return client.Transport(ctx, sign, pk)
+}
+
+func rootsAndFederationFlow(ctx *cli.Context, typ flowType) error {
+	if err := errs.NumberOfArguments(ctx, 1); err != nil {
+		return err
+	}
+
+	token := ctx.String("token")
+	if len(token) == 0 {
+		errs.RequiredFlag(ctx, "token")
+	}
+
+	tok, err := jose.ParseSigned(token)
+	if err != nil {
+		return errors.Wrap(err, "error parsing flag '--token'")
+	}
+	var claims tokenClaims
+	if err := tok.UnsafeClaimsWithoutVerification(&claims); err != nil {
+		return errors.Wrap(err, "error parsing flag '--token'")
+	}
+
+	// Prepare client for bootstrap or provisioning tokens
+	var caURL string
+	var options []ca.ClientOption
+	if len(claims.SHA) > 0 && len(claims.Audience) > 0 && strings.HasPrefix(strings.ToLower(claims.Audience[0]), "http") {
+		caURL = claims.Audience[0]
+		options = append(options, ca.WithRootSHA256(claims.SHA))
+	} else {
+		caURL = ctx.String("ca-url")
+		if len(caURL) == 0 {
+			return errs.RequiredFlag(ctx, "ca-url")
+		}
+		root := ctx.String("root")
+		if len(root) == 0 {
+			root = pki.GetRootCAPath()
+			if _, err := os.Stat(root); err != nil {
+				return errs.RequiredFlag(ctx, "root")
+			}
+		}
+		options = append(options, ca.WithRootFile(root))
+	}
+
+	ui.PrintSelected("CA", caURL)
+	client, err := ca.NewClient(caURL, options...)
+	if err != nil {
+		return err
+	}
+
+	tr, err := getMTLSTransport(client, token)
+	if err != nil {
+		return err
+	}
+
+	var certs []api.Certificate
+	switch typ {
+	case rootsFlow:
+		roots, err := client.Roots(tr)
+		if err != nil {
+			return err
+		}
+		certs = roots.Certificates
+	case federationFlow:
+		federation, err := client.Federation(tr)
+		if err != nil {
+			return err
+		}
+		certs = federation.Certificates
+	default:
+		return errors.New("unknown flow type: this should not happen")
+	}
+
+	var data []byte
+	for _, cert := range certs {
+		block, err := pemutil.Serialize(cert.Certificate)
+		if err != nil {
+			return err
+		}
+		data = append(data, pem.EncodeToMemory(block)...)
+	}
+
+	outFile := ctx.Args().Get(0)
+	if err := utils.WriteFile(outFile, data, 0600); err != nil {
+		return err
+	}
+
+	switch typ {
+	case rootsFlow:
+		ui.Printf("The root certificate bundle has been saved in %s.\n", outFile)
+	case federationFlow:
+		ui.Printf("The federation certificate bundle has been saved in %s.\n", outFile)
+	default:
+		return errors.New("unknown flow type: this should not happen")
+	}
+
+	return nil
+}

--- a/command/ca/federation.go
+++ b/command/ca/federation.go
@@ -50,7 +50,7 @@ Download the roots with custom flags:
 '''
 $ step ca roots roots.pem \
     --ca-url https://ca.example.com \
-	--root /path/to/root_ca.crt
+    --root /path/to/root_ca.crt
 '''`,
 		Flags: []cli.Flag{
 			caURLFlag,

--- a/command/ca/federation.go
+++ b/command/ca/federation.go
@@ -30,7 +30,7 @@ func rootsCommand() cli.Command {
 		Action: command.ActionFunc(rootsAction),
 		Usage:  "download all the root certificates",
 		UsageText: `**step ca roots** <roots-file>
-		[**--token**=<token>] [**--ca-url**=<uri>] [**--root**=<file>]`,
+		[**--ca-url**=<uri>] [**--root**=<file>]`,
 		Description: `**step ca roots** downloads a certificate bundle with all the root
 certificates.
 
@@ -66,7 +66,7 @@ func federationCommand() cli.Command {
 		Action: command.ActionFunc(federationAction),
 		Usage:  "download all the federated certificates",
 		UsageText: `**step ca federation** <federation-file>
-		[**--token**=<token>] [**--ca-url**=<uri>] [**--root**=<file>]`,
+		[**--ca-url**=<uri>] [**--root**=<file>]`,
 		Description: `**step ca federation** downloads a certificate bundle with all the root
 certificates in the federation.
 

--- a/command/ca/federation.go
+++ b/command/ca/federation.go
@@ -1,12 +1,8 @@
 package ca
 
 import (
-	"context"
 	"encoding/pem"
-	"net/http"
 	"os"
-	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/smallstep/certificates/api"
@@ -14,10 +10,8 @@ import (
 	"github.com/smallstep/cli/command"
 	"github.com/smallstep/cli/crypto/pemutil"
 	"github.com/smallstep/cli/crypto/pki"
-	"github.com/smallstep/cli/crypto/randutil"
 	"github.com/smallstep/cli/errs"
 	"github.com/smallstep/cli/flags"
-	"github.com/smallstep/cli/jose"
 	"github.com/smallstep/cli/ui"
 	"github.com/smallstep/cli/utils"
 	"github.com/urfave/cli"
@@ -38,10 +32,7 @@ func rootsCommand() cli.Command {
 		UsageText: `**step ca roots** <roots-file>
 		[**--token**=<token>] [**--ca-url**=<uri>] [**--root**=<file>]`,
 		Description: `**step ca roots** downloads a certificate bundle with all the root
-certificates. The request to download the bundle requires
-a mTLS connection with the certificate authority, the command creates a 
-temporal certificate using the token and then does a mTLS request to the 
-CA.
+certificates.
 
 ## POSITIONAL ARGUMENTS
 
@@ -50,19 +41,18 @@ CA.
 
 ## EXAMPLES
 
-Download the roots with a token:
+Download the roots with flags set by <step ca bootstrap>:
 '''
-$ step ca roots --token $(step ca token whatever) roots.pem
+$ step ca roots roots.pem
 '''
 
-Download the roots doing the token flow:
+Download the roots with custom flags:
 '''
 $ step ca roots roots.pem \
     --ca-url https://ca.example.com \
 	--root /path/to/root_ca.crt
 '''`,
 		Flags: []cli.Flag{
-			tokenFlag,
 			caURLFlag,
 			rootFlag,
 			flags.Force,
@@ -78,10 +68,7 @@ func federationCommand() cli.Command {
 		UsageText: `**step ca federation** <federation-file>
 		[**--token**=<token>] [**--ca-url**=<uri>] [**--root**=<file>]`,
 		Description: `**step ca federation** downloads a certificate bundle with all the root
-certificates in the federation. The request to download the bundle requires
-a mTLS connection with the certificate authority, the command creates a 
-temporal certificate using the token and then does a mTLS request to the 
-CA.
+certificates in the federation.
 
 ## POSITIONAL ARGUMENTS
 
@@ -90,12 +77,12 @@ CA.
 
 ## EXAMPLES
 
-Download the federated roots with a token:
+Download the federated roots with flags set by <step ca bootstrap>:
 '''
-$ step ca federation --token $(step ca token whatever) federation.pem
+$ step ca federation federation.pem
 '''
 
-Download the federated roots doing the token flow:
+Download the federated roots with custom flags:
 '''
 $ step ca federation federation.pem \
     --ca-url https://ca.example.com \
@@ -103,7 +90,6 @@ $ step ca federation federation.pem \
 '''
 `,
 		Flags: []cli.Flag{
-			tokenFlag,
 			caURLFlag,
 			rootFlag,
 			flags.Force,
@@ -119,78 +105,25 @@ func federationAction(ctx *cli.Context) error {
 	return rootsAndFederationFlow(ctx, federationFlow)
 }
 
-func getMTLSTransport(client *ca.Client, token string) (*http.Transport, error) {
-	// Create a certificate for temporal use
-	req, pk, err := ca.CreateSignRequest(token)
-	if err != nil {
-		return nil, err
-	}
-	sign, err := client.Sign(req)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	return client.Transport(ctx, sign, pk)
-}
-
 func rootsAndFederationFlow(ctx *cli.Context, typ flowType) error {
 	if err := errs.NumberOfArguments(ctx, 1); err != nil {
 		return err
 	}
 
 	caURL := ctx.String("ca-url")
+	if len(caURL) == 0 {
+		return errs.RequiredFlag(ctx, "ca-url")
+	}
+
 	root := ctx.String("root")
-
-	token := ctx.String("token")
-	if len(token) == 0 {
-		s, err := randutil.Alphanumeric(10)
-		if err != nil {
-			return err
-		}
-
-		subject := "step-cli-" + s
-		token, err = newTokenFlow(ctx, subject, caURL, root, "", "", "", "", time.Time{}, time.Time{})
-		if err != nil {
-			return err
+	if len(root) == 0 {
+		root = pki.GetRootCAPath()
+		if _, err := os.Stat(root); err != nil {
+			return errs.RequiredFlag(ctx, "root")
 		}
 	}
 
-	tok, err := jose.ParseSigned(token)
-	if err != nil {
-		return errors.Wrap(err, "error parsing flag '--token'")
-	}
-	var claims tokenClaims
-	if err := tok.UnsafeClaimsWithoutVerification(&claims); err != nil {
-		return errors.Wrap(err, "error parsing flag '--token'")
-	}
-
-	// Prepare client for bootstrap or provisioning tokens
-	var options []ca.ClientOption
-	if len(claims.SHA) > 0 && len(claims.Audience) > 0 && strings.HasPrefix(strings.ToLower(claims.Audience[0]), "http") {
-		caURL = claims.Audience[0]
-		options = append(options, ca.WithRootSHA256(claims.SHA))
-	} else {
-		if len(caURL) == 0 {
-			return errs.RequiredFlag(ctx, "ca-url")
-		}
-		if len(root) == 0 {
-			root = pki.GetRootCAPath()
-			if _, err := os.Stat(root); err != nil {
-				return errs.RequiredFlag(ctx, "root")
-			}
-		}
-		options = append(options, ca.WithRootFile(root))
-	}
-
-	ui.PrintSelected("CA", caURL)
-	client, err := ca.NewClient(caURL, options...)
-	if err != nil {
-		return err
-	}
-
-	tr, err := getMTLSTransport(client, token)
+	client, err := ca.NewClient(caURL, ca.WithRootFile(root))
 	if err != nil {
 		return err
 	}
@@ -198,13 +131,13 @@ func rootsAndFederationFlow(ctx *cli.Context, typ flowType) error {
 	var certs []api.Certificate
 	switch typ {
 	case rootsFlow:
-		roots, err := client.Roots(tr)
+		roots, err := client.Roots()
 		if err != nil {
 			return err
 		}
 		certs = roots.Certificates
 	case federationFlow:
-		federation, err := client.Federation(tr)
+		federation, err := client.Federation()
 		if err != nil {
 			return err
 		}

--- a/crypto/pki/pki.go
+++ b/crypto/pki/pki.go
@@ -285,7 +285,8 @@ func (p *PKI) Save() error {
 	}
 
 	config := authority.Config{
-		Root:             p.root,
+		Root:             []string{p.root},
+		FederatedRoots:   []string{},
 		IntermediateCert: p.intermediate,
 		IntermediateKey:  p.intermediateKey,
 		Address:          p.address,


### PR DESCRIPTION
### Description
This PR adds two new commands to download the roots bundle and the federated bundle from the CA.
* `step ca roots`
* `step ca federation`

Both require the initial root to be present or passed using a flag.

Fixes smallstep/certificates#19

Note: before merging we will need to update the dependencies pointing to master.
