### PR TITLE
It's 2019

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Smallstep Labs, Inc.
+Copyright (c) 2019 Smallstep Labs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/step/main.go
+++ b/cmd/step/main.go
@@ -62,7 +62,7 @@ func main() {
 	app.Commands = command.Retrieve()
 	app.Flags = append(app.Flags, cli.HelpFlag)
 	app.EnableBashCompletion = true
-	app.Copyright = "(c) 2018 Smallstep Labs, Inc."
+	app.Copyright = "(c) 2019 Smallstep Labs, Inc."
 
 	// Flag of custom configuration flag
 	app.Flags = append(app.Flags, cli.StringFlag{

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,11 +3,11 @@ Upstream-Name: step
 Source: https://github.com/smallstep/cli
 
 Files: *
-Copyright: 2018 Smallstep Labs, Inc.
-License: MIT
+Copyright: 2019 Smallstep Labs, Inc.
+License: Apache
 
-License: MIT
- Copyright (c) 2018 Smallstep Labs, Inc.
+License: Apache
+ Copyright (c) 2019 Smallstep Labs, Inc.
  .
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,25 +4,19 @@ Source: https://github.com/smallstep/cli
 
 Files: *
 Copyright: 2019 Smallstep Labs, Inc.
-License: Apache
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the complete text of the Apache License 2.0 can
+ be found in "/usr/share/common-licenses/Apache-2.0"
 
-License: Apache
- Copyright (c) 2019 Smallstep Labs, Inc.
- .
- Permission is hereby granted, free of charge, to any person obtaining a copy
- of this software and associated documentation files (the "Software"), to deal
- in the Software without restriction, including without limitation the rights
- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- copies of the Software, and to permit persons to whom the Software is
- furnished to do so, subject to the following conditions:
- .
- The above copyright notice and this permission notice shall be included in all
- copies or substantial portions of the Software.
- .
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- SOFTWARE.


### PR DESCRIPTION
### Description
Replace mention of `2018` with `2019`. We've moved licenses from MIT to APL-2.0 as of smallstep/cli/issues/34. Let's be sure the debian package reflects that.