### PR TITLE
step certificate create: Added subject as SAN if empty

### DIFF
--- a/command/certificate/create.go
+++ b/command/certificate/create.go
@@ -292,7 +292,12 @@ func createAction(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	dnsNames, ips := x509util.SplitSANs(ctx.StringSlice("san"))
+
+	sans := ctx.StringSlice("san")
+	if len(sans) == 0 {
+		sans = []string{subject}
+	}
+	dnsNames, ips := x509util.SplitSANs(sans)
 
 	var (
 		priv       interface{}


### PR DESCRIPTION
```$ step certificate create --csr hello.smallstep.com hello.csr hello.key
Please enter the password to encrypt the private key:
Your certificate signing request has been saved in hello.csr.
Your private key has been saved in hello.key.
$ step ca sign hello.csr hello.crt
✔ Key ID: jO37dtDbku-Qnabs5VR0Yw6YFFv9weA18dp3htvdEjs (mariano@smallstep.com)
✔ Please enter the password to decrypt the provisioner key:
✔ CA: https://ca.smallstep.com:9000/1.0/sign
Unauthorized
```

Google Chrome version 58, released in April 2017, removed support for the X.509 certificate Subject Common Name (CN) as a source of naming information when validating certificates. As a result, certificates that do not carry all relevant domain names in the Subject Alternative Name (SAN) extension result in validation failures.

The `step ca` subcommands take this into account by adding the subject name as a SAN if no additional SANs are provided when generating a certificate. However, this behavior was not backfilled in the `step certificate` command group.