### PR TITLE
Avoids panic when the add user certificate is not provided.

### DIFF
--- a/command/ssh/certificate.go
+++ b/command/ssh/certificate.go
@@ -446,7 +446,7 @@ func certificateAction(ctx *cli.Context) error {
 	}
 
 	// Write Add User keys and certs
-	if isAddUser {
+	if isAddUser && resp.AddUserCertificate != nil {
 		id := provisioner.SanitizeSSHUserPrincipal(subject) + "-provisioner"
 		if _, err := pemutil.Serialize(auPriv, pemutil.WithOpenSSH(true), pemutil.ToFile(baseName+"-provisioner", 0600)); err != nil {
 			return err
@@ -486,10 +486,10 @@ func certificateAction(ctx *cli.Context) error {
 		}
 	}
 
-	if isAddUser {
-		ui.PrintSelected("Provisioner Private Key", baseName+"-provisioner")
-		ui.PrintSelected("Provisioner Public Key", baseName+"-provisioner.pub")
-		ui.PrintSelected("Provisioner Certificate", baseName+"-provisioner-cert.pub")
+	if isAddUser && resp.AddUserCertificate != nil {
+		ui.PrintSelected("Add User Private Key", baseName+"-provisioner")
+		ui.PrintSelected("Add User Public Key", baseName+"-provisioner.pub")
+		ui.PrintSelected("Add User Certificate", baseName+"-provisioner-cert.pub")
 	}
 
 	return nil

--- a/command/ssh/login.go
+++ b/command/ssh/login.go
@@ -223,7 +223,7 @@ func loginAction(ctx *cli.Context) error {
 	}
 	if isAddUser {
 		if resp.AddUserCertificate == nil {
-			ui.Printf(`{{ "%s" | red }} {{ "Add User:" | bold }} failed to create a provisioner certificate.`+"\n", ui.IconBad)
+			ui.Printf(`{{ "%s" | red }} {{ "Add User:" | bold }} failed to create a provisioner certificate`+"\n", ui.IconBad)
 		} else if err := agent.AddCertificate(subject, resp.AddUserCertificate.Certificate, auPriv); err != nil {
 			ui.Printf(`{{ "%s" | red }} {{ "Add User:" | bold }} %v`+"\n", ui.IconBad, err)
 		} else {

--- a/command/ssh/login.go
+++ b/command/ssh/login.go
@@ -222,10 +222,12 @@ func loginAction(ctx *cli.Context) error {
 		ui.PrintSelected("SSH Agent", "yes")
 	}
 	if isAddUser {
-		if err := agent.AddCertificate(subject, resp.AddUserCertificate.Certificate, auPriv); err != nil {
-			ui.Printf(`{{ "%s" | red }} {{ "SSH Agent:" | bold }} %v`+"\n", ui.IconBad, err)
+		if resp.AddUserCertificate == nil {
+			ui.Printf(`{{ "%s" | red }} {{ "Add User:" | bold }} failed to create a provisioner certificate.`+"\n", ui.IconBad)
+		} else if err := agent.AddCertificate(subject, resp.AddUserCertificate.Certificate, auPriv); err != nil {
+			ui.Printf(`{{ "%s" | red }} {{ "Add User:" | bold }} %v`+"\n", ui.IconBad, err)
 		} else {
-			ui.PrintSelected("SSH Agent", "yes")
+			ui.PrintSelected("Add User", "yes")
 		}
 	}
 

--- a/command/ssh/login.go
+++ b/command/ssh/login.go
@@ -223,11 +223,11 @@ func loginAction(ctx *cli.Context) error {
 	}
 	if isAddUser {
 		if resp.AddUserCertificate == nil {
-			ui.Printf(`{{ "%s" | red }} {{ "Add User:" | bold }} failed to create a provisioner certificate`+"\n", ui.IconBad)
+			ui.Printf(`{{ "%s" | red }} {{ "Add User Certificate:" | bold }} failed to create a provisioner certificate`+"\n", ui.IconBad)
 		} else if err := agent.AddCertificate(subject, resp.AddUserCertificate.Certificate, auPriv); err != nil {
-			ui.Printf(`{{ "%s" | red }} {{ "Add User:" | bold }} %v`+"\n", ui.IconBad, err)
+			ui.Printf(`{{ "%s" | red }} {{ "Add User Certificate:" | bold }} %v`+"\n", ui.IconBad, err)
 		} else {
-			ui.PrintSelected("Add User", "yes")
+			ui.PrintSelected("Add User Certificate", "yes")
 		}
 	}
 


### PR DESCRIPTION
### Description
This PR avoids a panic when the add user certificate is not provided.

On OIDC provisioner the certificate has two identities and
step-certificates does not create a user provisioner certificate.
This change avoid the panic and displays a proper message.

A fix in certificates is required to allow user provisioner
certificates with OIDC provisioners.

Partialy fixes #268
