### PR TITLE
Fix autocompletion for file paths in ZSH [#240]

### DIFF
--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -1,10 +1,13 @@
-#compdef _step step
+#compdef step
 
 function _step {
   local -a opts
   opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
-
-  _describe 'values' opts
-
-  return
+  if [[ "${opts}" != "" ]]; then
+    _describe -t step-commands 'values' opts
+  else
+    _path_files
+  fi
 }
+
+_step "$@"


### PR DESCRIPTION
Closes #240

### Description
This revision modifies the ZSH autocomplete script to check if the output of `--generate-bash-completion` is empty, and if is, it defaults to autocompleting files.

💔Thank you!
