### PR TITLE
command/path: fix typo on command description

### DIFF
--- a/command/path/path.go
+++ b/command/path/path.go
@@ -13,7 +13,7 @@ func init() {
 		Name:        "path",
 		Usage:       "print the configured step path and exit",
 		UsageText:   "step path",
-		Description: "**step ca** command prints the configured step path and exit",
+		Description: "**step path** command prints the configured step path and exit",
 		Action: cli.ActionFunc(func(ctx *cli.Context) error {
 			fmt.Println(config.StepPath())
 			return nil


### PR DESCRIPTION
Previously, the Description for “step path” command is
“step ca command prints …”, it should be “step path command prints …”.

This changes fix the typo.