### PR TITLE
Use default token duration in step ca certificate / sign

### DIFF
--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -299,7 +299,7 @@ func (f *certificateFlow) GenerateToken(ctx *cli.Context, subject string, sans [
 	return newTokenFlow(ctx, subject, sans, caURL, root, "", "", "", "", time.Time{}, time.Time{})
 }
 
-// Sign signs the token using the online or the offline certificate authority.
+// Sign signs the CSR using the online or the offline certificate authority.
 func (f *certificateFlow) Sign(ctx *cli.Context, token string, csr api.CertificateRequest, crtFile string) error {
 	client, err := f.getClient(ctx, csr.Subject.CommonName, token)
 	if err != nil {

--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -267,8 +267,9 @@ func (f *certificateFlow) getClient(ctx *cli.Context, subject, token string) (ca
 	return ca.NewClient(caURL, options...)
 }
 
-// GenerateToken generates the token using the token flow or the online mode.
-// Both flows use the default validity as the token will be used immediately.
+// GenerateToken generates a token for immediate use (therefore only default
+// validity values will be used). The token is generated either with the offline
+// token flow or the online mode.
 func (f *certificateFlow) GenerateToken(ctx *cli.Context, subject string, sans []string) (string, error) {
 	if f.offline {
 		return f.offlineCA.GenerateToken(ctx, subject, sans, time.Time{}, time.Time{})

--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/smallstep/certificates/api"
@@ -266,10 +267,11 @@ func (f *certificateFlow) getClient(ctx *cli.Context, subject, token string) (ca
 	return ca.NewClient(caURL, options...)
 }
 
+// GenerateToken generates the token using the token flow or the online mode.
+// Both flows use the default validity as the token will be used immediately.
 func (f *certificateFlow) GenerateToken(ctx *cli.Context, subject string, sans []string) (string, error) {
-	// For offline just generate the token
 	if f.offline {
-		return f.offlineCA.GenerateToken(ctx, subject, sans)
+		return f.offlineCA.GenerateToken(ctx, subject, sans, time.Time{}, time.Time{})
 	}
 
 	// Use online CA to get the provisioners and generate the token
@@ -286,16 +288,6 @@ func (f *certificateFlow) GenerateToken(ctx *cli.Context, subject string, sans [
 		}
 	}
 
-	// parse times or durations
-	notBefore, ok := flags.ParseTimeOrDuration(ctx.String("not-before"))
-	if !ok {
-		return "", errs.InvalidFlagValue(ctx, "not-before", ctx.String("not-before"), "")
-	}
-	notAfter, ok := flags.ParseTimeOrDuration(ctx.String("not-after"))
-	if !ok {
-		return "", errs.InvalidFlagValue(ctx, "not-after", ctx.String("not-after"), "")
-	}
-
 	var err error
 	if subject == "" {
 		subject, err = ui.Prompt("What DNS names or IP addresses would you like to use? (e.g. internal.smallstep.com)", ui.WithValidateNotEmpty())
@@ -304,9 +296,10 @@ func (f *certificateFlow) GenerateToken(ctx *cli.Context, subject string, sans [
 		}
 	}
 
-	return newTokenFlow(ctx, subject, sans, caURL, root, "", "", "", "", notBefore, notAfter)
+	return newTokenFlow(ctx, subject, sans, caURL, root, "", "", "", "", time.Time{}, time.Time{})
 }
 
+// Sign signs the token using the online or the offline certificate authority.
 func (f *certificateFlow) Sign(ctx *cli.Context, token string, csr api.CertificateRequest, crtFile string) error {
 	client, err := f.getClient(ctx, csr.Subject.CommonName, token)
 	if err != nil {

--- a/command/ca/offline.go
+++ b/command/ca/offline.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/smallstep/certificates/api"
@@ -37,7 +38,7 @@ type offlineCA struct {
 	configFile string
 }
 
-// newOfflineCA initializes an offliceCA.
+// newOfflineCA initializes an offlineCA.
 func newOfflineCA(configFile string) (*offlineCA, error) {
 	b, err := utils.ReadFile(configFile)
 	if err != nil {
@@ -131,17 +132,13 @@ func (c *offlineCA) Renew(rt http.RoundTripper) (*api.SignResponse, error) {
 }
 
 // GenerateToken creates the token used by the authority to sign certificates.
-func (c *offlineCA) GenerateToken(ctx *cli.Context, subject string, sans []string) (string, error) {
+func (c *offlineCA) GenerateToken(ctx *cli.Context, subject string, sans []string, notBefore, notAfter time.Time) (string, error) {
 	// Use ca.json configuration for the root and audience
 	root := c.Root()
 	audience := c.Audience()
 
 	// Get common parameters
 	passwordFile := ctx.String("password-file")
-	notBefore, notAfter, err := parseValidity(ctx)
-	if err != nil {
-		return "", err
-	}
 
 	// Get provisioner to use
 	var kid, issuer, encryptedKey string

--- a/command/ca/token.go
+++ b/command/ca/token.go
@@ -421,24 +421,24 @@ func offlineTokenFlow(ctx *cli.Context, subject string, sans []string) (string, 
 		return "", errs.InvalidFlagValue(ctx, "ca-config", "", "")
 	}
 
+	notBefore, notAfter, err := parseValidity(ctx)
+	if err != nil {
+		return "", err
+	}
+
 	// Using the offline CA
 	if utils.FileExists(caConfig) {
 		offlineCA, err := newOfflineCA(caConfig)
 		if err != nil {
 			return "", err
 		}
-		return offlineCA.GenerateToken(ctx, subject, sans)
+		return offlineCA.GenerateToken(ctx, subject, sans, notBefore, notAfter)
 	}
 
 	kid := ctx.String("kid")
 	issuer := ctx.String("issuer")
 	keyFile := ctx.String("key")
 	passwordFile := ctx.String("password-file")
-
-	notBefore, notAfter, err := parseValidity(ctx)
-	if err != nil {
-		return "", err
-	}
 
 	// Require issuer and keyFile if ca.json does not exists.
 	// kid can be passed or created using jwk.Thumbprint.


### PR DESCRIPTION
### Description
This PR forces the use of default token validity when `step ca certificate` and `step ca sign` are used without the `--token` flag. The token validity is irrelevant as the token is used immediately.

Fixes #97 
