### PR TITLE
Support for NEW CERTIFICATE REQUEST header

### DIFF
--- a/command/certificate/inspect.go
+++ b/command/certificate/inspect.go
@@ -244,7 +244,7 @@ func inspectAction(ctx *cli.Context) error {
 	switch blocks[0].Type {
 	case "CERTIFICATE":
 		return inspectCertificates(ctx, blocks)
-	case "CERTIFICATE REQUEST": // only one is supported
+	case "CERTIFICATE REQUEST", "NEW CERTIFICATE REQUEST": // only one is supported
 		return inspectCertificateRequest(ctx, blocks[0])
 	default:
 		return errors.Errorf("Invalid PEM type in %s. Expected [CERTIFICATE|CERTIFICATE REQUEST] but got %s)", crtFile, block.Type)

--- a/crypto/pemutil/pem.go
+++ b/crypto/pemutil/pem.go
@@ -296,7 +296,7 @@ func Parse(b []byte, opts ...Options) (interface{}, error) {
 		}
 		crt, err := x509.ParseCertificate(block.Bytes)
 		return crt, errors.Wrapf(err, "error parsing %s", ctx.filename)
-	case "CERTIFICATE REQUEST":
+	case "CERTIFICATE REQUEST", "NEW CERTIFICATE REQUEST":
 		if ctx.stepCrypto {
 			csr, err := stepx509.ParseCertificateRequest(block.Bytes)
 			return csr, errors.Wrapf(err, "error parsing %s", ctx.filename)

--- a/crypto/pemutil/pem_test.go
+++ b/crypto/pemutil/pem_test.go
@@ -54,6 +54,13 @@ hkjOPQIBBggqhkjOPQMBBwNCAASKj0MvK6CUzFqRLfDTQNQp0Zt5dcHYx+Dq1Wh9
 AwIDRwAwRAIgZgz9gdx9inOp6bSX4EkYiUCyLV9xGvabovu5C9UkRr8CIBGBbkp0
 l4tesAKoXelsLygJjPuUGRLK+OtdjPBIN1Zo
 -----END CERTIFICATE REQUEST-----`
+	testCSRKeytool = `-----BEGIN NEW CERTIFICATE REQUEST-----
+MIHYMIGAAgEAMB4xHDAaBgNVBAMTE2hlbGxvLnNtYWxsc3RlcC5jb20wWTATBgcq
+hkjOPQIBBggqhkjOPQMBBwNCAASKj0MvK6CUzFqRLfDTQNQp0Zt5dcHYx+Dq1Wh9
+5dhqf1Fu9+1m5+LKkgBWoZmo7sJH0RuSjIdv/sZwpBrkdn2soAAwCgYIKoZIzj0E
+AwIDRwAwRAIgZgz9gdx9inOp6bSX4EkYiUCyLV9xGvabovu5C9UkRr8CIBGBbkp0
+l4tesAKoXelsLygJjPuUGRLK+OtdjPBIN1Zo
+-----END NEW CERTIFICATE REQUEST-----`
 )
 
 type testdata struct {
@@ -663,6 +670,13 @@ func TestParseKey_x509(t *testing.T) {
 	csr, err := x509.ParseCertificateRequest(b.Bytes)
 	assert.FatalError(t, err)
 	key, err = ParseKey([]byte(testCSR))
+	assert.FatalError(t, err)
+	assert.Equals(t, csr.PublicKey, key)
+
+	b, _ = pem.Decode([]byte(testCSRKeytool))
+	csr, err = x509.ParseCertificateRequest(b.Bytes)
+	assert.FatalError(t, err)
+	key, err = ParseKey([]byte(testCSRKeytool))
 	assert.FatalError(t, err)
 	assert.Equals(t, csr.PublicKey, key)
 }


### PR DESCRIPTION
### Description
Certificate signing request created by some versions of java's keytool use the PEM header `NEW CERTIFICATE REQUEST`. This PR adds support for inspecting and signing these files.
