### PR TITLE
ssh: Add machine-id hash to host certificate

### DIFF
--- a/command/ssh/certificate.go
+++ b/command/ssh/certificate.go
@@ -35,7 +35,7 @@ func certificateCommand() cli.Command {
 		Action: command.ActionFunc(certificateAction),
 		Usage:  "sign a SSH certificate using the the SSH CA",
 		UsageText: `**step ssh certificate** <key-id> <key-file>
-[**--host**] [--host-id**] [**--sign**] [**--principal**=<string>] [**--password-file**=<path>]
+[**--host**] [--**host-id**] [**--sign**] [**--principal**=<string>] [**--password-file**=<path>]
 [**--provisioner-password-file**=<path>] [**--add-user**]
 [**--not-before**=<time|duration>] [**--not-after**=<time|duration>]
 [**--token**=<token>] [**--issuer**=<name>] [**--ca-url**=<uri>]
@@ -203,7 +203,7 @@ func certificateAction(ctx *cli.Context) error {
 	case isHost && isAddUser:
 		return errs.IncompatibleFlagWithFlag(ctx, "host", "add-user")
 	case !isHost && hostID != "":
-		return errors.New("flag '--host-id' can only be pass if '--host' is set")
+		return errs.RequiredWithFlag(ctx, sshHostIDFlag.Name, sshHostFlag.Name)
 	case isAddUser && len(principals) > 1:
 		return errors.New("flag '--add-user' is incompatible with more than one principal")
 	}

--- a/command/ssh/ssh.go
+++ b/command/ssh/ssh.go
@@ -113,6 +113,11 @@ var (
 		Usage: `Create a host certificate instead of a user certificate.`,
 	}
 
+	sshHostIDFlag = cli.StringFlag{
+		Name:  "host-id",
+		Usage: `Specify a <UUID> to identify the host rather than using an auto-generated UUID derived from the machine-id.`,
+	}
+
 	sshSignFlag = cli.BoolFlag{
 		Name:  "sign",
 		Usage: `Sign the public key passed as an argument instead of creating one.`,

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.14
 	github.com/ThomasRooney/gexpect v0.0.0-20161231170123-5482f0350944
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+	github.com/google/uuid v1.1.1
 	github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428
 	github.com/manifoldco/promptui v0.3.1
 	github.com/pkg/errors v0.8.1


### PR DESCRIPTION
Alternatively, allow the user to specify their own UUID. Adding an ID
derived from the machine ID allows us to authorize hosts to access their
own resources by ID. The machine-id is not supposed to be sent around as
a raw UUID. So we HMAC it with an application "secret" and use the first
sixteen bytes of the resulting sha256 sum to as the entropy source when
generating a new "random" UUIDv4.