### PR TITLE
Cosmetic improvement: avoid unintentional concat of columns

### DIFF
--- a/command/ssh/hosts.go
+++ b/command/ssh/hosts.go
@@ -65,7 +65,7 @@ func hostsAction(ctx *cli.Context) error {
 
 	w := new(tabwriter.Writer)
 	// Format in tab-separated columns with a tab stop of 8.
-	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
+	w.Init(os.Stdout, 0, 8, 1, '\t', 0)
 
 	fmt.Fprintln(w, "HOSTNAME\tID\tTAGS")
 	for _, h := range resp.Hosts {


### PR DESCRIPTION
### Description
When hostnames run up against the full length of their column there will be no separation between hostname and ID columns. This change will fix this. Please see before after example below.

:-(
```
HOSTNAME                                        ID                                      TAGS
ec2-18-xxx-x-x.compute-1.amazonaws.com          b160dd85-3ead-4479-xxxx-762d773dcce0    stage=dev
ec2-52-xx-xxx-xx.us-west-1.compute.amazonaws.combe5078ad-2c67-46ee-xxxx-7f658e83ca5a    stage=dev,box=small
ip-172-31-72-13                                 698d7af5-3f48-4477-xxxx-677fcf2fc158    stage=dev
```

:-)
```
ec2-18-xxx-x-x.compute-1.amazonaws.com                  b160dd85-3ead-4479-xxxx-762d773dcce0    stage=dev
ec2-52-xx-xxx-xx.us-west-1.compute.amazonaws.com        be5078ad-2c67-46ee-xxxx-7f658e83ca5a    stage=dev,box=small
ip-172-31-72-13                                         698d7af5-3f48-4477-xxxx-677fcf2fc158    stage=dev
```