### PR TITLE
oauth: Add terminal redirect URL option

### DIFF
--- a/command/ca/bootstrap.go
+++ b/command/ca/bootstrap.go
@@ -25,7 +25,7 @@ func bootstrapCommand() cli.Command {
 		Name:      "bootstrap",
 		Action:    command.ActionFunc(bootstrapAction),
 		Usage:     "initialize the environment to use the CA commands",
-		UsageText: `**step ca bootstrap** [**--ca-url**=<uri>] [**--fingerprint**=<fingerprint>] [**--install**]`,
+		UsageText: `**step ca bootstrap** [**--ca-url**=<uri>] [**--fingerprint**=<fingerprint>] [**--install**] [**--redirect-url**=<url>]`,
 		Description: `**step ca bootstrap** downloads the root certificate from the certificate
 authority and sets up the current environment to use it.
 
@@ -43,6 +43,7 @@ After the bootstrap, ca commands do not need to specify the flags
 				Name:  "install",
 				Usage: "Install the root certificate into the system truststore.",
 			},
+			flags.RedirectURL,
 			flags.Force,
 		},
 	}
@@ -52,6 +53,7 @@ type bootstrapConfig struct {
 	CA          string `json:"ca-url"`
 	Fingerprint string `json:"fingerprint"`
 	Root        string `json:"root"`
+	Redirect    string `json:"redirect-url"`
 }
 
 func bootstrapAction(ctx *cli.Context) error {
@@ -60,6 +62,7 @@ func bootstrapAction(ctx *cli.Context) error {
 	team := ctx.String("team")
 	rootFile := pki.GetRootCAPath()
 	configFile := filepath.Join(config.StepPath(), "config", "defaults.json")
+	redirectURL := ctx.String("redirect-url")
 
 	switch {
 	case team != "":
@@ -108,6 +111,7 @@ func bootstrapAction(ctx *cli.Context) error {
 		CA:          caURL,
 		Fingerprint: fingerprint,
 		Root:        pki.GetRootCAPath(),
+		Redirect:    redirectURL,
 	}, "", "  ")
 	if err != nil {
 		return errors.Wrap(err, "error marshaling defaults.json")

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -207,6 +207,11 @@ be stored in the 'sshpop' header.`,
 		Name:  "team",
 		Usage: "The team <name> used to bootstrap the environment.",
 	}
+
+	RedirectURL = cli.StringFlag{
+		Name:  "redirect-url",
+		Usage: "Terminal OAuth redirect <url>.",
+	}
 )
 
 // ParseTimeOrDuration is a helper that returns the time or the current time

--- a/utils/cautils/teams.go
+++ b/utils/cautils/teams.go
@@ -48,9 +48,12 @@ func BootstrapTeam(ctx *cli.Context, name string) error {
 		return errors.Wrap(err, "error getting team data")
 	}
 
+	sshRedirect := "https://smallstep.com/app/teams/sso/success"
+
 	args := []string{"ca", "bootstrap",
 		"--ca-url", r.CaURL,
 		"--fingerprint", r.Fingerprint,
+		"--redirect-url", sshRedirect,
 	}
 	if ctx.Bool("force") {
 		args = append(args, "--force")


### PR DESCRIPTION
Add a `--redirect-url` string option to the boostrap command that allows
the terminal redirect in the OAuth flow to be configured. This is useful
if you want to display a more interesting page than the locally hosted
basebones "Success" page.

If the user configures step-cli using the `ssh config` command and passes
the `--team` option, set the redirect url to:

    https://smallstep.com/app/teams/sso/success

so that the flow ends on a page that instructs users on what to do next.