### PR TITLE
Allow custom common names in cloud identity provisioners.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -418,7 +418,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5e778214d472b6d2ad4d544d293d1478d9b222db8ffc6079623fbe3e58e1841e"
+  digest = "1:9c1b7052fa8f2c918efd60ed5ae3c70ccbba08967c58ec71067535449a3ba220"
   name = "github.com/smallstep/nosql"
   packages = [
     ".",
@@ -428,7 +428,7 @@
     "mysql",
   ]
   pruneopts = "UT"
-  revision = "b66b34823456721912ba037126e92414690c07d6"
+  revision = "a0934e12468769d8cbede3ed316c47a4b88de4ca"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -410,11 +410,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c1f5d81fb178224e211c8ea8d589b266f51bb97c48031a47ef6000365674e399"
+  digest = "1:c3207093bfee46dc9f408a55408d6fa6ed59431bdeb54df2ab89ffa1d8e1bfaf"
   name = "github.com/smallstep/certinfo"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3e50cbc672cf9db49bd5c4bccf110a3981d7ddc5"
+  revision = "fef09aeb6b3b6451151ae248670cf020454c0d5b"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -392,8 +392,8 @@
   revision = "de77670473b5492f5d0bce155b5c01534c2d13f7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:5bdb12667536b63c2b391ed01a9f405f435f4af3eee4abec06fff002a1030d35"
+  branch = "iid-common-name"
+  digest = "1:12f34131d2a21014b4c0d1d3c8b99aecdc83c8e3f216a85cdad00a8e5a231586"
   name = "github.com/smallstep/certificates"
   packages = [
     "api",
@@ -406,7 +406,7 @@
     "server",
   ]
   pruneopts = "UT"
-  revision = "578beec25d34d5cf29a3d940de0cd7d0dab51b05"
+  revision = "3e69194cc45c650b8105e78f533789f121d6957b"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -392,7 +392,7 @@
   revision = "de77670473b5492f5d0bce155b5c01534c2d13f7"
 
 [[projects]]
-  branch = "iid-common-name"
+  branch = "master"
   digest = "1:12f34131d2a21014b4c0d1d3c8b99aecdc83c8e3f216a85cdad00a8e5a231586"
   name = "github.com/smallstep/certificates"
   packages = [
@@ -406,7 +406,7 @@
     "server",
   ]
   pruneopts = "UT"
-  revision = "3e69194cc45c650b8105e78f533789f121d6957b"
+  revision = "5356bce4d84ecbf8e3b4ff08eb3e5045b2fcec2d"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,7 +64,7 @@ required = [
   unused-packages = true
 
 [[constraint]]
-  branch = "master"
+  branch = "iid-common-name"
   name = "github.com/smallstep/certificates"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,7 +64,7 @@ required = [
   unused-packages = true
 
 [[constraint]]
-  branch = "iid-common-name"
+  branch = "master"
   name = "github.com/smallstep/certificates"
 
 [[constraint]]

--- a/command/ca/offline.go
+++ b/command/ca/offline.go
@@ -239,22 +239,11 @@ func (c *offlineCA) GenerateToken(ctx *cli.Context, typ int, subject string, san
 		}
 		return strings.TrimSpace(string(out)), nil
 	case *provisioner.GCP: // Do the identity request to get the token
-		return p.GetIdentityToken(c.CaURL())
+		return p.GetIdentityToken(subject, c.CaURL())
 	case *provisioner.AWS: // Do the identity request to get the token
-		return p.GetIdentityToken(c.CaURL())
+		return p.GetIdentityToken(subject, c.CaURL())
 	case *provisioner.Azure: // Do the identity request to get the token
-		return p.GetIdentityToken()
-	}
-
-	// With OIDC just run step oauth
-	if p, ok := p.(*provisioner.OIDC); ok {
-		out, err := exec.Step("oauth", "--oidc", "--bare",
-			"--provider", p.ConfigurationEndpoint,
-			"--client-id", p.ClientID, "--client-secret", p.ClientSecret)
-		if err != nil {
-			return "", err
-		}
-		return string(out), nil
+		return p.GetIdentityToken(subject, c.CaURL())
 	}
 
 	// JWK provisioner

--- a/command/ca/token.go
+++ b/command/ca/token.go
@@ -350,11 +350,11 @@ func newTokenFlow(ctx *cli.Context, typ int, subject string, sans []string, caUR
 		}
 		return strings.TrimSpace(string(out)), nil
 	case *provisioner.GCP: // Do the identity request to get the token
-		return p.GetIdentityToken(caURL)
+		return p.GetIdentityToken(subject, caURL)
 	case *provisioner.AWS: // Do the identity request to get the token
-		return p.GetIdentityToken(caURL)
+		return p.GetIdentityToken(subject, caURL)
 	case *provisioner.Azure: // Do the identity request to get the token
-		return p.GetIdentityToken()
+		return p.GetIdentityToken(subject, caURL)
 	}
 
 	// JWK provisioner


### PR DESCRIPTION
### Description
This PR allows using custom common names in cloud identity provisioners.
Related to https://github.com/smallstep/certificates/pull/84

It also includes a change in certinfo that adds support for extra fields in the x509 provisioner extension and some minor UI improvments. See https://github.com/smallstep/certinfo/commit/fef09aeb6b3b6451151ae248670cf020454c0d5b