### PR TITLE
Use standard x509 as much as possible

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -323,8 +323,8 @@
   revision = "de77670473b5492f5d0bce155b5c01534c2d13f7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:ddc780ea695358bba68986ae9e7ba342512de810d4099cc57f9f11e59c58aeea"
+  branch = "x509util-real-x509"
+  digest = "1:17d26abb91a3527139cc605781672b345ddbc58f4892abcbba7d68048e503819"
   name = "github.com/smallstep/certificates"
   packages = [
     "api",
@@ -336,7 +336,7 @@
     "server",
   ]
   pruneopts = "UT"
-  revision = "095ab891e736ea7eb1c77436fd6083a79d786151"
+  revision = "da7360e445a2d0e4fc8db73cc7398bb12fab09fe"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -323,8 +323,8 @@
   revision = "de77670473b5492f5d0bce155b5c01534c2d13f7"
 
 [[projects]]
-  branch = "x509util-real-x509"
-  digest = "1:17d26abb91a3527139cc605781672b345ddbc58f4892abcbba7d68048e503819"
+  branch = "master"
+  digest = "1:b66ff4abd77f39e94020219427c0c62bc1474d41edb2b445d2058adede69475f"
   name = "github.com/smallstep/certificates"
   packages = [
     "api",
@@ -336,7 +336,7 @@
     "server",
   ]
   pruneopts = "UT"
-  revision = "da7360e445a2d0e4fc8db73cc7398bb12fab09fe"
+  revision = "04da00d7167ab6cf9381c5465c5d11d9477f18db"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,7 +64,7 @@ required = [
   unused-packages = true
 
 [[constraint]]
-  branch = "master"
+  branch = "x509util-real-x509"
   name = "github.com/smallstep/certificates"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,7 +64,7 @@ required = [
   unused-packages = true
 
 [[constraint]]
-  branch = "x509util-real-x509"
+  branch = "master"
   name = "github.com/smallstep/certificates"
 
 [[constraint]]

--- a/command/ca/init.go
+++ b/command/ca/init.go
@@ -2,6 +2,7 @@ package ca
 
 import (
 	"crypto/rand"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/smallstep/cli/crypto/pemutil"
 	"github.com/smallstep/cli/crypto/pki"
 	"github.com/smallstep/cli/errs"
-	stepx509 "github.com/smallstep/cli/pkg/x509"
 	"github.com/smallstep/cli/ui"
 	"github.com/smallstep/cli/utils"
 	"github.com/urfave/cli"
@@ -46,7 +46,7 @@ func initCommand() cli.Command {
 			},
 			cli.StringFlag{
 				Name:  "dns",
-				Usage: "The comma sepparated DNS <names> or IP addresses of the new CA.",
+				Usage: "The comma separated DNS <names> or IP addresses of the new CA.",
 			},
 			cli.StringFlag{
 				Name:  "address",
@@ -77,7 +77,7 @@ func initAction(ctx *cli.Context) (err error) {
 		return err
 	}
 
-	var rootCrt *stepx509.Certificate
+	var rootCrt *x509.Certificate
 	var rootKey interface{}
 
 	root := ctx.String("root")
@@ -91,7 +91,7 @@ func initAction(ctx *cli.Context) (err error) {
 		return errs.RequiredWithFlag(ctx, "key", "root")
 	case len(root) > 0 && len(key) > 0:
 		var err error
-		if rootCrt, err = pemutil.ReadStepCertificate(root); err != nil {
+		if rootCrt, err = pemutil.ReadCertificate(root); err != nil {
 			return err
 		}
 		if rootKey, err = pemutil.Read(key); err != nil {

--- a/command/certificate/create.go
+++ b/command/certificate/create.go
@@ -12,7 +12,7 @@ import (
 	"github.com/smallstep/cli/crypto/x509util"
 	"github.com/smallstep/cli/errs"
 	"github.com/smallstep/cli/flags"
-	x509 "github.com/smallstep/cli/pkg/x509"
+	stepx509 "github.com/smallstep/cli/pkg/x509"
 	"github.com/smallstep/cli/ui"
 	"github.com/smallstep/cli/utils"
 	"github.com/urfave/cli"
@@ -314,14 +314,14 @@ func createAction(ctx *cli.Context) error {
 			return errors.WithStack(err)
 		}
 
-		_csr := &x509.CertificateRequest{
+		_csr := &stepx509.CertificateRequest{
 			Subject: pkix.Name{
 				CommonName: subject,
 			},
 			DNSNames:    dnsNames,
 			IPAddresses: ips,
 		}
-		csrBytes, err := x509.CreateCertificateRequest(rand.Reader, _csr, priv)
+		csrBytes, err := stepx509.CreateCertificateRequest(rand.Reader, _csr, priv)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/command/certificate/fingerprint.go
+++ b/command/certificate/fingerprint.go
@@ -4,9 +4,8 @@ import (
 	"crypto/x509"
 	"fmt"
 
-	"github.com/smallstep/cli/crypto/x509util"
-
 	"github.com/smallstep/cli/crypto/pemutil"
+	"github.com/smallstep/cli/crypto/x509util"
 	"github.com/smallstep/cli/errs"
 	"github.com/urfave/cli"
 )

--- a/command/certificate/sign.go
+++ b/command/certificate/sign.go
@@ -64,7 +64,7 @@ func signAction(ctx *cli.Context) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if err := csr.CheckSignature(); err != nil {
+	if err := x509util.CheckCertificateRequestSignature(csr); err != nil {
 		return errors.Wrapf(err, "Certificate Request has invalid signature")
 	}
 
@@ -89,6 +89,5 @@ func signAction(ctx *cli.Context) error {
 	}
 	fmt.Printf("%s", string(pem.EncodeToMemory(block)))
 
-	//tok := ctx.String("token")
 	return nil
 }

--- a/command/certificate/verify.go
+++ b/command/certificate/verify.go
@@ -1,7 +1,7 @@
 package certificate
 
 import (
-	realx509 "crypto/x509"
+	"crypto/x509"
 	"encoding/pem"
 	"io/ioutil"
 
@@ -100,9 +100,9 @@ func verifyAction(ctx *cli.Context) error {
 		crtFile          = ctx.Args().Get(0)
 		host             = ctx.String("host")
 		roots            = ctx.String("roots")
-		intermediatePool = realx509.NewCertPool()
-		rootPool         *realx509.CertPool
-		cert             *realx509.Certificate
+		intermediatePool = x509.NewCertPool()
+		rootPool         *x509.CertPool
+		cert             *x509.Certificate
 	)
 
 	if _, addr, isURL := trimURLPrefix(crtFile); isURL {
@@ -136,7 +136,7 @@ func verifyAction(ctx *cli.Context) error {
 				continue
 			}
 			if cert == nil {
-				cert, err = realx509.ParseCertificate(block.Bytes)
+				cert, err = x509.ParseCertificate(block.Bytes)
 				if err != nil {
 					return errors.WithStack(err)
 				}
@@ -159,7 +159,7 @@ func verifyAction(ctx *cli.Context) error {
 		}
 	}
 
-	opts := realx509.VerifyOptions{
+	opts := x509.VerifyOptions{
 		DNSName:       host,
 		Roots:         rootPool,
 		Intermediates: intermediatePool,

--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"bufio"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
@@ -23,7 +24,6 @@ import (
 	"github.com/smallstep/cli/errs"
 	"github.com/smallstep/cli/exec"
 	"github.com/smallstep/cli/jose"
-	"github.com/smallstep/cli/pkg/x509"
 	"github.com/urfave/cli"
 )
 

--- a/crypto/pki/pki.go
+++ b/crypto/pki/pki.go
@@ -2,6 +2,7 @@ package pki
 
 import (
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
@@ -21,7 +22,6 @@ import (
 	"github.com/smallstep/cli/crypto/x509util"
 	"github.com/smallstep/cli/errs"
 	"github.com/smallstep/cli/jose"
-	stepX509 "github.com/smallstep/cli/pkg/x509"
 	"github.com/smallstep/cli/ui"
 	"github.com/smallstep/cli/utils"
 )
@@ -213,7 +213,7 @@ func (p *PKI) GenerateKeyPairs(pass []byte) error {
 }
 
 // GenerateRootCertificate generates a root certificate with the given name.
-func (p *PKI) GenerateRootCertificate(name string, pass []byte) (*stepX509.Certificate, interface{}, error) {
+func (p *PKI) GenerateRootCertificate(name string, pass []byte) (*x509.Certificate, interface{}, error) {
 	rootProfile, err := x509util.NewRootProfile(name)
 	if err != nil {
 		return nil, nil, err
@@ -224,7 +224,7 @@ func (p *PKI) GenerateRootCertificate(name string, pass []byte) (*stepX509.Certi
 		return nil, nil, err
 	}
 
-	rootCrt, err := stepX509.ParseCertificate(rootBytes)
+	rootCrt, err := x509.ParseCertificate(rootBytes)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error parsing root certificate")
 	}
@@ -236,7 +236,7 @@ func (p *PKI) GenerateRootCertificate(name string, pass []byte) (*stepX509.Certi
 }
 
 // WriteRootCertificate writes to disk the given certificate and key.
-func (p *PKI) WriteRootCertificate(rootCrt *stepX509.Certificate, rootKey interface{}, pass []byte) error {
+func (p *PKI) WriteRootCertificate(rootCrt *x509.Certificate, rootKey interface{}, pass []byte) error {
 	if err := utils.WriteFile(p.root, pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: rootCrt.Raw,
@@ -253,7 +253,7 @@ func (p *PKI) WriteRootCertificate(rootCrt *stepX509.Certificate, rootKey interf
 
 // GenerateIntermediateCertificate generates an intermediate certificate with
 // the given name.
-func (p *PKI) GenerateIntermediateCertificate(name string, rootCrt *stepX509.Certificate, rootKey interface{}, pass []byte) error {
+func (p *PKI) GenerateIntermediateCertificate(name string, rootCrt *x509.Certificate, rootKey interface{}, pass []byte) error {
 	interProfile, err := x509util.NewIntermediateProfile(name, rootCrt, rootKey)
 	if err != nil {
 		return err

--- a/crypto/x509util/convert.go
+++ b/crypto/x509util/convert.go
@@ -3,12 +3,44 @@ package x509util
 import (
 	"crypto/x509"
 
+	"github.com/pkg/errors"
 	stepx509 "github.com/smallstep/cli/pkg/x509"
 )
 
-// ToStepX509 converts a x509.Certificate from the standard library to the step
-// version of the x509.Certificate.
-func ToStepX509(cert *x509.Certificate) *stepx509.Certificate {
+// ParseCertificate parses a single certificate from the given ASN.1 DER data.
+func ParseCertificate(asn1Data []byte) (*x509.Certificate, error) {
+	cert, err := stepx509.ParseCertificate(asn1Data)
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing certificate")
+	}
+	return ToX509Certificate(cert), nil
+}
+
+// ParseCertificateRequest parses a single certificate request from the given
+// ASN.1 DER data.
+func ParseCertificateRequest(asn1Data []byte) (*x509.CertificateRequest, error) {
+	csr, err := stepx509.ParseCertificateRequest(asn1Data)
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing certificate request")
+	}
+	return ToX509CertificateRequest(csr), nil
+}
+
+// CheckCertificateRequestSignature verifies that signature is a valid signature
+// over signed from csr's public key.
+//
+// CheckCertificateRequestSignature reports whether the signature on csr is
+// valid.
+func CheckCertificateRequestSignature(csr *x509.CertificateRequest) error {
+	if stepx509.SignatureAlgorithm(csr.SignatureAlgorithm) == stepx509.ED25519SIG {
+		return ToStepX509CertificateRequest(csr).CheckSignature()
+	}
+	return csr.CheckSignature()
+}
+
+// ToStepX509Certificate converts a x509.Certificate from the standard library
+// to the step version of the x509.Certificate.
+func ToStepX509Certificate(cert *x509.Certificate) *stepx509.Certificate {
 	return &stepx509.Certificate{
 		Raw:                         cert.Raw,
 		RawTBSCertificate:           cert.RawTBSCertificate,
@@ -63,4 +95,111 @@ func toStepExtKeyUsage(eku []x509.ExtKeyUsage) []stepx509.ExtKeyUsage {
 		ret = append(ret, stepx509.ExtKeyUsage(u))
 	}
 	return ret
+}
+
+// ToX509Certificate converts a x509.Certificate from the internal package to
+// the standard version of the x509.Certificate.
+func ToX509Certificate(cert *stepx509.Certificate) *x509.Certificate {
+	return &x509.Certificate{
+		Raw:                         cert.Raw,
+		RawTBSCertificate:           cert.RawTBSCertificate,
+		RawSubjectPublicKeyInfo:     cert.RawSubjectPublicKeyInfo,
+		RawSubject:                  cert.RawSubject,
+		RawIssuer:                   cert.RawIssuer,
+		Signature:                   cert.Signature,
+		SignatureAlgorithm:          x509.SignatureAlgorithm(cert.SignatureAlgorithm),
+		PublicKeyAlgorithm:          x509.PublicKeyAlgorithm(cert.PublicKeyAlgorithm),
+		PublicKey:                   cert.PublicKey,
+		Version:                     cert.Version,
+		SerialNumber:                cert.SerialNumber,
+		Issuer:                      cert.Issuer,
+		Subject:                     cert.Subject,
+		NotBefore:                   cert.NotBefore,
+		NotAfter:                    cert.NotAfter,
+		KeyUsage:                    x509.KeyUsage(cert.KeyUsage),
+		Extensions:                  cert.Extensions,
+		ExtraExtensions:             cert.ExtraExtensions,
+		UnhandledCriticalExtensions: cert.UnhandledCriticalExtensions,
+		ExtKeyUsage:                 toExtKeyUsage(cert.ExtKeyUsage),
+		UnknownExtKeyUsage:          cert.UnknownExtKeyUsage,
+		BasicConstraintsValid:       cert.BasicConstraintsValid,
+		IsCA:                        cert.IsCA,
+		MaxPathLen:                  cert.MaxPathLen,
+		MaxPathLenZero:              cert.MaxPathLenZero,
+		SubjectKeyId:                cert.SubjectKeyId,
+		AuthorityKeyId:              cert.AuthorityKeyId,
+		OCSPServer:                  cert.OCSPServer,
+		IssuingCertificateURL:       cert.IssuingCertificateURL,
+		DNSNames:                    cert.DNSNames,
+		EmailAddresses:              cert.EmailAddresses,
+		IPAddresses:                 cert.IPAddresses,
+		URIs:                        cert.URIs,
+		PermittedDNSDomainsCritical: cert.PermittedDNSDomainsCritical,
+		PermittedDNSDomains:         cert.PermittedDNSDomains,
+		ExcludedDNSDomains:          cert.ExcludedDNSDomains,
+		PermittedIPRanges:           cert.PermittedIPRanges,
+		ExcludedIPRanges:            cert.ExcludedIPRanges,
+		PermittedEmailAddresses:     cert.PermittedEmailAddresses,
+		ExcludedEmailAddresses:      cert.ExcludedEmailAddresses,
+		PermittedURIDomains:         cert.PermittedURIDomains,
+		ExcludedURIDomains:          cert.ExcludedURIDomains,
+		CRLDistributionPoints:       cert.CRLDistributionPoints,
+		PolicyIdentifiers:           cert.PolicyIdentifiers,
+	}
+}
+
+func toExtKeyUsage(eku []stepx509.ExtKeyUsage) []x509.ExtKeyUsage {
+	var ret []x509.ExtKeyUsage
+	for _, u := range eku {
+		ret = append(ret, x509.ExtKeyUsage(u))
+	}
+	return ret
+}
+
+// ToStepX509CertificateRequest converts a x509.CertificateRequest from the standard library
+// to the step version of the x509.CertificateRequest.
+func ToStepX509CertificateRequest(csr *x509.CertificateRequest) *stepx509.CertificateRequest {
+	return &stepx509.CertificateRequest{
+		Raw:                      csr.Raw,
+		RawTBSCertificateRequest: csr.RawTBSCertificateRequest,
+		RawSubjectPublicKeyInfo:  csr.RawSubjectPublicKeyInfo,
+		RawSubject:               csr.RawSubject,
+		Version:                  csr.Version,
+		Signature:                csr.Signature,
+		SignatureAlgorithm:       stepx509.SignatureAlgorithm(csr.SignatureAlgorithm),
+		PublicKeyAlgorithm:       stepx509.PublicKeyAlgorithm(csr.PublicKeyAlgorithm),
+		PublicKey:                csr.PublicKey,
+		Subject:                  csr.Subject,
+		Attributes:               csr.Attributes,
+		Extensions:               csr.Extensions,
+		ExtraExtensions:          csr.ExtraExtensions,
+		DNSNames:                 csr.DNSNames,
+		EmailAddresses:           csr.EmailAddresses,
+		IPAddresses:              csr.IPAddresses,
+		URIs:                     csr.URIs,
+	}
+}
+
+// ToX509CertificateRequest converts a x509.CertificateRequest from the internal package to
+// the standard version of the x509.CertificateRequest.
+func ToX509CertificateRequest(csr *stepx509.CertificateRequest) *x509.CertificateRequest {
+	return &x509.CertificateRequest{
+		Raw:                      csr.Raw,
+		RawTBSCertificateRequest: csr.RawTBSCertificateRequest,
+		RawSubjectPublicKeyInfo:  csr.RawSubjectPublicKeyInfo,
+		RawSubject:               csr.RawSubject,
+		Version:                  csr.Version,
+		Signature:                csr.Signature,
+		SignatureAlgorithm:       x509.SignatureAlgorithm(csr.SignatureAlgorithm),
+		PublicKeyAlgorithm:       x509.PublicKeyAlgorithm(csr.PublicKeyAlgorithm),
+		PublicKey:                csr.PublicKey,
+		Subject:                  csr.Subject,
+		Attributes:               csr.Attributes,
+		Extensions:               csr.Extensions,
+		ExtraExtensions:          csr.ExtraExtensions,
+		DNSNames:                 csr.DNSNames,
+		EmailAddresses:           csr.EmailAddresses,
+		IPAddresses:              csr.IPAddresses,
+		URIs:                     csr.URIs,
+	}
 }

--- a/crypto/x509util/convert.go
+++ b/crypto/x509util/convert.go
@@ -1,0 +1,66 @@
+package x509util
+
+import (
+	"crypto/x509"
+
+	stepx509 "github.com/smallstep/cli/pkg/x509"
+)
+
+// ToStepX509 converts a x509.Certificate from the standard library to the step
+// version of the x509.Certificate.
+func ToStepX509(cert *x509.Certificate) *stepx509.Certificate {
+	return &stepx509.Certificate{
+		Raw:                         cert.Raw,
+		RawTBSCertificate:           cert.RawTBSCertificate,
+		RawSubjectPublicKeyInfo:     cert.RawSubjectPublicKeyInfo,
+		RawSubject:                  cert.RawSubject,
+		RawIssuer:                   cert.RawIssuer,
+		Signature:                   cert.Signature,
+		SignatureAlgorithm:          stepx509.SignatureAlgorithm(cert.SignatureAlgorithm),
+		PublicKeyAlgorithm:          stepx509.PublicKeyAlgorithm(cert.PublicKeyAlgorithm),
+		PublicKey:                   cert.PublicKey,
+		Version:                     cert.Version,
+		SerialNumber:                cert.SerialNumber,
+		Issuer:                      cert.Issuer,
+		Subject:                     cert.Subject,
+		NotBefore:                   cert.NotBefore,
+		NotAfter:                    cert.NotAfter,
+		KeyUsage:                    stepx509.KeyUsage(cert.KeyUsage),
+		Extensions:                  cert.Extensions,
+		ExtraExtensions:             cert.ExtraExtensions,
+		UnhandledCriticalExtensions: cert.UnhandledCriticalExtensions,
+		ExtKeyUsage:                 toStepExtKeyUsage(cert.ExtKeyUsage),
+		UnknownExtKeyUsage:          cert.UnknownExtKeyUsage,
+		BasicConstraintsValid:       cert.BasicConstraintsValid,
+		IsCA:                        cert.IsCA,
+		MaxPathLen:                  cert.MaxPathLen,
+		MaxPathLenZero:              cert.MaxPathLenZero,
+		SubjectKeyId:                cert.SubjectKeyId,
+		AuthorityKeyId:              cert.AuthorityKeyId,
+		OCSPServer:                  cert.OCSPServer,
+		IssuingCertificateURL:       cert.IssuingCertificateURL,
+		DNSNames:                    cert.DNSNames,
+		EmailAddresses:              cert.EmailAddresses,
+		IPAddresses:                 cert.IPAddresses,
+		URIs:                        cert.URIs,
+		PermittedDNSDomainsCritical: cert.PermittedDNSDomainsCritical,
+		PermittedDNSDomains:         cert.PermittedDNSDomains,
+		ExcludedDNSDomains:          cert.ExcludedDNSDomains,
+		PermittedIPRanges:           cert.PermittedIPRanges,
+		ExcludedIPRanges:            cert.ExcludedIPRanges,
+		PermittedEmailAddresses:     cert.PermittedEmailAddresses,
+		ExcludedEmailAddresses:      cert.ExcludedEmailAddresses,
+		PermittedURIDomains:         cert.PermittedURIDomains,
+		ExcludedURIDomains:          cert.ExcludedURIDomains,
+		CRLDistributionPoints:       cert.CRLDistributionPoints,
+		PolicyIdentifiers:           cert.PolicyIdentifiers,
+	}
+}
+
+func toStepExtKeyUsage(eku []x509.ExtKeyUsage) []stepx509.ExtKeyUsage {
+	var ret []stepx509.ExtKeyUsage
+	for _, u := range eku {
+		ret = append(ret, stepx509.ExtKeyUsage(u))
+	}
+	return ret
+}

--- a/crypto/x509util/convert_test.go
+++ b/crypto/x509util/convert_test.go
@@ -3,7 +3,6 @@ package x509util
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"reflect"
 	"testing"
 
@@ -11,12 +10,196 @@ import (
 	stepx509 "github.com/smallstep/cli/pkg/x509"
 )
 
-func TestToStepX509(t *testing.T) {
-	b, err := ioutil.ReadFile("test_files/ca.crt")
-	assert.FatalError(t, err)
-	block, rest := pem.Decode(b)
+const p256Cert = `-----BEGIN CERTIFICATE-----
+MIIBbDCCARGgAwIBAgIQB2n32M1trIqbSNO5s4fDszAKBggqhkjOPQQDAjAUMRIw
+EAYDVQQDEwlTbWFsbHN0ZXAwHhcNMTkwMzIwMjEzNTQ3WhcNMjkwMzE3MjEzNTQ3
+WjAUMRIwEAYDVQQDEwlTbWFsbHN0ZXAwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC
+AAQYWj9HJC5ODzKccPs6PU0J024H1AvD6TZ9OKNCzUtnCL+xCieNoXt+nkz0bWYy
+B/l7NZYmiK/fm593cuH6s3OSo0UwQzAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/
+BAgwBgEB/wIBATAdBgNVHQ4EFgQUO4vdeQoiwWXxOf0PqR3Q8jHpEcowCgYIKoZI
+zj0EAwIDSQAwRgIhAKuPgK9oMG1sfZNRvl+nuih/pClJYkBL8xKn1nZegw8TAiEA
+yjfrPADkvXB+8Q+03y+LFpBKT+/Ik/QX0gg5aXV2QCI=
+-----END CERTIFICATE-----`
+
+const p256Csr = `-----BEGIN CERTIFICATE REQUEST-----
+MIHPMHYCAQAwFDESMBAGA1UEAxMJU21hbGxzdGVwMFkwEwYHKoZIzj0CAQYIKoZI
+zj0DAQcDQgAEtllRP2ccqN2Civ1XUU4TPjLHqiSN5GQh7QTtQLCjPT6DMsjahEiT
+8k34oGNi9MF66GqTwsBWD9HOqgcGqxVZw6AAMAoGCCqGSM49BAMCA0kAMEYCIQDK
+mKr4vkMPzu78/2sTOyMt0GVpWV+W7atLk7YhwhnfagIhANq6so7Hk8X16ps2SRAo
+GkaGf4tysRN6vKA/Oq77ukaG
+-----END CERTIFICATE REQUEST-----`
+
+const ed25519Cert = `-----BEGIN CERTIFICATE-----
+MIIBKjCB3aADAgECAhACaDrQ2I9zn60Pt5ctWZE7MAUGAytlcDAUMRIwEAYDVQQD
+EwlTbWFsbHN0ZXAwHhcNMTkwMzIwMjEzNDQ0WhcNMjkwMzE3MjEzNDQ0WjAUMRIw
+EAYDVQQDEwlTbWFsbHN0ZXAwKjAFBgMrZXADIQDjbJdq67orCi8Alkg6xtApQ879
+rYCyjgcGY9Ibu9gbu6NFMEMwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYB
+Af8CAQEwHQYDVR0OBBYEFMzQag6BfhEm3JwvmYkHBcjYeEZkMAUGAytlcANBAPA7
+gku6S6wxO+E4anCbyzIoc2kmNOKKkjkJhr5nxhpEfsz4i40E8p5YH20V2WQYjtBK
+vhhVZulIOs7FAqiU/AU=
+-----END CERTIFICATE-----`
+
+const ed25519Csr = `-----BEGIN CERTIFICATE REQUEST-----
+MIGTMEcCAQAwFDESMBAGA1UEAxMJU21hbGxzdGVwMCowBQYDK2VwAyEAk+PGnyUh
+20sK6UcTkSr+aGC3QVpt4x+uZnW5nASe/UigADAFBgMrZXADQQC/HMU8qPSgh8vY
+A0rCTeGgLIR0IJ65tR1CPwyeMZlFpe6AoyM7lIKDxWabZVBau1W8HqFDvhjaxNrE
+070Tz9oO
+-----END CERTIFICATE REQUEST-----`
+
+func pemBytes(t *testing.T, data string) []byte {
+	block, rest := pem.Decode([]byte(data))
 	if !assert.Len(t, 0, rest) || !assert.NotNil(t, block) {
-		t.Fatal("error decoding test_files/ca.crt")
+		t.Fatal("error decoding PEM")
+	}
+	return block.Bytes
+}
+
+func TestParseCertificate(t *testing.T) {
+	p256Bytes := pemBytes(t, p256Cert)
+	ed25519Bytes := pemBytes(t, ed25519Cert)
+
+	p256, err := x509.ParseCertificate(p256Bytes)
+	assert.FatalError(t, err)
+
+	edCert, err := stepx509.ParseCertificate(ed25519Bytes)
+	assert.FatalError(t, err)
+	ed25519 := ToX509Certificate(edCert)
+
+	type args struct {
+		asn1Data []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *x509.Certificate
+		wantErr bool
+	}{
+		{"p256", args{p256Bytes}, p256, false},
+		{"ed25519", args{ed25519Bytes}, ed25519, false},
+		{"fail", args{nil}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseCertificate(tt.args.asn1Data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseCertificate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseCertificate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCertificateRequest(t *testing.T) {
+	p256Bytes := pemBytes(t, p256Csr)
+	ed25519Bytes := pemBytes(t, ed25519Csr)
+
+	p256, err := x509.ParseCertificateRequest(p256Bytes)
+	assert.FatalError(t, err)
+
+	edCsr, err := stepx509.ParseCertificateRequest(ed25519Bytes)
+	assert.FatalError(t, err)
+	ed25519 := ToX509CertificateRequest(edCsr)
+
+	type args struct {
+		asn1Data []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *x509.CertificateRequest
+		wantErr bool
+	}{
+		{"p256", args{p256Bytes}, p256, false},
+		{"ed25519", args{ed25519Bytes}, ed25519, false},
+		{"fail", args{nil}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseCertificateRequest(tt.args.asn1Data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseCertificateRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseCertificateRequest() = %v, want %v", got, tt.want)
+			}
+			if got != nil {
+				if err := CheckCertificateRequestSignature(got); err != nil {
+					t.Errorf("CheckCertificateRequestSignature() error = %v", err)
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestParseEd25519NoError(t *testing.T) {
+	block, rest := pem.Decode([]byte(ed25519Cert))
+	if !assert.Len(t, 0, rest) || !assert.NotNil(t, block) {
+		t.Fatal("error decoding certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	assert.FatalError(t, err)
+	assert.Equals(t, x509.UnknownPublicKeyAlgorithm, cert.PublicKeyAlgorithm)
+	assert.Equals(t, x509.UnknownSignatureAlgorithm, cert.SignatureAlgorithm)
+	assert.Nil(t, cert.PublicKey)
+	assert.Len(t, 64, cert.Signature)
+
+	block, rest = pem.Decode([]byte(ed25519Csr))
+	if !assert.Len(t, 0, rest) || !assert.NotNil(t, block) {
+		t.Fatal("error decoding certificate request")
+	}
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	assert.FatalError(t, err)
+	assert.Equals(t, x509.UnknownPublicKeyAlgorithm, csr.PublicKeyAlgorithm)
+	assert.Equals(t, x509.UnknownSignatureAlgorithm, csr.SignatureAlgorithm)
+	assert.Nil(t, csr.PublicKey)
+	assert.Len(t, 64, csr.Signature)
+}
+
+func TestConvertCertificates(t *testing.T) {
+	p256Bytes := pemBytes(t, p256Cert)
+	ed25519Bytes := pemBytes(t, ed25519Cert)
+
+	p1, err := x509.ParseCertificate(p256Bytes)
+	assert.FatalError(t, err)
+	p2, err := stepx509.ParseCertificate(p256Bytes)
+	assert.FatalError(t, err)
+	assert.Equals(t, p1, ToX509Certificate(p2))
+	assert.Equals(t, p2, ToStepX509Certificate(p1))
+	assert.Equals(t, p1, ToX509Certificate(ToStepX509Certificate(p1)))
+	assert.Equals(t, p2, ToStepX509Certificate(ToX509Certificate(p2)))
+
+	e1, err := stepx509.ParseCertificate(ed25519Bytes)
+	assert.FatalError(t, err)
+	assert.Equals(t, e1, ToStepX509Certificate(ToX509Certificate(e1)))
+}
+
+func TestconvertCertificateRequests(t *testing.T) {
+	p256Bytes := pemBytes(t, p256Csr)
+	ed25519Bytes := pemBytes(t, ed25519Csr)
+
+	p1, err := x509.ParseCertificateRequest(p256Bytes)
+	assert.FatalError(t, err)
+	p2, err := stepx509.ParseCertificateRequest(p256Bytes)
+	assert.FatalError(t, err)
+	assert.Equals(t, p1, ToX509CertificateRequest(p2))
+	assert.Equals(t, p2, ToStepX509CertificateRequest(p1))
+	assert.Equals(t, p1, ToX509CertificateRequest(ToStepX509CertificateRequest(p1)))
+	assert.Equals(t, p2, ToStepX509CertificateRequest(ToX509CertificateRequest(p2)))
+
+	e1, err := stepx509.ParseCertificateRequest(ed25519Bytes)
+	assert.FatalError(t, err)
+	assert.Equals(t, e1, ToStepX509CertificateRequest(ToX509CertificateRequest(e1)))
+}
+
+func TestToStepX509Certificate(t *testing.T) {
+	block, rest := pem.Decode([]byte(p256Cert))
+	if !assert.Len(t, 0, rest) || !assert.NotNil(t, block) {
+		t.Fatal("error decoding certificate")
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)
@@ -37,8 +220,101 @@ func TestToStepX509(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ToStepX509(tt.args.cert); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ToStepX509() = %v, want %v", got, tt.want)
+			if got := ToStepX509Certificate(tt.args.cert); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ToStepX509Certificate() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToX509Certificate(t *testing.T) {
+	block, rest := pem.Decode([]byte(p256Cert))
+	if !assert.Len(t, 0, rest) || !assert.NotNil(t, block) {
+		t.Fatal("error decoding certificate")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	assert.FatalError(t, err)
+
+	scert, err := stepx509.ParseCertificate(block.Bytes)
+	assert.FatalError(t, err)
+
+	type args struct {
+		cert *stepx509.Certificate
+	}
+	tests := []struct {
+		name string
+		args args
+		want *x509.Certificate
+	}{
+		{"ok", args{scert}, cert},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToX509Certificate(tt.args.cert); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ToX509Certificate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToStepX509CertificateRequest(t *testing.T) {
+	block, rest := pem.Decode([]byte(p256Csr))
+	if !assert.Len(t, 0, rest) || !assert.NotNil(t, block) {
+		t.Fatal("error decoding certificate request")
+	}
+
+	cert, err := x509.ParseCertificateRequest(block.Bytes)
+	assert.FatalError(t, err)
+
+	scert, err := stepx509.ParseCertificateRequest(block.Bytes)
+	assert.FatalError(t, err)
+
+	type args struct {
+		cert *x509.CertificateRequest
+	}
+	tests := []struct {
+		name string
+		args args
+		want *stepx509.CertificateRequest
+	}{
+		{"ok", args{cert}, scert},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToStepX509CertificateRequest(tt.args.cert); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ToStepX509CertificateRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToX509CertificateRequest(t *testing.T) {
+	block, rest := pem.Decode([]byte(p256Csr))
+	if !assert.Len(t, 0, rest) || !assert.NotNil(t, block) {
+		t.Fatal("error decoding certificate request")
+	}
+
+	cert, err := x509.ParseCertificateRequest(block.Bytes)
+	assert.FatalError(t, err)
+
+	scert, err := stepx509.ParseCertificateRequest(block.Bytes)
+	assert.FatalError(t, err)
+
+	type args struct {
+		cert *stepx509.CertificateRequest
+	}
+	tests := []struct {
+		name string
+		args args
+		want *x509.CertificateRequest
+	}{
+		{"ok", args{scert}, cert},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToX509CertificateRequest(tt.args.cert); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ToX509CertificateRequest() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/crypto/x509util/convert_test.go
+++ b/crypto/x509util/convert_test.go
@@ -1,0 +1,45 @@
+package x509util
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	"github.com/smallstep/assert"
+	stepx509 "github.com/smallstep/cli/pkg/x509"
+)
+
+func TestToStepX509(t *testing.T) {
+	b, err := ioutil.ReadFile("test_files/ca.crt")
+	assert.FatalError(t, err)
+	block, rest := pem.Decode(b)
+	if !assert.Len(t, 0, rest) || !assert.NotNil(t, block) {
+		t.Fatal("error decoding test_files/ca.crt")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	assert.FatalError(t, err)
+
+	scert, err := stepx509.ParseCertificate(block.Bytes)
+	assert.FatalError(t, err)
+
+	type args struct {
+		cert *x509.Certificate
+	}
+	tests := []struct {
+		name string
+		args args
+		want *stepx509.Certificate
+	}{
+		{"ok", args{cert}, scert},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToStepX509(tt.args.cert); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ToStepX509() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/crypto/x509util/convert_test.go
+++ b/crypto/x509util/convert_test.go
@@ -178,7 +178,7 @@ func TestConvertCertificates(t *testing.T) {
 	assert.Equals(t, e1, ToStepX509Certificate(ToX509Certificate(e1)))
 }
 
-func TestconvertCertificateRequests(t *testing.T) {
+func TestConvertCertificateRequests(t *testing.T) {
 	p256Bytes := pemBytes(t, p256Csr)
 	ed25519Bytes := pemBytes(t, ed25519Csr)
 

--- a/crypto/x509util/csr.go
+++ b/crypto/x509util/csr.go
@@ -1,10 +1,9 @@
 package x509util
 
 import (
+	"crypto/x509"
 	"encoding/pem"
 	"errors"
-
-	"github.com/smallstep/cli/pkg/x509"
 )
 
 // LoadCSRFromBytes loads a CSR given the ASN.1 DER format.
@@ -13,5 +12,5 @@ func LoadCSRFromBytes(der []byte) (*x509.CertificateRequest, error) {
 	if block == nil {
 		return nil, errors.New("failed to decode PEM block containing CSR")
 	}
-	return x509.ParseCertificateRequest(block.Bytes)
+	return ParseCertificateRequest(block.Bytes)
 }

--- a/crypto/x509util/csr_test.go
+++ b/crypto/x509util/csr_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/smallstep/assert"
-	"github.com/smallstep/cli/pkg/x509"
+	stepx509 "github.com/smallstep/cli/pkg/x509"
 )
 
 func TestCSR_LoadCSRFromBytes(t *testing.T) {
@@ -35,16 +35,16 @@ func TestCSR_LoadCSRFromBytes(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				template := &x509.CertificateRequest{
+				template := &stepx509.CertificateRequest{
 					Subject: pkix.Name{
 						Country:      []string{"Foo"},
 						Organization: []string{"Smallstep"},
 						CommonName:   "Bar",
 					},
-					SignatureAlgorithm: x509.SHA256WithRSA,
+					SignatureAlgorithm: stepx509.SHA256WithRSA,
 				}
 
-				bytes, err := x509.CreateCertificateRequest(rand.Reader, template, keypair)
+				bytes, err := stepx509.CreateCertificateRequest(rand.Reader, template, keypair)
 				if err != nil {
 					return nil, err
 				}

--- a/crypto/x509util/identity.go
+++ b/crypto/x509util/identity.go
@@ -1,11 +1,11 @@
 package x509util
 
 import (
+	"crypto/x509"
 	"io/ioutil"
 
 	"github.com/pkg/errors"
 	"github.com/smallstep/cli/crypto/pemutil"
-	"github.com/smallstep/cli/pkg/x509"
 )
 
 // Identity contains a public/private x509 certificate/key pair.
@@ -25,21 +25,20 @@ func NewIdentity(c *x509.Certificate, k interface{}) *Identity {
 // LoadIdentityFromDisk load a public certificate and private key (both in PEM
 // format) from disk.
 func LoadIdentityFromDisk(crtPath, keyPath string, pemOpts ...pemutil.Options) (*Identity, error) {
+	// Read using stepx509 to parse the PublicKey
 	crt, err := pemutil.ReadStepCertificate(crtPath)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-
 	keyBytes, err := ioutil.ReadFile(keyPath)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	pemOpts = append(pemOpts, pemutil.WithFilename(keyPath),
-		pemutil.WithStepCrypto())
+	pemOpts = append(pemOpts, pemutil.WithFilename(keyPath))
 	key, err := pemutil.Parse(keyBytes, pemOpts...)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	return NewIdentity(crt, key), nil
+	return NewIdentity(ToX509Certificate(crt), key), nil
 }

--- a/crypto/x509util/intermediateProfile.go
+++ b/crypto/x509util/intermediateProfile.go
@@ -2,10 +2,9 @@ package x509util
 
 import (
 	"crypto"
+	"crypto/x509"
 	"crypto/x509/pkix"
 	"time"
-
-	"github.com/smallstep/cli/pkg/x509"
 )
 
 // DefaultIntermediateCertValidity is the default validity of a intermediate certificate in the step PKI.

--- a/crypto/x509util/leafProfile.go
+++ b/crypto/x509util/leafProfile.go
@@ -2,11 +2,11 @@ package x509util
 
 import (
 	"crypto"
+	"crypto/x509"
 	"crypto/x509/pkix"
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/smallstep/cli/pkg/x509"
 )
 
 // Leaf implements the Profile for a leaf certificate.

--- a/crypto/x509util/rootProfile.go
+++ b/crypto/x509util/rootProfile.go
@@ -1,11 +1,11 @@
 package x509util
 
 import (
+	"crypto/x509"
 	"crypto/x509/pkix"
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/smallstep/cli/pkg/x509"
 )
 
 // DefaultRootCertValidity is the default validity of a root certificate in the step PKI.

--- a/utils/cli.go
+++ b/utils/cli.go
@@ -57,8 +57,8 @@ func GetKeyDetailsFromCLI(ctx *cli.Context, insecure bool, ktyKey, curveKey, siz
 			case "": // ok: OKP defaults to Ed25519
 				crv = "Ed25519"
 			default:
-				return kty, crv, size, errs.IncompatibleFlagValueWithFlagValue(ctx, curveKey,
-					crv, ktyKey, kty, "Ed25519")
+				return kty, crv, size, errs.IncompatibleFlagValueWithFlagValue(ctx, ktyKey, kty,
+					curveKey, crv, "Ed25519")
 			}
 		default:
 			return kty, crv, size, errs.InvalidFlagValue(ctx, ktyKey, kty, "RSA, EC, OKP")


### PR DESCRIPTION
### Description
This PR tries to remove the use of the internal `cli/pkg/x509` as much as possible without affecting to the current functionality.

Fixes #95