### PR TITLE
Add :latest tag to docker on the release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,13 @@ artifacts-tag: artifacts-linux-tag artifacts-darwin-tag
 # For all builds that are not tagged
 artifacts-master:
 
+# For all builds with a release candidate tag
+artifacts-release-candidate: artifacts-tag
+
 # For all builds with a release tag
 artifacts-release: artifacts-tag
 
 # This command is called by travis directly *after* a successful build
 artifacts: artifacts-$(PUSHTYPE) docker-$(PUSHTYPE)
 
-.PHONY: artifacts-master artifacts-release artifacts
+.PHONY: artifacts-master artifacts-release-candidate artifacts-release artifacts

--- a/make/common.mk
+++ b/make/common.mk
@@ -48,10 +48,15 @@ $(foreach pkg,$(BOOTSTRAP),$(eval $(call VENDOR_BIN_TMPL,$(pkg))))
 # Version flags to embed in the binaries
 VERSION ?= $(shell [ -d .git ] && git describe --tags --always --dirty="-dev")
 VERSION := $(shell echo $(VERSION) | sed 's/^v//')
+NOT_RC  := $(shell echo $(VERSION) | grep -v -e -rc)
 
 # If TRAVIS_TAG is set then we know this ref has been tagged.
 ifdef TRAVIS_TAG
-	PUSHTYPE=release
+	ifeq ($(NOT_RC),)
+		PUSHTYPE=release-candidate
+	else
+		PUSHTYPE=release
+	endif
 else
 	PUSHTYPE=master
 endif

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -43,21 +43,27 @@ docker-tag:
 docker-push-tag: docker-tag
 	$(call DOCKER_PUSH,step-cli,$(VERSION))
 
+docker-push-tag-latest:
+	$(call DOCKER_PUSH,step-cli,latest)
+
 # Rely on DOCKER_USERNAME and DOCKER_PASSWORD being set inside the CI or
 # equivalent environment
 docker-login:
 	$Q docker login -u="$(DOCKER_USERNAME)" -p="$(DOCKER_PASSWORD)"
 
-.PHONY: docker-tag docker-push-tag docker-login
+.PHONY: docker-tag docker-push-tag docker-push-tag-latest docker-login
 
 #################################################
 # Targets for different type of builds
 #################################################
 
-# For all builds on the master branch we build the container but do not push.
+# For all builds we build the docker container
 docker-master: docker
 
-# For all builds of a tagged release we build and push the container.
-docker-release: docker-master docker-login docker-push-tag
+# For all builds with a release candidate tag
+docker-release-candidate: docker-master docker-login docker-push-tag
 
-.PHONY: docker-master docker-release
+# For all builds of a release tag
+docker-release: docker-release-candidate docker-push-tag-latest
+
+.PHONY: docker-master docker-release-candidate docker-release


### PR DESCRIPTION
### Description
This PR adds the `:latest` tag to all release builds, but not the release candidates.