### PR TITLE
Improvements in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ VERSION ?= $(shell [ -d .git ] && git describe --tags --always --dirty="-dev")
 # .VERSION contains a slug populated by `git archive`.
 VERSION := $(or $(VERSION),$(shell ./.version.sh .VERSION))
 
--include make/common.mk
--include make/docker.mk
+include make/common.mk
+include make/docker.mk
 
 #########################################
 # Debian

--- a/make/common.mk
+++ b/make/common.mk
@@ -56,7 +56,7 @@ build: $(PREFIX)bin/$(BINNAME)
 
 $(PREFIX)bin/$(BINNAME): download $(call rwildcard,*.go)
 	$Q mkdir -p $(@D)
-	$Q $(GOOS_OVERRIDE) $(GOFLAGS) go build -v -o $(PREFIX)bin/$(BINNAME) $(LDFLAGS) $(PKG)
+	$Q $(GOOS_OVERRIDE) $(GOFLAGS) go build -v -o $@ $(LDFLAGS) $(PKG)
 
 # Target to force a build of step without running tests
 simple:


### PR DESCRIPTION
# Description
The included sub-Makefiles are present in the source code. Thus, they should be present always. There is no need to silently fail if the files are not found. In contrary this indicates a clearly broken setup.