### PR TITLE
Help formatting and generalizing of version

### DIFF
--- a/cmd/step/main.go
+++ b/cmd/step/main.go
@@ -38,7 +38,7 @@ var Version = "N/A"
 var BuildTime = "N/A"
 
 func init() {
-	config.Set(Version, BuildTime)
+	config.Set("Smallstep CLI", Version, BuildTime)
 	rand.Seed(time.Now().UnixNano())
 }
 

--- a/command/ca/revoke.go
+++ b/command/ca/revoke.go
@@ -58,7 +58,7 @@ $ step ca revoke
 '''
 
 Revoke a certificate using a transparently generated API token and the default
-'uspecified' reason:
+'unspecified' reason:
 '''
 $ step ca revoke 308893286343609293989051180431574390766
 '''
@@ -86,6 +86,7 @@ the request with the CA:
 '''
 $ TOKEN=$(step ca token --revoke 308893286343609293989051180431574390766)
 $ step ca revoke --token $TOKEN 308893286343609293989051180431574390766
+'''
 
 Revoke a certificate in offline mode:
 '''
@@ -97,8 +98,7 @@ will be validated against the root and intermediate certifcates configured in
 the step CA):
 '''
 $ step ca revoke --offline --cert foo.crt --key foo.key
-'''
-`,
+'''`,
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "reasonCode",
@@ -111,45 +111,45 @@ If unset, default is Unspecified.
 one of the following options:
 
     **Unspecified**
-	:  No reason given (Default).
+    :  No reason given (Default).
 
     **KeyCompromise**
-	:  The key is believed to have been compromised.
+    :  The key is believed to have been compromised.
 
     **CACompromise**
-	:  The issuing Certificate Authority itself has been compromised.
+    :  The issuing Certificate Authority itself has been compromised.
 
     **AffiliationChanged**
-	:  The certificate contained affiliation information, for example, it may
+    :  The certificate contained affiliation information, for example, it may
 have been an EV certificate and the associated business is no longer owned by
 the same entity.
 
     **Superseded**
-	:  The certificate is being replaced.
+    :  The certificate is being replaced.
 
     **CessationOfOperation**
-	:  If a CA is decommissioned, no longer to be used, the CA's certificate
+    :  If a CA is decommissioned, no longer to be used, the CA's certificate
 should be revoked with this reason code. Do not revoke the CA's certificate if
 the CA no longer issues new certificates, yet still publishes CRLs for the
 currently issued certificates.
 
     **CertificateHold**
-	:  A temporary revocation that indicates that a CA will not vouch for a
+    :  A temporary revocation that indicates that a CA will not vouch for a
 certificate at a specific point in time. Once a certificate is revoked with a
 CertificateHold reason code, the certificate can then be revoked with another
 Reason Code, or unrevoked and returned to use.
 
     **RemoveFromCRL**
-	:  If a certificate is revoked with the CertificateHold reason code, it is
+    :  If a certificate is revoked with the CertificateHold reason code, it is
 possible to "unrevoke" a certificate. The unrevoking process still lists the
 certificate in the CRL, but with the reason code set to RemoveFromCRL.
 Note: This is specific to the CertificateHold reason and is only used in DeltaCRLs.
 
     **PrivilegeWithdrawn**
-	:  The right to represent the given entity was revoked for some reason.
+    :  The right to represent the given entity was revoked for some reason.
 
     **AACompromise**
-	:   It is known or suspected that aspects of the AA validated in the
+    :   It is known or suspected that aspects of the AA validated in the
 attribute certificate have been compromised.
 `,
 			},

--- a/command/crypto/jwk/create.go
+++ b/command/crypto/jwk/create.go
@@ -232,7 +232,7 @@ depends on the key use, key type, and curve (for EC and OKP keys). Defaults are:
     :  HMAC using SHA-384
 
     **HS512**
-	  :  HMAC using SHA-512
+    :  HMAC using SHA-512
 
     **RS256**
     :  RSASSA-PKCS1-v1_5 using SHA-256

--- a/command/crypto/jwk/create.go
+++ b/command/crypto/jwk/create.go
@@ -232,7 +232,7 @@ depends on the key use, key type, and curve (for EC and OKP keys). Defaults are:
     :  HMAC using SHA-384
 
     **HS512**
-	:  HMAC using SHA-512
+	  :  HMAC using SHA-512
 
     **RS256**
     :  RSASSA-PKCS1-v1_5 using SHA-256

--- a/command/crypto/jws/sign.go
+++ b/command/crypto/jws/sign.go
@@ -289,7 +289,7 @@ func readPayload(filename string) ([]byte, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "error reading data")
 		}
-		if st.Size() == 0 {
+		if st.Size() == 0 && st.Mode()&os.ModeNamedPipe == 0 {
 			return []byte{}, nil
 		}
 		return utils.ReadAll(os.Stdin)

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 
 // version and buildTime are filled in during build by the Makefile
 var (
+	name      = "Smallstep CLI"
 	buildTime = "N/A"
 	commit    = "N/A"
 )
@@ -62,7 +63,8 @@ func init() {
 }
 
 // Set updates the Version and ReleaseDate
-func Set(v, t string) {
+func Set(n, v, t string) {
+	name = n
 	buildTime = t
 	commit = v
 }
@@ -74,8 +76,8 @@ func Version() string {
 		out = "0000000-dev"
 	}
 
-	return fmt.Sprintf("Smallstep CLI/%s (%s/%s)",
-		out, runtime.GOOS, runtime.GOARCH)
+	return fmt.Sprintf("%s/%s (%s/%s)",
+		name, out, runtime.GOOS, runtime.GOARCH)
 }
 
 // ReleaseDate returns the time of when the binary was built

--- a/usage/renderer.go
+++ b/usage/renderer.go
@@ -229,14 +229,13 @@ func (r *Renderer) RenderNode(w io.Writer, node *md.Node, entering bool) md.Walk
 				w.Init(r.out.w, 0, 8, 4, ' ', tabwriter.StripEscape)
 				for _, item := range r.list.items {
 					fmt.Fprintf(w, strings.TrimRight(string(item.term), " \n"))
-					fmt.Fprintf(w, "\t")
+					fmt.Fprintf(w, "\n")
 					for _, def := range item.definitions {
-						fmt.Fprintf(w, strings.Trim(string(def), " \n"))
+						fmt.Fprintf(w, strings.TrimRight(string(def), " \n"))
 					}
-					fmt.Fprintf(w, "\t\n")
+					fmt.Fprintf(w, "\n\n")
 				}
 				w.Flush()
-				r.printf("\n")
 			} else {
 				ordered := (node.ListFlags&md.ListTypeOrdered != 0)
 				unordered := (node.ListFlags&md.ListTypeOrdered == 0 && node.ListFlags&md.ListTypeDefinition == 0)


### PR DESCRIPTION
### Description
This PR allows the re-use the config and version command in multiple tools. It also includes a change in the terminal help renderer that helps with the formatting of list long definitions better, using a renderer more similar to the HTML. Long definitions were not rendered properly and it was hard to fix, now long definitions are looking good:

```
Superseded
  The certificate is being replaced.

CessationOfOperation
  If a CA is decommissioned, no longer to be used, the CA's certificate
  should be revoked with this reason code. Do not revoke the CA's certificate if
  the CA no longer issues new certificates, yet still publishes CRLs for the
  currently issued certificates.
```

But short definitions are now more verbose, what it used to be:
```
HS256       HMAC using SHA-256
HS384       HMAC using SHA-384
HS512       HMAC using SHA-512
```

Now is
```
HS256
    HMAC using SHA-256

HS384
    HMAC using SHA-384

HS512
    HMAC using SHA-512

```

This PR adds also a fix for #109 