### PR TITLE
Add ARM support for step-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,41 +37,45 @@ distclean: clean
 #################################################
 
 BINARY_OUTPUT=$(OUTPUT_ROOT)binary/
-BUNDLE_MAKE=v=$v GOOS_OVERRIDE='GOOS=$(1) GOARCH=$(2)' PREFIX=$(3) make $(3)bin/step
 RELEASE=./.travis-releases
 
-binary-linux:
-	$(call BUNDLE_MAKE,linux,amd64,$(BINARY_OUTPUT)linux/)
-
-binary-darwin:
-	$(call BUNDLE_MAKE,darwin,amd64,$(BINARY_OUTPUT)darwin/)
-
-binary-windows:
-	$(call BUNDLE_MAKE,windows,amd64,$(BINARY_OUTPUT)windows/)
-
-define BUNDLE
-	$(q)set -e; BUNDLE_DIR=$(BINARY_OUTPUT)$(1)/bundle; \
-	stepName=step_$(2); \
- 	mkdir -p $$BUNDLE_DIR $(RELEASE); \
-	TMP=$$(mktemp -d $$BUNDLE_DIR/tmp.XXXX); \
-	trap "rm -rf $$TMP" EXIT INT QUIT TERM; \
-	newdir=$$TMP/$$stepName; \
-	mkdir -p $$newdir/bin; \
-	cp $(BINARY_OUTPUT)$(1)/bin/step $$newdir/bin/$(4); \
-	cp README.md $$newdir/; \
-	NEW_BUNDLE=$(RELEASE)/step_$(2)_$(1)_$(3).tar.gz; \
-	rm -f $$NEW_BUNDLE; \
-    tar -zcvf $$NEW_BUNDLE -C $$TMP $$stepName;
+define BUNDLE_MAKE
+	$(q) GOOS_OVERRIDE='GOOS=$(1) GOARCH=$(2) GOARM=$(3)' PREFIX=$(4) make $(4)bin/step
 endef
 
-bundle-linux: binary-linux
-	$(call BUNDLE,linux,$(VERSION),amd64,step)
+binary-linux:
+	$(call BUNDLE_MAKE,linux,amd64,,$(BINARY_OUTPUT)linux/)
+
+binary-linux-arm64:
+	$(call BUNDLE_MAKE,linux,arm64,,$(BINARY_OUTPUT)linux.arm64/)
+
+binary-linux-armv7:
+	$(call BUNDLE_MAKE,linux,arm,7,$(BINARY_OUTPUT)linux.armv7/)
+
+binary-darwin:
+	$(call BUNDLE_MAKE,darwin,amd64,,$(BINARY_OUTPUT)darwin/)
+
+binary-windows:
+	$(call BUNDLE_MAKE,windows,amd64,,$(BINARY_OUTPUT)windows/)
+
+define BUNDLE
+	# $(1) -- Binary Output Dir Name
+	# $(2) -- Step Platform Name
+	# $(3) -- Step Binary Architecture
+	# $(4) -- Step Binary Name (For Windows Comaptibility)
+	$(q) ./make/bundle.sh "$(BINARY_OUTPUT)$(1)" "$(RELEASE)" "$(VERSION)" "$(2)" "$(3)" "$(4)"
+endef
+
+bundle-linux: binary-linux binary-linux-arm64 binary-linux-armv7
+	$(call BUNDLE,linux,linux,amd64,step)
+	$(call BUNDLE,linux.arm64,linux,arm64,step)
+	$(call BUNDLE,linux.armv7,linux,armv7,step)
 
 bundle-darwin: binary-darwin
-	$(call BUNDLE,darwin,$(VERSION),amd64,step)
+	$(call BUNDLE,darwin,darwin,amd64,step)
 
 bundle-windows: binary-windows
-	$(call BUNDLE,windows,$(VERSION),amd64,step.exe)
+	$(call BUNDLE,windows,windows,amd64,step.exe)
 
 .PHONY: binary-linux binary-darwin binary-windows bundle-linux bundle-darwin bundle-windows
 

--- a/make/bundle.sh
+++ b/make/bundle.sh
@@ -1,0 +1,28 @@
+#/bin/sh
+set -ex;
+
+OUTPUT_DIR=$1
+RELEASE_DIR=$2
+
+STEP_VERSION=$3
+STEP_PLATFORM=$4
+STEP_ARCH=$5
+STEP_EXEC_NAME=$6
+
+BUNDLE_DIR=${OUTPUT_DIR}/bundle
+
+mkdir -p "$BUNDLE_DIR" "$RELEASE_DIR"
+TMP=$(mktemp -d "$BUNDLE_DIR/tmp.XXXX")
+trap "rm -rf $TMP" EXIT INT QUIT TERM
+
+stepName=step_${STEP_VERSION}
+newdir="$TMP/${stepName}"
+mkdir -p "$newdir/bin"
+
+cp "$OUTPUT_DIR/bin/step" "$newdir/bin/${STEP_EXEC_NAME}"
+
+cp README.md "$newdir"
+NEW_BUNDLE="${RELEASE_DIR}/step_${STEP_PLATFORM}_${STEP_VERSION}_${STEP_ARCH}.tar.gz"
+
+rm -f "$NEW_BUNDLE"
+tar -zcvf "$NEW_BUNDLE" -C "$TMP" "${stepName}"


### PR DESCRIPTION
### Description

Partially solves: smallstep/certificates#152

This revision:
- Adds rules for building ARM Linux releases for Arm64 and ArmV7 (tested on my RPI)
- Refactors out the BUNDLE script from Makefile into a shell script
  - improves readability
  - adds support for specifying architecture and artifact directory separately from each other

Thank you!
