### PR TITLE
Add support for the string: prefix

### DIFF
--- a/command/crypto/nacl/box.go
+++ b/command/crypto/nacl/box.go
@@ -46,8 +46,8 @@ messages are sent to two different public keys.
 By default nonce are alphanumeric, but it's possible to use binary nonces using
 the prefix 'base64:' and the standard base64 encoding of the data, e.g.
 'base64:081D3pFPBkwx1bURR9HQjiYbAUxigo0Z'. The prefix 'string:' is also
-accepted, but it will be equivalent to not using a prefix. Nonces cannot longer
-than 24 bytes.
+accepted, but it will be equivalent to not using a prefix. Nonces cannot be
+longer than 24 bytes.
 
 NaCl crypto_box is not meant to provide non-repudiation. On the contrary: they
 guarantee repudiability. A receiver can freely modify a boxed message, and

--- a/command/crypto/nacl/box.go
+++ b/command/crypto/nacl/box.go
@@ -48,7 +48,6 @@ the prefix 'base64:' and the standard base64 encoding of the data, e.g.
 'base64:081D3pFPBkwx1bURR9HQjiYbAUxigo0Z'. The prefix 'string:' is also
 accepted, but it will be equivalent to not using a prefix. Nonces cannot longer
 than 24 bytes.
-*/
 
 NaCl crypto_box is not meant to provide non-repudiation. On the contrary: they
 guarantee repudiability. A receiver can freely modify a boxed message, and

--- a/command/crypto/nacl/box.go
+++ b/command/crypto/nacl/box.go
@@ -43,6 +43,13 @@ receiver} sets are different. This is true even if the sets overlap. For
 example, a sender can use the same nonce for two different messages if the
 messages are sent to two different public keys.
 
+By default nonce are alphanumeric, but it's possible to use binary nonces using
+the prefix 'base64:' and the standard base64 encoding of the data, e.g.
+'base64:081D3pFPBkwx1bURR9HQjiYbAUxigo0Z'. The prefix 'string:' is also
+accepted, but it will be equivalent to not using a prefix. Nonces cannot longer
+than 24 bytes.
+*/
+
 NaCl crypto_box is not meant to provide non-repudiation. On the contrary: they
 guarantee repudiability. A receiver can freely modify a boxed message, and
 therefore cannot convince third parties that this particular message came from

--- a/command/crypto/nacl/box.go
+++ b/command/crypto/nacl/box.go
@@ -43,7 +43,7 @@ receiver} sets are different. This is true even if the sets overlap. For
 example, a sender can use the same nonce for two different messages if the
 messages are sent to two different public keys.
 
-By default nonce are alphanumeric, but it's possible to use binary nonces using
+By default nonces are alphanumeric, but it's possible to use binary nonces using
 the prefix 'base64:' and the standard base64 encoding of the data, e.g.
 'base64:081D3pFPBkwx1bURR9HQjiYbAUxigo0Z'. The prefix 'string:' is also
 accepted, but it will be equivalent to not using a prefix. Nonces cannot be

--- a/command/crypto/nacl/nacl.go
+++ b/command/crypto/nacl/nacl.go
@@ -49,7 +49,10 @@ var b64Encoder = base64.RawURLEncoding
 // it will decode the rest using the base64 standard encoding.
 func decodeNonce(in string) ([]byte, error) {
 	nonce := []byte(in)
-	if strings.HasPrefix(in, "base64:") {
+	switch {
+	case strings.HasPrefix(in, "string:"):
+		return nonce[7:], nil
+	case strings.HasPrefix(in, "base64:"):
 		input := nonce[7:]
 		nonce = make([]byte, base64.StdEncoding.DecodedLen(len(input)))
 		n, err := base64.StdEncoding.Decode(nonce, input)
@@ -57,6 +60,7 @@ func decodeNonce(in string) ([]byte, error) {
 			return nil, errors.Wrap(err, "error decoding base64 nonce")
 		}
 		return nonce[:n], nil
+	default:
+		return nonce, nil
 	}
-	return nonce, nil
 }

--- a/command/crypto/nacl/secretbox.go
+++ b/command/crypto/nacl/secretbox.go
@@ -32,6 +32,12 @@ uniqueness of nonces—for example, by using nonce 1 for the first message, nonc
 2 for the second message, etc. Nonces are long enough that randomly generated
 nonces have negligible risk of collision.
 
+By default nonce are alphanumeric, but it's possible to use binary nonces using
+the prefix 'base64:' and the standard base64 encoding of the data, e.g.
+'base64:081D3pFPBkwx1bURR9HQjiYbAUxigo0Z'. The prefix 'string:' is also
+accepted, but it will be equivalent to not using a prefix. Nonces cannot longer
+than 24 bytes.
+
 NaCl crypto_secretbox is crypto_secretbox_xsalsa20poly1305, a particular
 combination of Salsa20 and Poly1305 specified in "Cryptography in NaCl". This
 function is conjectured to meet the standard notions of privacy and

--- a/command/crypto/nacl/secretbox.go
+++ b/command/crypto/nacl/secretbox.go
@@ -32,7 +32,7 @@ uniqueness of nonces—for example, by using nonce 1 for the first message, nonc
 2 for the second message, etc. Nonces are long enough that randomly generated
 nonces have negligible risk of collision.
 
-By default nonce are alphanumeric, but it's possible to use binary nonces using
+By default nonces are alphanumeric, but it's possible to use binary nonces using
 the prefix 'base64:' and the standard base64 encoding of the data, e.g.
 'base64:081D3pFPBkwx1bURR9HQjiYbAUxigo0Z'. The prefix 'string:' is also
 accepted, but it will be equivalent to not using a prefix. Nonces cannot be

--- a/command/crypto/nacl/secretbox.go
+++ b/command/crypto/nacl/secretbox.go
@@ -35,8 +35,8 @@ nonces have negligible risk of collision.
 By default nonce are alphanumeric, but it's possible to use binary nonces using
 the prefix 'base64:' and the standard base64 encoding of the data, e.g.
 'base64:081D3pFPBkwx1bURR9HQjiYbAUxigo0Z'. The prefix 'string:' is also
-accepted, but it will be equivalent to not using a prefix. Nonces cannot longer
-than 24 bytes.
+accepted, but it will be equivalent to not using a prefix. Nonces cannot be
+longer than 24 bytes.
 
 NaCl crypto_secretbox is crypto_secretbox_xsalsa20poly1305, a particular
 combination of Salsa20 and Poly1305 specified in "Cryptography in NaCl". This


### PR DESCRIPTION
### Description
This PR adds the `string:` prefix after Mike's suggestion in https://github.com/smallstep/cli/issues/279#issuecomment-624881170

