### PR TITLE
Update go-jose to 2.3.0.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -323,8 +323,8 @@
   revision = "de77670473b5492f5d0bce155b5c01534c2d13f7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:b66ff4abd77f39e94020219427c0c62bc1474d41edb2b445d2058adede69475f"
+  branch = "update-go-jose"
+  digest = "1:9efbb46c88d769c4ef0004369c4fa445d9b7a4ce019bf0648ec813781af94ff1"
   name = "github.com/smallstep/certificates"
   packages = [
     "api",
@@ -336,7 +336,7 @@
     "server",
   ]
   pruneopts = "UT"
-  revision = "1bb25b517115cebfb8ce9e5ecb48fc7bbea055ec"
+  revision = "1812c0619a53db9994cb9dc1cccb18a49fdf52ab"
 
 [[projects]]
   branch = "master"
@@ -513,7 +513,7 @@
   revision = "63abe20a23e29e80bbef8089bd3dee3ac25e5306"
 
 [[projects]]
-  digest = "1:7fbe10f3790dc4e6296c7c844c5a9b35513e5521c29c47e10ba99cd2956a2719"
+  digest = "1:005cbf8b937fcb1694b9dbb845b0aef618627be7faf7bb330eb2490e3f506ef8"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
@@ -522,8 +522,8 @@
     "jwt",
   ]
   pruneopts = "UT"
-  revision = "ef984e69dd356202fd4e4910d4d9c24468bdf0b8"
-  version = "v2.1.9"
+  revision = "628223f44a71f715d2881ea69afc795a1e9c01be"
+  version = "v2.3.0"
 
 [[projects]]
   digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -336,7 +336,7 @@
     "server",
   ]
   pruneopts = "UT"
-  revision = "1812c0619a53db9994cb9dc1cccb18a49fdf52ab"
+  revision = "b171e57c860391eb80352409aac90c1d1e93f83e"
 
 [[projects]]
   branch = "master"
@@ -513,7 +513,8 @@
   revision = "63abe20a23e29e80bbef8089bd3dee3ac25e5306"
 
 [[projects]]
-  digest = "1:005cbf8b937fcb1694b9dbb845b0aef618627be7faf7bb330eb2490e3f506ef8"
+  branch = "v2"
+  digest = "1:9593bab40e981b1f90b7e07faeab0d09b75fe338880d08880f986a9d3283c53f"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
@@ -522,8 +523,8 @@
     "jwt",
   ]
   pruneopts = "UT"
-  revision = "628223f44a71f715d2881ea69afc795a1e9c01be"
-  version = "v2.3.0"
+  revision = "fd0b35a2f1ec103c6bb76cc6d4b8077fa5844fb2"
+  source = "github.com/maraino/go-jose"
 
 [[projects]]
   digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,7 +64,7 @@ required = [
   unused-packages = true
 
 [[constraint]]
-  branch = "master"
+  branch = "update-go-jose"
   name = "github.com/smallstep/certificates"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -49,7 +49,10 @@ required = [
 
 [[constraint]]
   name = "gopkg.in/square/go-jose.v2"
-  version = "2.1.9"
+  # version = "2.3.0"
+  # Using special branch with ed25519 fix
+  source = "github.com/maraino/go-jose"
+  branch = "v2"
 
 [[constraint]]
   branch = "master"

--- a/command/crypto/jwt/sign.go
+++ b/command/crypto/jwt/sign.go
@@ -290,7 +290,7 @@ func signAction(ctx *cli.Context) error {
 	}
 
 	// Validate exp
-	if !isSubtle && ctx.IsSet("exp") && jose.NumericDate(ctx.Int64("exp")).Time().Before(time.Now()) {
+	if !isSubtle && ctx.IsSet("exp") && jose.UnixNumericDate(ctx.Int64("exp")).Time().Before(time.Now()) {
 		return errors.New("flag '--exp' must be in the future unless the '--subtle' flag is provided")
 	}
 
@@ -299,16 +299,16 @@ func signAction(ctx *cli.Context) error {
 		Issuer:    ctx.String("iss"),
 		Subject:   ctx.String("sub"),
 		Audience:  ctx.StringSlice("aud"),
-		Expiry:    jose.NumericDate(ctx.Int64("exp")),
-		NotBefore: jose.NumericDate(ctx.Int64("nbf")),
-		IssuedAt:  jose.NumericDate(ctx.Int64("iat")),
+		Expiry:    jose.UnixNumericDate(ctx.Int64("exp")),
+		NotBefore: jose.UnixNumericDate(ctx.Int64("nbf")),
+		IssuedAt:  jose.UnixNumericDate(ctx.Int64("iat")),
 		ID:        ctx.String("jti"),
 	}
 	now := time.Now()
-	if c.NotBefore == 0 {
+	if c.NotBefore == nil {
 		c.NotBefore = jose.NewNumericDate(now)
 	}
-	if c.IssuedAt == 0 {
+	if c.IssuedAt == nil {
 		c.IssuedAt = jose.NewNumericDate(now)
 	}
 	if c.ID == "" && ctx.IsSet("jti") {
@@ -326,7 +326,7 @@ func signAction(ctx *cli.Context) error {
 			return errors.New("flag '--aud' is required unless '--subtle' is used")
 		case len(c.Subject) == 0:
 			return errors.New("flag '--sub' is required unless '--subtle' is used")
-		case c.Expiry == 0:
+		case c.Expiry == nil:
 			return errors.New("flag '--exp' is required unless '--subtle' is used")
 		case c.Expiry.Time().Before(time.Now()):
 			return errors.New("flag '--exp' must be in the future unless '--subtle' is used")

--- a/jose/types.go
+++ b/jose/types.go
@@ -210,8 +210,18 @@ func NewEncrypter(enc ContentEncryption, rcpt Recipient, opts *EncrypterOptions)
 }
 
 // NewNumericDate constructs NumericDate from time.Time value.
-func NewNumericDate(t time.Time) NumericDate {
+func NewNumericDate(t time.Time) *NumericDate {
 	return jwt.NewNumericDate(t)
+}
+
+// UnixNumericDate returns a NumericDate from the given seconds since the UNIX
+// Epoch time. For backward compatibility is s is 0, a nil value will be returned.
+func UnixNumericDate(s int64) *NumericDate {
+	if s == 0 {
+		return nil
+	}
+	out := NumericDate(s)
+	return &out
 }
 
 // NewSigner creates an appropriate signer based on the key type


### PR DESCRIPTION
### Description
This PR adapts certificates code to go-jose@2.3.0, claims `iat`, `nbf`, and `exp` are now pointers instead of values. This PR won't be merged until square/go-jose#224 gets merged.

With square/go-jose#224 merged, Ed25519 JWK keys will be properly marshaled. Instead of waiting for the merge, we are using our fork.

Fixes #105
