### PR TITLE
Usage summary for `step ssh fingerprint`

### DIFF
--- a/command/ssh/fingerprint.go
+++ b/command/ssh/fingerprint.go
@@ -14,7 +14,7 @@ func fingerPrintCommand() cli.Command {
 	return cli.Command{
 		Name:      "fingerprint",
 		Action:    command.ActionFunc(fingerprint),
-		Usage:     "list public keys known to the ssh agent",
+		Usage:     "print the fingerprint of an SSH public key or certificate",
 		UsageText: `**step ssh fingerprint** <file>`,
 		Description: `**step ssh fingerprint** prints the fingerprint of an ssh public key or
 certificate.


### PR DESCRIPTION
Wrote a Usage summary for `step ssh fingerprint`. The old one was the same text as `step ssh list`.