### PR TITLE
Redirect to localhost using the `--listen` flag

### DIFF
--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -75,8 +75,56 @@ func init() {
 **step oauth** [**--account**=<account>] [**--authorization-endpoint**=<authorization-endpoint> **--token-endpoint**=<token-endpoint>]
   [**--scope**=<scope> ...] [**--bare** [**--oidc**]] [**--header** [**--oidc**]]
 
-**step oauth** **--account**=<account> **--jwt** [**--scope**=<scope> ...] [**--header**] [**-bare**]
-`,
+**step oauth** **--account**=<account> **--jwt** [**--scope**=<scope> ...] [**--header**] [**-bare**]`,
+		Description: `**step oauth** command implements the OAuth 2.0 authorization flow.
+
+OAuth is an open standard for access delegation, commonly used as a way for
+Internet users to grant websites or applications access to their information on
+other websites but without giving them the passwords. This mechanism is used by
+companies such as Amazon, Google, Facebook, Microsoft and Twitter to permit the
+users to share information about their accounts with third party applications or
+websites. Learn more at https://en.wikipedia.org/wiki/OAuth.
+
+This command by default performs he authorization flow with a preconfigured
+Google application, but a custom one can be set combining the flags
+**--client-id**, **--client-secret**, and **--provider**. The provider value
+must be set to the OIDC discovery document (.well-known/openid-configuration)
+endpoint. If Google is used this flag is not necessary, but the appropriate
+value would be be https://accounts.google.com or
+https://accounts.google.com/.well-known/openid-configuration
+
+## EXAMPLES
+
+Do the OAuth 2.0 flow using the default client:
+'''
+$ step oauth
+'''
+
+Redirect to localhost instead of 127.0.0.1:
+'''
+$ step oauth --listen localhost:0
+'''
+
+Redirect to a fixed port instead of random one:
+'''
+$ step oauth --listen :10000
+'''
+
+Get just the access token:
+'''
+$ step oauth --bare
+'''
+
+Get just the OIDC token:
+'''
+$ step oauth --oidc --bare
+'''
+
+Use a custom OAuth2.0 server:
+''''
+$ step oauth --client-id my-client-id --client-secret my-client-secret \
+  --provider https://example.org
+'''`,
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "provider, idp",

--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -447,6 +447,16 @@ func (o *oauth) NewServer() (*httptest.Server, error) {
 		Config:   &http.Server{Handler: o},
 	}
 	srv.Start()
+
+	// Update host to use for example localhost
+	if host != "127.0.0.1" {
+		_, p, err := net.SplitHostPort(l.Addr().String())
+		if err != nil {
+			return nil, errors.Wrapf(err, "error parsing %s", l.Addr().String())
+		}
+		srv.URL = "http://" + host + ":" + p
+	}
+
 	return srv, nil
 }
 


### PR DESCRIPTION
## Description

Some IdPs do not support the recommended 127.0.0.1, and only support
localhost as redirect uri. This change allows to run use localhost
with `step oauth --listen localhost:0`.

Fixes #169

This is an alternative approach to #278 that integrates better with step-ca