### PR TITLE
Add tip about STEPPATH to step path docs.

### DIFF
--- a/command/path/path.go
+++ b/command/path/path.go
@@ -10,10 +10,12 @@ import (
 
 func init() {
 	cmd := cli.Command{
-		Name:        "path",
-		Usage:       "print the configured step path and exit",
-		UsageText:   "step path",
-		Description: "**step path** command prints the configured step path and exit",
+		Name:      "path",
+		Usage:     "print the configured step path and exit",
+		UsageText: "step path",
+		Description: `**step path** command prints the configured step path and exits.
+
+The default step path of $HOME/.step can be overridden with the **STEPPATH** environment variable.`,
 		Action: cli.ActionFunc(func(ctx *cli.Context) error {
 			fmt.Println(config.StepPath())
 			return nil


### PR DESCRIPTION
Just a minor edit to add a tip about `STEPPATH` when running `step path --help`