### PR TITLE
Allow to use certificates as keys and add command to extract public keys

### DIFF
--- a/command/certificate/certificate.go
+++ b/command/certificate/certificate.go
@@ -64,6 +64,11 @@ Convert PEM format certificate to DER and write to disk.
 '''
 $ step certificate format foo.pem --out foo.der
 '''
+
+Extract the public key from a PEM encoded certificate:
+'''
+$ step certificate key foo.crt
+'''
 `,
 
 		Subcommands: cli.Commands{
@@ -73,9 +78,9 @@ $ step certificate format foo.pem --out foo.der
 			inspectCommand(),
 			fingerprintCommand(),
 			lintCommand(),
-			//renewCommand(),
 			signCommand(),
 			verifyCommand(),
+			keyCommand(),
 		},
 	}
 

--- a/command/certificate/key.go
+++ b/command/certificate/key.go
@@ -1,0 +1,91 @@
+package certificate
+
+import (
+	"encoding/pem"
+	"fmt"
+
+	"github.com/smallstep/cli/flags"
+	"github.com/smallstep/cli/ui"
+
+	"github.com/smallstep/cli/command"
+	"github.com/smallstep/cli/crypto/pemutil"
+	"github.com/smallstep/cli/errs"
+	"github.com/smallstep/cli/utils"
+	"github.com/urfave/cli"
+)
+
+func keyCommand() cli.Command {
+	return cli.Command{
+		Name:      "key",
+		Action:    command.ActionFunc(keyAction),
+		Usage:     "print public key embedded in a certificate",
+		UsageText: "**step certificate key** <crt-file> [**--out**=<file>]",
+		Description: `**step certificate key** prints the public key embedded in a certificate or 
+a certificate signing request. If <crt-file> is a certificate bundle, only the
+first block will be taken into account.
+
+The command will print a public or a decrypted private key if <crt-file> 
+contains only a key.
+
+## POSITIONAL ARGUMENTS
+
+<crt-file>
+:  Path to a certificate or certificate signing request (CSR).
+
+## EXAMPLES
+
+Get the public key of a certificate:
+'''
+$ step certificate key certificate.crt
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEio9DLyuglMxakS3w00DUKdGbeXXB
+2Mfg6tVofeXYan9RbvftZufiypIAVqGZqO7CR9EbkoyHb/7GcKQa5HZ9rA==
+-----END PUBLIC KEY-----
+'''
+
+Get the public key of a CSR and save it to a file:
+'''
+$ step certificate key certificate.csr --out key.pem
+'''`,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "out,output-file",
+				Usage: "The destination <file> of the public key.",
+			},
+			flags.Force,
+		},
+	}
+}
+
+func keyAction(ctx *cli.Context) error {
+	if err := errs.NumberOfArguments(ctx, 1); err != nil {
+		return err
+	}
+
+	filename := ctx.Args().Get(0)
+	b, err := utils.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	// Look only at the first block
+	key, err := pemutil.ParseKey(b, pemutil.WithFirstBlock())
+	if err != nil {
+		return err
+	}
+	block, err := pemutil.Serialize(key)
+	if err != nil {
+		return err
+	}
+
+	if outputFile := ctx.String("output-file"); len(outputFile) > 0 {
+		if err := utils.WriteFile(outputFile, pem.EncodeToMemory(block), 0600); err != nil {
+			return err
+		}
+		ui.Printf("The public key has been saved in %s.\n", outputFile)
+		return nil
+	}
+
+	fmt.Print(string(pem.EncodeToMemory(block)))
+	return nil
+}

--- a/crypto/keys/key.go
+++ b/crypto/keys/key.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 
 	"github.com/pkg/errors"
+	stepx509 "github.com/smallstep/cli/pkg/x509"
 	"golang.org/x/crypto/ed25519"
 )
 
@@ -70,6 +71,10 @@ func ExtractKey(in interface{}) (interface{}, error) {
 	case *x509.Certificate:
 		return k.PublicKey, nil
 	case *x509.CertificateRequest:
+		return k.PublicKey, nil
+	case *stepx509.Certificate:
+		return k.PublicKey, nil
+	case *stepx509.CertificateRequest:
 		return k.PublicKey, nil
 	default:
 		return nil, errors.Errorf("cannot extract the key from type '%T'", k)

--- a/crypto/keys/key.go
+++ b/crypto/keys/key.go
@@ -5,6 +5,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"math/big"
 
 	"github.com/pkg/errors"
@@ -55,6 +56,23 @@ func GenerateKey(kty, crv string, size int) (interface{}, error) {
 		return generateOctKey(size)
 	default:
 		return nil, errors.Errorf("unrecognized key type: %s", kty)
+	}
+}
+
+// ExtractKey returns the given public or private key or extracts the public key
+// if a x509.Certificate or x509.CertificateRequest is given.
+func ExtractKey(in interface{}) (interface{}, error) {
+	switch k := in.(type) {
+	case *rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey, *rsa.PrivateKey, *ecdsa.PrivateKey, ed25519.PrivateKey:
+		return in, nil
+	case []byte:
+		return in, nil
+	case *x509.Certificate:
+		return k.PublicKey, nil
+	case *x509.CertificateRequest:
+		return k.PublicKey, nil
+	default:
+		return nil, errors.Errorf("cannot extract the key from type '%T'", k)
 	}
 }
 

--- a/crypto/keys/key_test.go
+++ b/crypto/keys/key_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/smallstep/assert"
+	stepx509 "github.com/smallstep/cli/pkg/x509"
 	"golang.org/x/crypto/ed25519"
 )
 
@@ -96,8 +97,13 @@ func TestExtractKey(t *testing.T) {
 	b, _ := pem.Decode([]byte(testCRT))
 	cert, err := x509.ParseCertificate(b.Bytes)
 	assert.FatalError(t, err)
+	stepCert, err := stepx509.ParseCertificate(b.Bytes)
+	assert.FatalError(t, err)
+
 	b, _ = pem.Decode([]byte(testCSR))
 	csr, err := x509.ParseCertificateRequest(b.Bytes)
+	assert.FatalError(t, err)
+	stepCsr, err := stepx509.ParseCertificateRequest(b.Bytes)
 	assert.FatalError(t, err)
 
 	type args struct {
@@ -118,6 +124,8 @@ func TestExtractKey(t *testing.T) {
 		{"oct key", args{octKey}, octKey, false},
 		{"certificate", args{cert}, cert.PublicKey, false},
 		{"csr", args{csr}, csr.PublicKey, false},
+		{"step certificate", args{stepCert}, stepCert.PublicKey, false},
+		{"step csr", args{stepCsr}, stepCsr.PublicKey, false},
 		{"fail", args{"fooo"}, nil, true},
 	}
 	for _, tt := range tests {

--- a/crypto/keys/key_test.go
+++ b/crypto/keys/key_test.go
@@ -3,9 +3,37 @@ package keys
 import (
 	"crypto/ecdsa"
 	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"reflect"
 	"testing"
 
 	"github.com/smallstep/assert"
+	"golang.org/x/crypto/ed25519"
+)
+
+const (
+	testCRT = `-----BEGIN CERTIFICATE-----
+MIICLjCCAdSgAwIBAgIQBvswFbAODY9xtJ/myiuEHzAKBggqhkjOPQQDAjAkMSIw
+IAYDVQQDExlTbWFsbHN0ZXAgSW50ZXJtZWRpYXRlIENBMB4XDTE4MTEzMDE5NTkw
+OVoXDTE4MTIwMTE5NTkwOVowHjEcMBoGA1UEAxMTaGVsbG8uc21hbGxzdGVwLmNv
+bTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABIqPQy8roJTMWpEt8NNA1CnRm3l1
+wdjH4OrVaH3l2Gp/UW737Wbn4sqSAFahmajuwkfRG5KMh2/+xnCkGuR2fayjge0w
+geowDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcD
+AjAdBgNVHQ4EFgQU5bqyXvZaEmtZ3OpZapq7pBIkVvgwHwYDVR0jBBgwFoAUu97P
+aFQPfuyKOeew7Hg45WFIAVMwHgYDVR0RBBcwFYITaGVsbG8uc21hbGxzdGVwLmNv
+bTBZBgwrBgEEAYKkZMYoQAEESTBHAgEBBBVtYXJpYW5vQHNtYWxsc3RlcC5jb20E
+K2pPMzdkdERia3UtUW5hYnM1VlIwWXc2WUZGdjl3ZUExOGRwM2h0dmRFanMwCgYI
+KoZIzj0EAwIDSAAwRQIhALKeC2q0HWyHoZobZFK9HQynLbPOOtAK437RaetlX5ty
+AiBXQzvaLlDprQu+THj18aDYLnHA//5mdD3HPJV6KmgdDg==
+-----END CERTIFICATE-----`
+	testCSR = `-----BEGIN CERTIFICATE REQUEST-----
+MIHYMIGAAgEAMB4xHDAaBgNVBAMTE2hlbGxvLnNtYWxsc3RlcC5jb20wWTATBgcq
+hkjOPQIBBggqhkjOPQMBBwNCAASKj0MvK6CUzFqRLfDTQNQp0Zt5dcHYx+Dq1Wh9
+5dhqf1Fu9+1m5+LKkgBWoZmo7sJH0RuSjIdv/sZwpBrkdn2soAAwCgYIKoZIzj0E
+AwIDRwAwRAIgZgz9gdx9inOp6bSX4EkYiUCyLV9xGvabovu5C9UkRr8CIBGBbkp0
+l4tesAKoXelsLygJjPuUGRLK+OtdjPBIN1Zo
+-----END CERTIFICATE REQUEST-----`
 )
 
 func TestGenerateKey_unrecognizedkt(t *testing.T) {
@@ -48,5 +76,60 @@ func TestGenerateKey_unrecognizedkt(t *testing.T) {
 	if assert.NoError(t, err) {
 		_, ok := k.(*rsa.PrivateKey)
 		assert.True(t, ok)
+	}
+}
+
+func TestExtractKey(t *testing.T) {
+	k, err := GenerateKey("RSA", "", 2048)
+	assert.FatalError(t, err)
+	rsaKey := k.(*rsa.PrivateKey)
+	k, err = GenerateKey("EC", "P-256", 0)
+	assert.FatalError(t, err)
+	ecKey := k.(*ecdsa.PrivateKey)
+	k, err = GenerateKey("OKP", "Ed25519", 0)
+	assert.FatalError(t, err)
+	edKey := k.(ed25519.PrivateKey)
+	k, err = GenerateKey("oct", "", 64)
+	assert.FatalError(t, err)
+	octKey := k.([]byte)
+
+	b, _ := pem.Decode([]byte(testCRT))
+	cert, err := x509.ParseCertificate(b.Bytes)
+	assert.FatalError(t, err)
+	b, _ = pem.Decode([]byte(testCSR))
+	csr, err := x509.ParseCertificateRequest(b.Bytes)
+	assert.FatalError(t, err)
+
+	type args struct {
+		in interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{"RSA private key", args{rsaKey}, rsaKey, false},
+		{"RSA public key", args{rsaKey.Public()}, rsaKey.Public(), false},
+		{"EC private key", args{ecKey}, ecKey, false},
+		{"EC public key", args{ecKey.Public()}, ecKey.Public(), false},
+		{"OKP private key", args{edKey}, edKey, false},
+		{"OKP public key", args{edKey.Public()}, edKey.Public(), false},
+		{"oct key", args{octKey}, octKey, false},
+		{"certificate", args{cert}, cert.PublicKey, false},
+		{"csr", args{csr}, csr.PublicKey, false},
+		{"fail", args{"fooo"}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractKey(tt.args.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExtractKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractKey() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/crypto/pemutil/pem.go
+++ b/crypto/pemutil/pem.go
@@ -13,6 +13,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	"github.com/smallstep/cli/crypto/keys"
 	"github.com/smallstep/cli/errs"
 	"github.com/smallstep/cli/pkg/x509"
 	"github.com/smallstep/cli/ui"
@@ -247,6 +248,16 @@ func Parse(b []byte, opts ...Options) (interface{}, error) {
 	default:
 		return nil, errors.Errorf("error decoding %s: contains an unexpected header '%s'", ctx.filename, block.Type)
 	}
+}
+
+// ParseKey returns the key or the public key of a certificate or certificate
+// signing request in the given PEM-encoded bytes.
+func ParseKey(b []byte, opts ...Options) (interface{}, error) {
+	k, err := Parse(b, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return keys.ExtractKey(k)
 }
 
 // Read returns the key or certificate encoded in the given PEM file.

--- a/jose/parse.go
+++ b/jose/parse.go
@@ -91,7 +91,7 @@ func ParseKey(filename string, opts ...Option) (*JSONWebKey, error) {
 			return nil, errors.Errorf("error reading %s: unsupported format", filename)
 		}
 	case pemKeyType:
-		jwk.Key, err = pemutil.Parse(b, pemutil.WithFilename(filename), pemutil.WithPassword(ctx.password))
+		jwk.Key, err = pemutil.ParseKey(b, pemutil.WithFilename(filename), pemutil.WithPassword(ctx.password))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Description
This PR allows using certificates as keys in commands like `step crypto jwt verify --key cert.crt ...` and adds a command to extract public keys from certificates or CSRs `step certificate key cert.crt`

Fixes #67, #68, and #69