### PR TITLE
ACME client support for standalone and webroot mode

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -310,10 +310,12 @@
   revision = "de77670473b5492f5d0bce155b5c01534c2d13f7"
 
 [[projects]]
-  branch = "master"
-  digest = "1:6122a459c2fc45bbab40570f11b23b999f2056f54ce9453c98f27b86ee0ee9e6"
+  branch = "acme"
+  digest = "1:9ff61904f80fc83f52cbb93cd4466ea404a0c724faf87df869b21c7e58aa087c"
   name = "github.com/smallstep/certificates"
   packages = [
+    "acme",
+    "acme/api",
     "api",
     "authority",
     "authority/provisioner",
@@ -324,15 +326,15 @@
     "server",
   ]
   pruneopts = "UT"
-  revision = "4c390dcfe1b688bfb76fd61c1a2df2cd3272af27"
+  revision = "1799cde43966f697e19c0437d300f7b69fa78940"
 
 [[projects]]
   branch = "master"
-  digest = "1:f4d37f61cbbd5adb7066017d7e5f303b722a39c3408b41d46a5ea04f81adba8c"
+  digest = "1:743362bd9879b63a73c060d74cfd90d46aab4913aea2b0714ceaacee64e6a9fa"
   name = "github.com/smallstep/certinfo"
   packages = ["."]
   pruneopts = "UT"
-  revision = "203093530c86c19d79cfe5ce9ad0b8897e3cce9b"
+  revision = "78e21b44234ef6ddeb58f5e8aad2ed09975b694a"
 
 [[projects]]
   branch = "master"
@@ -562,6 +564,8 @@
     "github.com/samfoo/ansi",
     "github.com/shurcooL/sanitized_anchor_name",
     "github.com/smallstep/assert",
+    "github.com/smallstep/certificates/acme",
+    "github.com/smallstep/certificates/acme/api",
     "github.com/smallstep/certificates/api",
     "github.com/smallstep/certificates/authority",
     "github.com/smallstep/certificates/authority/provisioner",

--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -20,8 +20,10 @@ func certificateCommand() cli.Command {
 		Action: command.ActionFunc(certificateAction),
 		Usage:  "generate a new private key and certificate signed by the root certificate",
 		UsageText: `**step ca certificate** <subject> <crt-file> <key-file>
-[**--token**=<token>] [**--issuer**=<name>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--not-before**=<time|duration>] [**--not-after**=<time|duration>] [**--san**=<SAN>]
+[**--token**=<token>]  [**--issuer**=<name>] [**--ca-url**=<uri>] [**--root**=<file>]
+[**--not-before**=<time|duration>] [**--not-after**=<time|duration>]
+[**--san**=<SAN>] [**--acme**=<path>] [**--standalone**] [**--webroot**=<path>]
+[**--contact**=<email>] [**--http-listen**=<address>] [**--bundle**]
 [**--kty**=<type>] [**--curve**=<curve>] [**--size**=<size>] [**--console**]`,
 		Description: `**step ca certificate** command generates a new certificate pair
 
@@ -82,8 +84,36 @@ $ step ca certificate joe@example.com joe.crt joe.key --issuer Google --console
 Request a new certificate with an RSA public key (default is ECDSA256):
 '''
 $ step ca certificate foo.internal foo.crt foo.key --kty RSA --size 4096
+'''
+
+**step CA ACME** - In order to use the step CA ACME protocol you must add a
+ACME provisioner to the step CA config. See **step ca provisioner add -h**.
+
+Request a new certificate using the step CA ACME server and a standalone server
+to serve the challenges locally (standalone mode is the default):
+'''
+$ step ca certificate foobar foo.crt foo.key --provisioner my-acme-provisioner --san foo.internal --san bar.internal
+'''
+
+Request a new certificate using the step CA ACME server and an existing server
+along with webroot mode to serve the challenges locally:
+'''
+$ step ca certificate foobar foo.crt foo.key --provisioner my-acme-provisioner --webroot "./acme-www" \
+--san foo.internal --san bar.internal
+'''
+
+Request a new certificate using the ACME protocol not served via the step CA
+(e.g. letsencrypt). NOTE: Let's Encrypt requires that the Subject Common Name
+of a requested certificate be validated as an Identifier in the ACME order along
+with any other SANS. Therefore, the Common Name must be a valid DNS Name. The
+step CA does not impose this requirement.
+'''
+$ step ca certificate foo.internal foo.crt foo.key \
+--acme https://acme-staging-v02.api.letsencrypt.org/directory --san bar.internal
 '''`,
 		Flags: []cli.Flag{
+			consoleFlag,
+			flags.CaConfig,
 			flags.CaURL,
 			flags.Curve,
 			flags.Force,
@@ -95,8 +125,6 @@ $ step ca certificate foo.internal foo.crt foo.key --kty RSA --size 4096
 			flags.Size,
 			flags.Token,
 			flags.Offline,
-			flags.CaConfig,
-			consoleFlag,
 			cli.StringSliceFlag{
 				Name: "san",
 				Usage: `Add DNS Name, IP Address, or Email Address Subjective Alternative Names (SANs)
@@ -105,6 +133,51 @@ this token must match the complete set of subjective alternative names in the
 token 1:1. Use the '--san' flag multiple times to configure multiple SANs. The
 '--san' flag and the '--token' flag are mutually exlusive.`,
 			},
+			cli.StringFlag{
+				Name: "acme",
+				Usage: `ACME directory URL to be used for requesting certificates via the ACME protocol.
+Use this flag to define an ACME server other than the Step CA. If this flag is
+absent and an ACME provisioner has been selected then the '--ca-url' flag must be defined.`,
+			},
+			cli.BoolFlag{
+				Name: "standalone",
+				Usage: `Get a certificate using the ACME protocol and standalone mode for validation.
+Standalone is a mode in which the step process will run a server that will
+will respond to ACME challenge validation requests. Standalone is the default
+mode for serving challenge validation requests.`,
+			},
+			cli.StringFlag{
+				Name: "webroot",
+				Usage: `Get a certificate using the ACME protocol and webroot mode for validation.
+Webroot is a mode in which the step process will write a challenge file to a location
+being served by an existing fileserver in order to respond to ACME challenge
+validation requests.`,
+			},
+			cli.StringSliceFlag{
+				Name: "contact",
+				Usage: `Email addresses for contact as part of the ACME protocol. These contacts
+may be used to warn of certificate expration or other certificate lifetime events.
+Use the '--contact' flag multiple times to configure multiple contacts.`,
+			},
+			cli.StringFlag{
+				Name: "http-listen",
+				Usage: `Use a non-standard http address, behind a reverse proxy or load balancer, for
+serving ACME challenges. The default address is :80, which requires super user
+(sudo) privileges. This flag must be used in conjunction with the '--standalone'
+flag.`,
+				Value: ":80",
+			},
+			/*
+							TODO: Not implemented yet.
+							cli.StringFlag{
+								Name: "https-listen",
+								Usage: `Use a non-standard https address, behind a reverse proxy or load balancer, for
+				serving ACME challenges. The default address is :443, which requires super user
+				(sudo) privileges. This flag must be used in conjunction with the '--standalone'
+				flag.`,
+								Value: ":443",
+							},
+			*/
 		},
 	}
 }
@@ -117,6 +190,7 @@ func certificateAction(ctx *cli.Context) error {
 	args := ctx.Args()
 	subject := args.Get(0)
 	crtFile, keyFile := args.Get(1), args.Get(2)
+
 	tok := ctx.String("token")
 	offline := ctx.Bool("offline")
 	sans := ctx.StringSlice("san")
@@ -134,8 +208,18 @@ func certificateAction(ctx *cli.Context) error {
 	}
 
 	if len(tok) == 0 {
+		// Use the ACME protocol with a different certificate authority.
+		if ctx.IsSet("acme") {
+			return cautils.ACMECreateCertFlow(ctx, "")
+		}
 		if tok, err = flow.GenerateToken(ctx, subject, sans); err != nil {
-			return err
+			switch k := err.(type) {
+			// Use the ACME flow with the step certificate authority.
+			case *cautils.ErrACMEToken:
+				return cautils.ACMECreateCertFlow(ctx, k.Name)
+			default:
+				return err
+			}
 		}
 	}
 

--- a/command/ca/provisioner/remove.go
+++ b/command/ca/provisioner/remove.go
@@ -52,7 +52,10 @@ and must be one of:
     : Use Google instance identity tokens.
 
     **Azure**
-    : Uses Microsoft Azure identity tokens.`,
+    : Uses Microsoft Azure identity tokens.
+
+    **ACME**
+    : Uses ACME protocol.`,
 			},
 		},
 		Description: `**step ca provisioner remove** removes one or more provisioners
@@ -82,6 +85,11 @@ $ step ca provisioner remove Google --ca-config ca.json \
 '''
 
 Remove the cloud identity provisioner given name and a type:
+'''
+$ step ca provisioner remove Amazon --ca-config ca.json --type AWS
+'''
+
+Remove the ACME provisioner by name:
 '''
 $ step ca provisioner remove Amazon --ca-config ca.json --type AWS
 '''`,
@@ -145,8 +153,8 @@ func removeAction(ctx *cli.Context) error {
 				if clientID != "" && pp.ClientID != clientID {
 					provisioners = append(provisioners, p)
 				}
-			case *provisioner.AWS, *provisioner.Azure, *provisioner.GCP:
-				// they are filtered by type
+			case *provisioner.AWS, *provisioner.Azure, *provisioner.GCP, *provisioner.ACME:
+				// they are filtered by type and name.
 			default:
 				continue
 			}

--- a/command/ca/token.go
+++ b/command/ca/token.go
@@ -125,11 +125,6 @@ $ step ca token --offline --revoke 146103349666685108195655980390445292315
 '''
 `,
 		Flags: []cli.Flag{
-			flags.CaURL,
-			flags.CaConfig,
-			flags.Force,
-			flags.Root,
-			flags.Provisioner,
 			certNotAfterFlag,
 			certNotBeforeFlag,
 			notBeforeFlag,
@@ -137,6 +132,11 @@ $ step ca token --offline --revoke 146103349666685108195655980390445292315
 			provisionerKidFlag,
 			sshPrincipalFlag,
 			sshHostFlag,
+			flags.CaURL,
+			flags.CaConfig,
+			flags.Force,
+			flags.Root,
+			flags.Provisioner,
 			cli.StringSliceFlag{
 				Name: "san",
 				Usage: `Add DNS or IP Address Subjective Alternative Names (SANs) that the token is

--- a/command/certificate/inspect.go
+++ b/command/certificate/inspect.go
@@ -22,8 +22,8 @@ func inspectCommand() cli.Command {
 		Name:   "inspect",
 		Action: cli.ActionFunc(inspectAction),
 		Usage:  `print certificate or CSR details in human readable format`,
-		UsageText: `**step certificate inspect** <crt_file> [**--bundle**]
-[**--format**=<format>] [**--roots**=<root-bundle>]`,
+		UsageText: `**step certificate inspect** <crt_file>
+[**--bundle**] [**--short**] [**--format**=<format>] [**--roots**=<root-bundle>]`,
 		Description: `**step certificate inspect** prints the details of a certificate
 or CSR in a human readable format. Output from the inspect command is printed to
 STDERR instead of STDOUT unless. This is an intentional barrier to accidental

--- a/command/certificate/sign.go
+++ b/command/certificate/sign.go
@@ -39,19 +39,16 @@ This command returns 0 on success and \>0 if any error occurs.
 ## EXAMPLES
 
 Sign a certificate signing request:
-
 '''
 $ step certificate sign ./certificate-signing-request.csr \
 ./issuer-certificate.crt ./issuer-private-key.priv
 '''
 
 Sign a certificate signing request and bundle the new certificate with the issuer:
-
 '''
 $ step certificate sign ./certificate-signing-request.csr \
 ./issuer-certificate.crt ./issuer-private-key.priv --bundle
-'''
-`,
+'''`,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
 				Name:  "bundle",

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -237,6 +237,16 @@ func RequiredOrFlag(ctx *cli.Context, flags ...string) error {
 	return errors.Errorf("one of flag %s is required", strings.Join(params, " or "))
 }
 
+// RequiredWithOrFlag returns an error with a list of flags at least one of which
+// is required in conjunction with the last flag in the list.
+func RequiredWithOrFlag(ctx *cli.Context, withFlag string, flags ...string) error {
+	params := make([]string, len(flags))
+	for i := 0; i < len(flags); i++ {
+		params[i] = "--" + flags[i]
+	}
+	return errors.Errorf("one of flag %s is required with flag --%s", strings.Join(params, " or "), withFlag)
+}
+
 // MinSizeFlag returns an error with a greater or equal message message for
 // the given flag and size.
 func MinSizeFlag(ctx *cli.Context, flag string, size string) error {

--- a/utils/cautils/acme_flow.go
+++ b/utils/cautils/acme_flow.go
@@ -1,0 +1,56 @@
+package cautils
+
+import (
+	"crypto/x509"
+
+	"github.com/pkg/errors"
+	"github.com/smallstep/cli/crypto/pemutil"
+	"github.com/smallstep/cli/ui"
+	"github.com/urfave/cli"
+)
+
+// ACMECreateCertFlow performs an ACME transaction to get a new certificate.
+func ACMECreateCertFlow(ctx *cli.Context, provisionerName string) error {
+	args := ctx.Args()
+	subject := args.Get(0)
+	certFile, keyFile := args.Get(1), args.Get(2)
+
+	af, err := newACMEFlow(ctx, withSubjectSANs(subject, ctx.StringSlice("san")),
+		withProvisionerName(provisionerName))
+	if err != nil {
+		return err
+	}
+	certs, err := af.GetCertificate()
+	if err != nil {
+		return err
+	}
+	if err = writeCert(certs, certFile); err != nil {
+		return err
+	}
+	ui.PrintSelected("Certificate", certFile)
+
+	_, err = pemutil.Serialize(af.priv, pemutil.ToFile(keyFile, 0600))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	ui.PrintSelected("Private Key", keyFile)
+	return nil
+}
+
+// ACMESignCSRFlow performs an ACME transaction using an existing CSR to get a
+// new certificate.
+func ACMESignCSRFlow(ctx *cli.Context, csr *x509.CertificateRequest, certFile, provisionerName string) error {
+	af, err := newACMEFlow(ctx, withCSR(csr), withProvisionerName(provisionerName))
+	if err != nil {
+		return err
+	}
+	certs, err := af.GetCertificate()
+	if err != nil {
+		return err
+	}
+	if err = writeCert(certs, certFile); err != nil {
+		return err
+	}
+	ui.PrintSelected("Certificate", certFile)
+	return nil
+}

--- a/utils/cautils/acmeutils.go
+++ b/utils/cautils/acmeutils.go
@@ -1,0 +1,499 @@
+package cautils
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/smallstep/certificates/acme"
+	acmeAPI "github.com/smallstep/certificates/acme/api"
+	"github.com/smallstep/certificates/ca"
+	"github.com/smallstep/cli/crypto/keys"
+	"github.com/smallstep/cli/crypto/pki"
+	"github.com/smallstep/cli/errs"
+	"github.com/smallstep/cli/jose"
+	"github.com/smallstep/cli/ui"
+	"github.com/smallstep/cli/utils"
+	"github.com/urfave/cli"
+)
+
+func startHTTPServer(addr string, token string, keyAuth string) *http.Server {
+	srv := &http.Server{Addr: addr}
+
+	http.HandleFunc(fmt.Sprintf("/.well-known/acme-challenge/%s", token), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write([]byte(keyAuth))
+	})
+
+	go func() {
+		// returns ErrServerClosed on graceful close
+		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+			// NOTE: there is a chance that next line won't have time to run,
+			// as main() doesn't wait for this goroutine to stop. don't use
+			// code with race conditions like these for production. see post
+			// comments below on more discussion on how to handle this.
+			ui.Printf("\nListenAndServe(): %s\n", err)
+		}
+	}()
+
+	// returning reference so caller can call Shutdown()
+	return srv
+}
+
+type issueMode interface {
+	Run() error
+	Cleanup() error
+}
+
+type standaloneMode struct {
+	identifier, token string
+	key               *jose.JSONWebKey
+	listenAddr        string
+	srv               *http.Server
+}
+
+func newStandaloneMode(identifier, listenAddr, token string, key *jose.JSONWebKey) *standaloneMode {
+	return &standaloneMode{
+		identifier: identifier,
+		listenAddr: listenAddr,
+		token:      token,
+		key:        key,
+	}
+}
+
+func (sm *standaloneMode) Run() error {
+	ui.Printf("Using Standalone Mode HTTP challenge to validate %s", sm.identifier)
+	keyAuth, err := acme.KeyAuthorization(sm.token, sm.key)
+	if err != nil {
+		return errors.Wrap(err, "error generating ACME key authorization")
+	}
+	sm.srv = startHTTPServer(sm.listenAddr, sm.token, keyAuth)
+	return nil
+}
+
+func (sm *standaloneMode) Cleanup() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	return errors.Wrap(sm.srv.Shutdown(ctx), "error gracefully shutting down server")
+}
+
+type webrootMode struct {
+	dir, token, identifier string
+	key                    *jose.JSONWebKey
+}
+
+func newWebrootMode(dir, token, identifier string, key *jose.JSONWebKey) *webrootMode {
+	return &webrootMode{
+		dir:        dir,
+		token:      token,
+		identifier: identifier,
+		key:        key,
+	}
+}
+
+func (wm *webrootMode) Run() error {
+	ui.Printf("Using Webroot Mode HTTP challenge to validate %s", wm.identifier)
+	keyAuth, err := acme.KeyAuthorization(wm.token, wm.key)
+	if err != nil {
+		return errors.Wrap(err, "error generating ACME key authorization")
+	}
+	_, err = os.Stat(wm.dir)
+	switch {
+	case os.IsNotExist(err):
+		return errors.Errorf("webroot directory %s does not exist", wm.dir)
+	case err != nil:
+		return errors.Wrapf(err, "error checking for directory %s", wm.dir)
+	}
+
+	// Use 0755 and 0644 (rather than 0700 and 0600) for directory and file
+	// respectively because the process running the file server, and therefore
+	// reading/serving the file, may be owned by a different user than
+	// the one running the `step` command that will write the file.
+	chPath := fmt.Sprintf("%s/.well-known/acme-challenge", wm.dir)
+	if _, err = os.Stat(chPath); os.IsNotExist(err) {
+		if err = os.MkdirAll(chPath, 0755); err != nil {
+			return errors.Wrapf(err, "error creating directory path %s", chPath)
+		}
+	}
+
+	return errors.Wrapf(ioutil.WriteFile(fmt.Sprintf("%s/%s", chPath, wm.token), []byte(keyAuth), 0644),
+		"error writing key authorization file %s", chPath+wm.token)
+}
+
+func (wm *webrootMode) Cleanup() error {
+	return errors.Wrap(os.Remove(fmt.Sprintf("%s/.well-known/acme-challenge/%s",
+		wm.dir, wm.token)), "error removing ACME challenge file")
+}
+
+func serveAndValidateHTTPChallenge(ctx *cli.Context, ac *ca.ACMEClient, ch *acme.Challenge, identifier string) error {
+	var mode issueMode
+	if ctx.Bool("standalone") {
+		mode = newStandaloneMode(identifier, ctx.String("http-listen"), ch.Token, ac.Key)
+	} else {
+		mode = newWebrootMode(ctx.String("webroot"), ch.Token, identifier, ac.Key)
+	}
+	if err := mode.Run(); err != nil {
+		ui.Printf(" Error!\n\n")
+		mode.Cleanup()
+		return err
+	}
+	ui.Printf(" .") // Indicates passage of time.
+
+	if err := ac.ValidateChallenge(ch.URL); err != nil {
+		ui.Printf(" Error!\n\n")
+		mode.Cleanup()
+		return errors.Wrapf(err, "error validating ACME Challenge at %s", ch.URL)
+	}
+	var (
+		isValid = false
+		vch     *acme.Challenge
+		err     error
+	)
+	for attempts := 0; attempts < 10; attempts++ {
+		time.Sleep(1 * time.Second)
+		ui.Printf(".")
+		vch, err = ac.GetChallenge(ch.URL)
+		if err != nil {
+			ui.Printf(" Error!\n\n")
+			mode.Cleanup()
+			return errors.Wrapf(err, "error retrieving ACME Challenge at %s", ch.URL)
+		}
+		if vch.Status == "valid" {
+			isValid = true
+			break
+		}
+	}
+	if !isValid {
+		ui.Printf(" Error!\n\n")
+		mode.Cleanup()
+		return errors.Errorf("Unable to validate challenge: %+v", vch)
+	}
+	if err := mode.Cleanup(); err != nil {
+		return err
+	}
+	ui.Printf(" done!\n")
+	return nil
+}
+
+func authorizeOrder(ctx *cli.Context, ac *ca.ACMEClient, o *acme.Order) error {
+	for _, azURL := range o.Authorizations {
+		az, err := ac.GetAuthz(azURL)
+		if err != nil {
+			return errors.Wrapf(err, "error retrieving ACME Authz at %s", azURL)
+		}
+
+		ident := az.Identifier.Value
+		if az.Wildcard {
+			ident = "*." + ident
+		}
+
+		chValidated := false
+		for _, ch := range az.Challenges {
+			// TODO: Allow other types of challenges (not just http).
+			if ch.Type == "http-01" {
+				if err := serveAndValidateHTTPChallenge(ctx, ac, ch, ident); err != nil {
+					return err
+				}
+				chValidated = true
+				break
+			}
+		}
+		if !chValidated {
+			return errors.Errorf("unable to validate any challenges for identifier: %s", ident)
+		}
+	}
+	return nil
+}
+
+func finalizeOrder(ac *ca.ACMEClient, o *acme.Order, csr *x509.CertificateRequest) (*acme.Order, error) {
+	var (
+		err              error
+		ro, fo           *acme.Order
+		isReady, isValid bool
+	)
+	ui.Printf("Waiting for Order to be 'ready' for finalization .")
+	for i := 9; i >= 0; i-- {
+		time.Sleep(1 * time.Second)
+		ui.Printf(".")
+		ro, err = ac.GetOrder(o.ID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error retrieving order %s", o.ID)
+		}
+		if ro.Status == "ready" {
+			isReady = true
+			ui.Printf(" done!\n")
+			break
+		}
+	}
+	if !isReady {
+		ui.Printf(" Error!\n\n")
+		return nil, errors.Errorf("Unable to validate order: %+v", ro)
+	}
+
+	ui.Printf("Finalizing Order .")
+	if err = ac.FinalizeOrder(o.Finalize, csr); err != nil {
+		return nil, errors.Wrapf(err, "error finalizing order")
+	}
+
+	for i := 9; i >= 0; i-- {
+		time.Sleep(1 * time.Second)
+		ui.Printf(".")
+		fo, err = ac.GetOrder(o.ID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error retrieving order %s", o.ID)
+		}
+		if fo.Status == "valid" {
+			isValid = true
+			ui.Printf(" done!\n")
+			break
+		}
+	}
+	if !isValid {
+		ui.Printf(" Error!\n\n")
+		return nil, errors.Errorf("Unable to finalize order: %+v", fo)
+	}
+
+	return fo, nil
+}
+
+func validateSANsForACME(sans []string) ([]string, error) {
+	dnsNames, ips, emails := splitSANs(sans)
+	if len(ips) > 0 || len(emails) > 0 {
+		return nil, errors.New("IP Address and Email Address SANs are not supported for ACME flow")
+	}
+	for _, dns := range dnsNames {
+		if strings.Contains(dns, "*") {
+			return nil, errors.Errorf("wildcard dnsnames (%s) require dns validation, "+
+				"which is currently not implemented in this client", dns)
+		}
+	}
+	return dnsNames, nil
+}
+
+type acmeFlowOp func(*acmeFlow) error
+
+func withProvisionerName(name string) acmeFlowOp {
+	return func(af *acmeFlow) error {
+		af.provisionerName = name
+		return nil
+	}
+}
+
+func withCSR(csr *x509.CertificateRequest) acmeFlowOp {
+	return func(af *acmeFlow) error {
+		af.csr = csr
+		af.subject = csr.Subject.CommonName
+		af.sans = csr.DNSNames
+		return nil
+	}
+}
+
+func withSubjectSANs(sub string, sans []string) acmeFlowOp {
+	return func(af *acmeFlow) error {
+		af.subject = sub
+		af.sans = sans
+		return nil
+	}
+}
+
+type acmeFlow struct {
+	ctx             *cli.Context
+	provisionerName string
+	csr             *x509.CertificateRequest
+	priv            interface{}
+	subject         string
+	sans            []string
+	acmeDir         string
+}
+
+func newACMEFlow(ctx *cli.Context, ops ...acmeFlowOp) (*acmeFlow, error) {
+	// Offline mode is not supported for ACME protocol
+	if ctx.Bool("offline") {
+		return nil, errors.New("offline mode and ACME are mutually exclusive")
+	}
+	// One of --standalone or --webroot must be selected for use with ACME protocol.
+	isStandalone, webroot := ctx.Bool("standalone"), ctx.String("webroot")
+	switch {
+	case isStandalone && len(webroot) > 0:
+		return nil, errs.MutuallyExclusiveFlags(ctx, "standalone", "webroot")
+	case !isStandalone && len(webroot) == 0:
+		if err := ctx.Set("standalone", "true"); err != nil {
+			return nil, errors.Wrap(err, "error setting 'standalone' value in cli ctx")
+		}
+	}
+
+	af := new(acmeFlow)
+	for _, op := range ops {
+		if err := op(af); err != nil {
+			return nil, err
+		}
+	}
+	if len(af.sans) == 0 {
+		af.sans = []string{af.subject}
+	}
+
+	af.ctx = ctx
+
+	af.acmeDir = ctx.String("acme")
+	if len(af.acmeDir) == 0 {
+		caURL := ctx.String("ca-url")
+		if len(caURL) == 0 {
+			return nil, errs.RequiredFlag(ctx, "ca-url")
+		}
+		if len(af.provisionerName) == 0 {
+			return nil, errors.New("acme flow expected provisioner ID")
+		}
+		af.acmeDir = fmt.Sprintf("%s/acme/%s/directory", caURL, af.provisionerName)
+	}
+
+	return af, nil
+}
+
+func (af *acmeFlow) GetCertificate() ([]*x509.Certificate, error) {
+	dnsNames, err := validateSANsForACME(af.sans)
+	if err != nil {
+		return nil, err
+	}
+
+	var idents []acme.Identifier
+	for _, dns := range dnsNames {
+		idents = append(idents, acme.Identifier{
+			Type:  "dns",
+			Value: dns,
+		})
+	}
+
+	var (
+		orderPayload []byte
+		clientOps    []ca.ClientOption
+	)
+	if strings.Contains(af.acmeDir, "letsencrypt") {
+		// LetsEncrypt does not support NotBefore and NotAfter attributes in orders.
+		if af.ctx.IsSet("not-before") || af.ctx.IsSet("not-after") {
+			return nil, errors.New("LetsEncrypt public CA does not support NotBefore/NotAfter " +
+				"attributes for certificates. Instead, each certificate has a default lifetime of 3 months.")
+		}
+		// Use default transport for public CAs
+		clientOps = append(clientOps, ca.WithTransport(http.DefaultTransport))
+		// LetsEncrypt requires that the Common Name of the Certificate also be
+		// represented as a DNSName in the SAN extension, and therefore must be
+		// authorized as part of the ACME order.
+		hasSubject := false
+		for _, n := range idents {
+			if n.Value == af.subject {
+				hasSubject = true
+			}
+		}
+		if !hasSubject {
+			dnsNames = append(dnsNames, af.subject)
+			idents = append(idents, acme.Identifier{
+				Type:  "dns",
+				Value: af.subject,
+			})
+		}
+		orderPayload, err = json.Marshal(struct {
+			Identifiers []acme.Identifier
+		}{Identifiers: idents})
+		if err != nil {
+			return nil, errors.Wrap(err, "error marshaling new letsencrypt order request")
+		}
+	} else {
+		// If the CA is not public then a root file is required.
+		root := af.ctx.String("root")
+		if len(root) == 0 {
+			root = pki.GetRootCAPath()
+			if _, err := os.Stat(root); err != nil {
+				return nil, errs.RequiredFlag(af.ctx, "root")
+			}
+		}
+		clientOps = append(clientOps, ca.WithRootFile(root))
+		// parse times or durations
+		nbf, naf, err := parseTimeDuration(af.ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		nor := acmeAPI.NewOrderRequest{
+			Identifiers: idents,
+			NotAfter:    naf.Time(),
+			NotBefore:   nbf.Time(),
+		}
+		orderPayload, err = json.Marshal(nor)
+		if err != nil {
+			return nil, errors.Wrap(err, "error marshaling new order request")
+		}
+	}
+
+	ac, err := ca.NewACMEClient(af.acmeDir, af.ctx.StringSlice("contact"), clientOps...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error initializing ACME client with server %s", af.acmeDir)
+	}
+
+	o, err := ac.NewOrder(orderPayload)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating new ACME order")
+	}
+
+	if err = authorizeOrder(af.ctx, ac, o); err != nil {
+		return nil, err
+	}
+
+	if af.csr == nil {
+		af.priv, err = keys.GenerateDefaultKey()
+		if err != nil {
+			return nil, errors.Wrap(err, "error generating private key")
+		}
+
+		_csr := &x509.CertificateRequest{
+			Subject: pkix.Name{
+				CommonName: af.subject,
+			},
+			DNSNames: dnsNames,
+		}
+		var csrBytes []byte
+		csrBytes, err = x509.CreateCertificateRequest(rand.Reader, _csr, af.priv)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating certificate request")
+		}
+		af.csr, err = x509.ParseCertificateRequest(csrBytes)
+		if err != nil {
+			return nil, errors.Wrap(err, "error parsing certificate request")
+		}
+	}
+
+	fo, err := finalizeOrder(ac, o, af.csr)
+	if err != nil {
+		return nil, err
+	}
+
+	leaf, chain, err := ac.GetCertificate(fo.Certificate)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting certificate")
+	}
+	return append([]*x509.Certificate{leaf}, chain...), nil
+}
+
+func writeCert(chain []*x509.Certificate, certFile string) error {
+	var certBytes = []byte{}
+	for _, c := range chain {
+		certBytes = append(certBytes, pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: c.Raw,
+		})...)
+	}
+
+	if err := utils.WriteFile(certFile, certBytes, 0600); err != nil {
+		return errs.FileError(err, certFile)
+	}
+	return nil
+}

--- a/utils/cautils/offline.go
+++ b/utils/cautils/offline.go
@@ -283,6 +283,8 @@ func (c *OfflineCA) GenerateToken(ctx *cli.Context, typ int, subject string, san
 	case *provisioner.Azure: // Do the identity request to get the token
 		sharedContext.DisableCustomSANs = p.DisableCustomSANs
 		return p.GetIdentityToken(subject, c.CaURL())
+	case *provisioner.ACME: // ACME provisioners do not implement the token flow.
+		return "", &ErrACMEToken{p.GetID()}
 	}
 
 	// JWK provisioner

--- a/utils/cautils/token_flow.go
+++ b/utils/cautils/token_flow.go
@@ -65,6 +65,17 @@ func parseAudience(ctx *cli.Context, tokType int) (string, error) {
 	}
 }
 
+// ErrACMEToken is the error type returned when the user attempts a Token Flow
+// while using an ACME provisioner.
+type ErrACMEToken struct {
+	Name string
+}
+
+// Error implements the error interface.
+func (e *ErrACMEToken) Error() string {
+	return "step ACME provisioners do not support token auth flows"
+}
+
 // NewTokenFlow implements the common flow used to generate a token
 func NewTokenFlow(ctx *cli.Context, typ int, subject string, sans []string, caURL, root string, notBefore, notAfter time.Time, certNotBefore, certNotAfter provisioner.TimeDuration) (string, error) {
 	// Get audience from ca-url
@@ -105,6 +116,8 @@ func NewTokenFlow(ctx *cli.Context, typ int, subject string, sans []string, caUR
 	case *provisioner.Azure: // Do the identity request to get the token
 		sharedContext.DisableCustomSANs = p.DisableCustomSANs
 		return p.GetIdentityToken(subject, caURL)
+	case *provisioner.ACME: // Return an error with the provisioner ID
+		return "", &ErrACMEToken{p.GetName()}
 	}
 
 	// JWK provisioner
@@ -254,7 +267,7 @@ func provisionerPrompt(ctx *cli.Context, provisioners provisioner.List) (provisi
 	// Filter by type
 	provisioners = provisionerFilter(provisioners, func(p provisioner.Interface) bool {
 		switch p.GetType() {
-		case provisioner.TypeJWK, provisioner.TypeOIDC:
+		case provisioner.TypeJWK, provisioner.TypeOIDC, provisioner.TypeACME:
 			return true
 		case provisioner.TypeGCP, provisioner.TypeAWS, provisioner.TypeAzure:
 			return true
@@ -321,6 +334,11 @@ func provisionerPrompt(ctx *cli.Context, provisioners provisioner.List) (provisi
 		case *provisioner.Azure:
 			items = append(items, &provisionersSelect{
 				Name:        fmt.Sprintf("%s (%s) [tenant: %s]", p.Name, p.GetType(), p.TenantID),
+				Provisioner: p,
+			})
+		case *provisioner.ACME:
+			items = append(items, &provisionersSelect{
+				Name:        fmt.Sprintf("%s (%s)", p.Name, p.GetType()),
 				Provisioner: p,
 			})
 		default:


### PR DESCRIPTION
Integrate with any ACME 2.0 server to get certificates using standalone or webroot mode.

