### PR TITLE
Add support for base64 encoded nonces.

### DIFF
--- a/command/crypto/nacl/box.go
+++ b/command/crypto/nacl/box.go
@@ -84,6 +84,12 @@ private key and validates the message from Bob using his public key:
 '''
 $ echo 0oM0A6xIezA6iMYssZECmbMRQh77mzDt | step crypto nacl box open nonce bob.box.pub alice.box.priv
 message
+'''
+
+Decrypt the message using a base64 nonce:
+'''
+$ echo 0oM0A6xIezA6iMYssZECmbMRQh77mzDt | step crypto nacl box open base64:bm9uY2U= bob.box.pub alice.box.priv
+message
 '''`,
 		Subcommands: cli.Commands{
 			boxKeypairCommand(),
@@ -137,6 +143,9 @@ For examples, see **step help crypto nacl box**.
 <nonce>
 :  The nonce provided when the box was sealed.
 
+:  To use a binary nonce use the prefix 'base64:' and the standard base64
+encoding. e.g. base64:081D3pFPBkwx1bURR9HQjiYbAUxigo0Z
+
 <sender-pub-key>
 :  The path to the public key of the peer that produced the sealed box.
 
@@ -170,6 +179,9 @@ For examples, see **step help crypto nacl box**.
 
 <nonce>
 :  Must be unique for each distinct message for a given pair of keys.
+
+:  To use a binary nonce use the prefix 'base64:' and the standard base64
+encoding. e.g. base64:081D3pFPBkwx1bURR9HQjiYbAUxigo0Z
 
 <recipient-pub-key>
 :  The path to the public key of the intended recipient of the sealed box.
@@ -220,7 +232,11 @@ func boxOpenAction(ctx *cli.Context) error {
 	}
 
 	args := ctx.Args()
-	nonce, pubFile, privFile := []byte(args[0]), args[1], args[2]
+	nonce, err := decodeNonce(args[0])
+	if err != nil {
+		return err
+	}
+	pubFile, privFile := args[1], args[2]
 
 	if len(nonce) > 24 {
 		return errors.New("nonce cannot be longer than 24 bytes")
@@ -282,7 +298,11 @@ func boxSealAction(ctx *cli.Context) error {
 	}
 
 	args := ctx.Args()
-	nonce, pubFile, privFile := []byte(args[0]), args[1], args[2]
+	nonce, err := decodeNonce(args[0])
+	if err != nil {
+		return err
+	}
+	pubFile, privFile := args[1], args[2]
 
 	if len(nonce) > 24 {
 		return errors.New("nonce cannot be longer than 24 bytes")

--- a/command/crypto/nacl/nacl.go
+++ b/command/crypto/nacl/nacl.go
@@ -2,7 +2,9 @@ package nacl
 
 import (
 	"encoding/base64"
+	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -42,3 +44,19 @@ For more information on NaCl visit https://nacl.cr.yp.to`,
 }
 
 var b64Encoder = base64.RawURLEncoding
+
+// decodeNonce returns the nonce in bytes. If the input has the prefix base64:
+// it will decode the rest using the base64 standard encoding.
+func decodeNonce(in string) ([]byte, error) {
+	nonce := []byte(in)
+	if strings.HasPrefix(in, "base64:") {
+		input := nonce[7:]
+		nonce = make([]byte, base64.StdEncoding.DecodedLen(len(input)))
+		n, err := base64.StdEncoding.Decode(nonce, input)
+		if err != nil {
+			return nil, errors.Wrap(err, "error decoding base64 nonce")
+		}
+		return nonce[:n], nil
+	}
+	return nonce, nil
+}

--- a/command/crypto/nacl/secretbox.go
+++ b/command/crypto/nacl/secretbox.go
@@ -52,6 +52,12 @@ $ cat message.txt | step crypto nacl secretbox seal nonce secretbox.key
 o2NJTsIJsk0dl4epiBwS1mM4xFED7iE
 '''
 
+Encrypt the message using a base64 nonce:
+'''
+$ cat message.txt | step crypto nacl secretbox seal base64:bm9uY2U= secretbox.key
+o2NJTsIJsk0dl4epiBwS1mM4xFED7iE
+'''
+
 Decrypt and authenticate the message:
 '''
 $ echo o2NJTsIJsk0dl4epiBwS1mM4xFED7iE | step crypto nacl secretbox open nonce secretbox.key
@@ -76,7 +82,18 @@ secret key and a nonce.
 
 This command uses an implementation of NaCl's crypto_secretbox_open function.
 
-For examples, see **step help crypto nacl secretbox**.`,
+For examples, see **step help crypto nacl secretbox**.
+
+## POSITIONAL ARGUMENTS
+
+<nonce>
+:  The nonce provided when the secretbox was sealed.
+
+:  To use a binary nonce use the prefix 'base64:' and the standard base64
+encoding. e.g. base64:081D3pFPBkwx1bURR9HQjiYbAUxigo0Z
+
+<key-file>
+:  The path to the shared key.`,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
 				Name:  "raw",
@@ -98,7 +115,18 @@ a secret key and a nonce.
 
 This command uses an implementation of NaCl's crypto_secretbox function.
 
-For examples, see **step help crypto nacl secretbox**.`,
+For examples, see **step help crypto nacl secretbox**.
+
+## POSITIONAL ARGUMENTS
+
+<nonce>
+:  Must be unique for each distinct message for a given key.
+
+:  To use a binary nonce use the prefix 'base64:' and the standard base64
+encoding. e.g. base64:081D3pFPBkwx1bURR9HQjiYbAUxigo0Z
+
+<key-file>
+:  The path to the shared key.`,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
 				Name:  "raw",
@@ -114,7 +142,11 @@ func secretboxOpenAction(ctx *cli.Context) error {
 	}
 
 	args := ctx.Args()
-	nonce, keyFile := []byte(args[0]), args[1]
+	nonce, err := decodeNonce(args[0])
+	if err != nil {
+		return err
+	}
+	keyFile := args[1]
 
 	if len(nonce) > 24 {
 		return errors.New("nonce cannot be longer than 24 bytes")
@@ -168,7 +200,11 @@ func secretboxSealAction(ctx *cli.Context) error {
 	}
 
 	args := ctx.Args()
-	nonce, keyFile := []byte(args[0]), args[1]
+	nonce, err := decodeNonce(args[0])
+	if err != nil {
+		return err
+	}
+	keyFile := args[1]
 
 	if len(nonce) > 24 {
 		return errors.New("nonce cannot be longer than 24 bytes")


### PR DESCRIPTION
### Description

In nacl box and secretbox operations is hard to use a binary nonce. This change provides the posibility to encode the nonce in base64 if the `base64:` prefix is used.

Fixes #279
