### PR TITLE
Seb/new website frontmatter

### DIFF
--- a/usage/help.go
+++ b/usage/help.go
@@ -41,6 +41,10 @@ func HelpCommand() cli.Command {
 				Name:  "report",
 				Usage: "Writes a JSON report to the HTML docs directory.",
 			},
+			cli.BoolFlag{
+				Name:  "hugo",
+				Usage: "Writes hugo.js (vs jekyll) compatible markdown files",
+			},
 		},
 	}
 }

--- a/usage/help.go
+++ b/usage/help.go
@@ -43,7 +43,7 @@ func HelpCommand() cli.Command {
 			},
 			cli.BoolFlag{
 				Name:  "hugo",
-				Usage: "Writes hugo.js (vs jekyll) compatible markdown files",
+				Usage: "Writes hugo (vs jekyll) compatible markdown files",
 			},
 		},
 	}

--- a/usage/html.go
+++ b/usage/html.go
@@ -41,21 +41,27 @@ func markdownHelpAction(ctx *cli.Context) error {
 		return errs.FileError(err, index)
 	}
 
+	// preserve jekyll compatibility for transition period
+	fileName := "index.md"
+	if ctx.IsSet("hugo") {
+		fileName = "_index.md"
+	}
+
 	// Subcommands
 	for _, cmd := range ctx.App.Commands {
-		if err := markdownHelpCommand(ctx.App, cmd, cmd, path.Join(dir, cmd.Name)); err != nil {
+		if err := markdownHelpCommand(ctx.App, cmd, cmd, path.Join(dir, cmd.Name), fileName); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func markdownHelpCommand(app *cli.App, cmd cli.Command, parent cli.Command, base string) error {
+func markdownHelpCommand(app *cli.App, cmd cli.Command, parent cli.Command, base string, fileName string) error {
 	if err := os.MkdirAll(base, 0755); err != nil {
 		return errs.FileError(err, base)
 	}
 
-	index := path.Join(base, "index.md")
+	index := path.Join(base, fileName)
 	w, err := os.Create(index)
 	if err != nil {
 		return errs.FileError(err, index)
@@ -80,7 +86,7 @@ func markdownHelpCommand(app *cli.App, cmd cli.Command, parent cli.Command, base
 
 	for _, sub := range cmd.Subcommands {
 		sub.HelpName = fmt.Sprintf("%s %s", cmd.HelpName, sub.Name)
-		if err := markdownHelpCommand(app, sub, cmd, path.Join(base, sub.Name)); err != nil {
+		if err := markdownHelpCommand(app, sub, cmd, path.Join(base, sub.Name), fileName); err != nil {
 			return err
 		}
 	}

--- a/usage/html.go
+++ b/usage/html.go
@@ -43,7 +43,7 @@ func markdownHelpAction(ctx *cli.Context) error {
 
 	// preserve jekyll compatibility for transition period
 	fileName := "index.md"
-	if ctx.IsSet("hugo") {
+	if ctx.Bool("hugo") {
 		fileName = "_index.md"
 	}
 

--- a/usage/html.go
+++ b/usage/html.go
@@ -36,21 +36,21 @@ func markdownHelpAction(ctx *cli.Context) error {
 	if err != nil {
 		return errs.FileError(err, index)
 	}
-	markdownHelpPrinter(w, mdAppHelpTemplate, ctx.App)
+	markdownHelpPrinter(w, mdAppHelpTemplate, "", ctx.App)
 	if err := w.Close(); err != nil {
 		return errs.FileError(err, index)
 	}
 
 	// Subcommands
 	for _, cmd := range ctx.App.Commands {
-		if err := markdownHelpCommand(ctx.App, cmd, path.Join(dir, cmd.Name)); err != nil {
+		if err := markdownHelpCommand(ctx.App, cmd, cmd, path.Join(dir, cmd.Name)); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func markdownHelpCommand(app *cli.App, cmd cli.Command, base string) error {
+func markdownHelpCommand(app *cli.App, cmd cli.Command, parent cli.Command, base string) error {
 	if err := os.MkdirAll(base, 0755); err != nil {
 		return errs.FileError(err, base)
 	}
@@ -61,21 +61,26 @@ func markdownHelpCommand(app *cli.App, cmd cli.Command, base string) error {
 		return errs.FileError(err, index)
 	}
 
+	parentName := parent.HelpName
+	if cmd.HelpName == parent.HelpName {
+		parentName = "step"
+	}
+
 	if len(cmd.Subcommands) == 0 {
-		markdownHelpPrinter(w, mdCommandHelpTemplate, cmd)
+		markdownHelpPrinter(w, mdCommandHelpTemplate, parentName, cmd)
 		return errs.FileError(w.Close(), index)
 	}
 
 	ctx := cli.NewContext(app, nil, nil)
 	ctx.App = createCliApp(ctx, cmd)
-	markdownHelpPrinter(w, mdSubcommandHelpTemplate, ctx.App)
+	markdownHelpPrinter(w, mdSubcommandHelpTemplate, parentName, ctx.App)
 	if err := w.Close(); err != nil {
 		return errs.FileError(err, index)
 	}
 
 	for _, sub := range cmd.Subcommands {
 		sub.HelpName = fmt.Sprintf("%s %s", cmd.HelpName, sub.Name)
-		if err := markdownHelpCommand(app, sub, path.Join(base, sub.Name)); err != nil {
+		if err := markdownHelpCommand(app, sub, cmd, path.Join(base, sub.Name)); err != nil {
 			return err
 		}
 	}

--- a/usage/printer.go
+++ b/usage/printer.go
@@ -16,6 +16,11 @@ var sectionRe = regexp.MustCompile(`(?m:^##)`)
 
 //var sectionRe = regexp.MustCompile(`^## [^\n]*$`)
 
+type frontmatterData struct {
+	Data   interface{}
+	Parent string
+}
+
 // HelpPrinter overwrites cli.HelpPrinter and prints the formatted help to the terminal.
 func HelpPrinter(w io.Writer, templ string, data interface{}) {
 	b := helpPreprocessor(w, templ, data)
@@ -34,11 +39,20 @@ func htmlHelpPrinter(w io.Writer, templ string, data interface{}) []byte {
 	return html
 }
 
-func markdownHelpPrinter(w io.Writer, templ string, data interface{}) {
+func markdownHelpPrinter(w io.Writer, templ string, parent string, data interface{}) {
 	b := helpPreprocessor(w, templ, data)
+
+	frontmatter := frontmatterData{
+		Data:   data,
+		Parent: parent,
+	}
+
 	var frontMatterTemplate = `---
 layout: auto-doc
-title: {{.HelpName}}
+title: {{.Data.HelpName}}{{if .Parent}}
+menu:
+  docs:
+    parent: {{.Parent}}{{end}}
 ---
 
 `
@@ -46,7 +60,7 @@ title: {{.HelpName}}
 	if err != nil {
 		panic(err)
 	}
-	err = t.Execute(w, data)
+	err = t.Execute(w, frontmatter)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### Description
Auto-gen'd reference docs will move from `jekyll` to `hugo.js` which requires additional frontmatter (backwards compatible) & different files names (breaking change; behind flag).