### PR TITLE
Add password-file flag on key creation and independent provisioner password

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -22,6 +22,21 @@ var Force = cli.BoolFlag{
 	Usage: "Force the overwrite of files without asking.",
 }
 
+// PasswordFile is a cli.Flag used to pass a file to encrypt or decrypt a
+// private key.
+var PasswordFile = cli.StringFlag{
+	Name:  "password-file",
+	Usage: `The path to the <file> containing the password to encrypt or decrypt the private key.`,
+}
+
+// NoPassword is a cli.Flag used to avoid using a password to encrypt private
+// keys.
+var NoPassword = cli.BoolFlag{
+	Name: "no-password",
+	Usage: `Do not ask for a password to encrypt a private key. Sensitive key material will
+be written to disk unencrypted. This is not recommended. Requires **--insecure** flag.`,
+}
+
 // ParseTimeOrDuration is a helper that returns the time or the current time
 // with an extra duration. It's used in flags like --not-before, --not-after.
 func ParseTimeOrDuration(s string) (time.Time, bool) {

--- a/utils/read.go
+++ b/utils/read.go
@@ -45,6 +45,16 @@ func ReadPasswordFromFile(filename string) ([]byte, error) {
 	return password, nil
 }
 
+// ReadStringPasswordFromFile reads and returns the password from the given filename.
+// The contents of the file will be trimmed at the right.
+func ReadStringPasswordFromFile(filename string) (string, error) {
+	b, err := ReadPasswordFromFile(filename)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
 // ReadInput from stdin if something is detected or ask the user for an input
 // using the given prompt.
 func ReadInput(prompt string) ([]byte, error) {


### PR DESCRIPTION
### Description
This PR adds the --password-file flag to:
* `step crypto jwk create`
* `step crypto keypair`
* `step ca provisioner add`

The PR also adds an independent password for the provisioner on `step ca init` if `--provisioner-password-file` is used.
