### PR TITLE
ssh/certificate: Generate a random UUID by default

### DIFF
--- a/command/ssh/ssh.go
+++ b/command/ssh/ssh.go
@@ -114,8 +114,9 @@ var (
 	}
 
 	sshHostIDFlag = cli.StringFlag{
-		Name:  "host-id",
-		Usage: `Specify a <UUID> to identify the host rather than using an auto-generated UUID derived from the machine-id.`,
+		Name: "host-id",
+		Usage: `Specify a <UUID> to identify the host rather than using an auto-generated UUID.
+		If "machine" is passed, derive a UUID from "/etc/machine-id."`,
 	}
 
 	sshSignFlag = cli.BoolFlag{


### PR DESCRIPTION
Apparently some images don't properly handle the machine-id and it ends
up not being unique. By default play it safe and generate our own UUID.
Deriving a UUID from `/etc/machine-id` is still supported. To trigger
that behavior, pass 'machine' as the `--host-id` flag.
