### PR TITLE
certificates: create: only force default SAN for leaf certs

### DIFF
--- a/command/certificate/create.go
+++ b/command/certificate/create.go
@@ -270,10 +270,6 @@ func createAction(ctx *cli.Context) error {
 	}
 
 	sans := ctx.StringSlice("san")
-	if len(sans) == 0 {
-		sans = []string{subject}
-	}
-	dnsNames, ips, emails := x509util.SplitSANs(sans)
 
 	var (
 		priv       interface{}
@@ -293,6 +289,11 @@ func createAction(ctx *cli.Context) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
+
+		if len(sans) == 0 {
+			sans = []string{subject}
+		}
+		dnsNames, ips, emails := x509util.SplitSANs(sans)
 
 		csr := &x509.CertificateRequest{
 			Subject: pkix.Name{
@@ -320,6 +321,12 @@ func createAction(ctx *cli.Context) error {
 			caKeyPath = ctx.String("ca-key")
 			profile   x509util.Profile
 		)
+
+		if (len(sans) == 0) && (prof == "leaf") {
+			sans = []string{subject}
+		}
+		dnsNames, ips, emails := x509util.SplitSANs(sans)
+
 		if bundle && prof != "leaf" {
 			return errs.IncompatibleFlagValue(ctx, "bundle", "profile", prof)
 		}


### PR DESCRIPTION
Forcing this for root CA and intermediate CA certs was resulting
in the subject (typically a company name) being interpreted as
a dnsName SAN.  This produced an invalid certificate.  It is also
highly unusual to have a root CA with a SAN at all as seen in
censys so it's best to leave it out.

Fixes #263
