### PR TITLE
Use TimeDuration for step ca certificate and sign

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -323,8 +323,8 @@
   revision = "de77670473b5492f5d0bce155b5c01534c2d13f7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:ddc780ea695358bba68986ae9e7ba342512de810d4099cc57f9f11e59c58aeea"
+  branch = "time-duration"
+  digest = "1:fde62d07f48defb58684b70dbc61b34694426c684cad33385888535592d6a0cc"
   name = "github.com/smallstep/certificates"
   packages = [
     "api",
@@ -336,7 +336,7 @@
     "server",
   ]
   pruneopts = "UT"
-  revision = "095ab891e736ea7eb1c77436fd6083a79d786151"
+  revision = "64f261586490180e2d3b87152c6279a9b761165e"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -323,8 +323,8 @@
   revision = "de77670473b5492f5d0bce155b5c01534c2d13f7"
 
 [[projects]]
-  branch = "time-duration"
-  digest = "1:fde62d07f48defb58684b70dbc61b34694426c684cad33385888535592d6a0cc"
+  branch = "master"
+  digest = "1:769f3b11e4b4306146e61e6f4772985e50acd1a975de964b99a5fde9bb04f10f"
   name = "github.com/smallstep/certificates"
   packages = [
     "api",
@@ -336,7 +336,7 @@
     "server",
   ]
   pruneopts = "UT"
-  revision = "64f261586490180e2d3b87152c6279a9b761165e"
+  revision = "5b8b9ff7686d538f2cee7671eb3c0b892e4445e7"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,7 +64,7 @@ required = [
   unused-packages = true
 
 [[constraint]]
-  branch = "time-duration"
+  branch = "master"
   name = "github.com/smallstep/certificates"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,7 +64,7 @@ required = [
   unused-packages = true
 
 [[constraint]]
-  branch = "master"
+  branch = "time-duration"
   name = "github.com/smallstep/certificates"
 
 [[constraint]]

--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -308,7 +308,7 @@ func (f *certificateFlow) Sign(ctx *cli.Context, token string, csr api.Certifica
 	}
 
 	// parse times or durations
-	notBefore, notAfter, err := parseValidity(ctx)
+	notBefore, notAfter, err := parseTimeDuration(ctx)
 	if err != nil {
 		return err
 	}
@@ -401,4 +401,18 @@ func splitSANs(args ...[]string) (dnsNames []string, ipAddresses []net.IP) {
 		}
 	}
 	return x509util.SplitSANs(unique)
+}
+
+// parseTimeDuration parses the not-before and not-after flags as a timeDuration
+func parseTimeDuration(ctx *cli.Context) (notBefore api.TimeDuration, notAfter api.TimeDuration, err error) {
+	var zero api.TimeDuration
+	notBefore, err = api.ParseTimeDuration(ctx.String("not-before"))
+	if err != nil {
+		return zero, zero, errs.InvalidFlagValue(ctx, "not-before", ctx.String("not-before"), "")
+	}
+	notAfter, err = api.ParseTimeDuration(ctx.String("not-after"))
+	if err != nil {
+		return zero, zero, errs.InvalidFlagValue(ctx, "not-after", ctx.String("not-after"), "")
+	}
+	return
 }


### PR DESCRIPTION
### Description
This PR adapts the CLI to work with the certificates TimeDuration type. Now the `/sign` endpoint accepts durations and RFC3339 timestamps.

Fixes #60
Depends on smallstep/certificates#56