### PR TITLE
Fix local development doc

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -30,7 +30,7 @@ Once you've cloned the repository to the appropriate location, you will now be
 able to install any other dependencies via the `make bootstrap` command.
 
 You should only ever need to run this command once, as it will ensure you have
-the right version of `gometalinter` installed.
+the right version of `golangci-lint` installed.
 
 ### Building step
 
@@ -48,12 +48,6 @@ Run the unit tests:
 
 ```
 make test
-```
-
-For a more verbose version of the unit tests:
-
-```
-make vtest
 ```
 
 #### Integration Tests


### PR DESCRIPTION
- remove vtest description. See https://github.com/smallstep/cli/commit/71ee01bbfa698835c9bfac73458a95113181abef
- fix linter desc metalinter -> golangci-lint. See #130

### Description
I tried and found some deprecated guide descriptions as above.

Thank you.
