### PR TITLE
Copy 'Extensions' of csr to 'ExtraExtensions' of cert ...

### DIFF
--- a/crypto/x509util/leafProfile.go
+++ b/crypto/x509util/leafProfile.go
@@ -55,8 +55,7 @@ func NewLeafProfileWithCSR(csr *x509.CertificateRequest, iss *x509.Certificate, 
 	}
 
 	sub := defaultLeafTemplate(csr.Subject, iss.Subject)
-	sub.Extensions = csr.Extensions
-	sub.ExtraExtensions = csr.ExtraExtensions
+	sub.ExtraExtensions = csr.Extensions
 	sub.DNSNames = csr.DNSNames
 	sub.EmailAddresses = csr.EmailAddresses
 	sub.IPAddresses = csr.IPAddresses


### PR DESCRIPTION
* Current code is copying these extensions in a way that any extensions
on the csr will be ignored.

Fixes #185 
Fixes #196 