### PR TITLE
Added support for DN for certificate subjects

### DIFF
--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smallstep/cli/token"
 	"github.com/smallstep/cli/ui"
 	"github.com/smallstep/cli/utils/cautils"
+	"github.com/smallstep/cli/utils/pkiutils"
 	"github.com/urfave/cli"
 )
 
@@ -211,7 +212,8 @@ func certificateAction(ctx *cli.Context) error {
 		if ctx.String("token") != "" && len(sans) > 0 {
 			return errs.MutuallyExclusiveFlags(ctx, "token", "san")
 		}
-		if !strings.EqualFold(subject, req.CsrPEM.Subject.CommonName) {
+		pkixName, _ := pkiutils.ParseSubject(subject)
+		if !strings.EqualFold(pkixName.CommonName, req.CsrPEM.Subject.CommonName) {
 			return errors.Errorf("token subject '%s' and argument '%s' do not match", req.CsrPEM.Subject.CommonName, subject)
 		}
 	case token.OIDC: // Validate that the subject matches an email SAN

--- a/command/ca/sign.go
+++ b/command/ca/sign.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smallstep/cli/token"
 	"github.com/smallstep/cli/ui"
 	"github.com/smallstep/cli/utils/cautils"
+	"github.com/smallstep/cli/utils/pkiutils"
 	"github.com/urfave/cli"
 )
 
@@ -174,7 +175,8 @@ func signCertificateAction(ctx *cli.Context) error {
 		// Common name will be validated on the server side, it depends on
 		// server configuration.
 	default:
-		if !strings.EqualFold(jwt.Payload.Subject, csr.Subject.CommonName) {
+		pkixName, _ := pkiutils.ParseSubject(jwt.Payload.Subject)
+		if !strings.EqualFold(pkixName.CommonName, csr.Subject.CommonName) {
 			return errors.Errorf("token subject '%s' and CSR CommonName '%s' do not match", jwt.Payload.Subject, csr.Subject.CommonName)
 		}
 	}

--- a/crypto/x509util/intermediateProfile.go
+++ b/crypto/x509util/intermediateProfile.go
@@ -5,6 +5,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"time"
+
+	"github.com/smallstep/cli/utils/pkiutils"
 )
 
 // DefaultIntermediateCertValidity is the default validity of a intermediate certificate in the step PKI.
@@ -22,11 +24,12 @@ func (i *Intermediate) DefaultDuration() time.Duration {
 
 // NewIntermediateProfile returns a new intermediate x509 Certificate profile.
 func NewIntermediateProfile(name string, iss *x509.Certificate, issPriv crypto.PrivateKey, withOps ...WithOption) (Profile, error) {
-	sub := defaultIntermediateTemplate(name)
+	pkixName, _ := pkiutils.ParseSubject(name)
+	sub := defaultIntermediateTemplate(pkixName)
 	return newProfile(&Intermediate{}, sub, iss, issPriv, withOps...)
 }
 
-func defaultIntermediateTemplate(name string) *x509.Certificate {
+func defaultIntermediateTemplate(sub pkix.Name) *x509.Certificate {
 	notBefore := time.Now()
 	return &x509.Certificate{
 		IsCA:                  true,
@@ -36,7 +39,7 @@ func defaultIntermediateTemplate(name string) *x509.Certificate {
 		BasicConstraintsValid: true,
 		MaxPathLen:            0,
 		MaxPathLenZero:        true,
-		Issuer:                pkix.Name{CommonName: name},
-		Subject:               pkix.Name{CommonName: name},
+		Issuer:                sub,
+		Subject:               sub,
 	}
 }

--- a/crypto/x509util/leafProfile.go
+++ b/crypto/x509util/leafProfile.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/smallstep/cli/utils/pkiutils"
 )
 
 // Leaf implements the Profile for a leaf certificate.
@@ -27,7 +28,8 @@ func NewLeafProfileWithTemplate(sub *x509.Certificate, iss *x509.Certificate, is
 // A new public/private key pair will be generated for the Profile if
 // not set in the `withOps` profile modifiers.
 func NewLeafProfile(cn string, iss *x509.Certificate, issPriv crypto.PrivateKey, withOps ...WithOption) (Profile, error) {
-	sub := defaultLeafTemplate(pkix.Name{CommonName: cn}, iss.Subject)
+	pkixName, _ := pkiutils.ParseSubject(cn)
+	sub := defaultLeafTemplate(pkixName, iss.Subject)
 	return newProfile(&Leaf{}, sub, iss, issPriv, withOps...)
 }
 
@@ -35,7 +37,8 @@ func NewLeafProfile(cn string, iss *x509.Certificate, issPriv crypto.PrivateKey,
 // A new public/private key pair will be generated for the Profile if
 // not set in the `withOps` profile modifiers.
 func NewSelfSignedLeafProfile(cn string, withOps ...WithOption) (Profile, error) {
-	sub := defaultLeafTemplate(pkix.Name{CommonName: cn}, pkix.Name{CommonName: cn})
+	pkixName, _ := pkiutils.ParseSubject(cn)
+	sub := defaultLeafTemplate(pkixName, pkixName)
 	p, err := newProfile(&Leaf{}, sub, sub, nil, withOps...)
 	if err != nil {
 		return nil, err

--- a/crypto/x509util/rootProfile.go
+++ b/crypto/x509util/rootProfile.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/smallstep/cli/utils/pkiutils"
 )
 
 // DefaultRootCertValidity is the default validity of a root certificate in the step PKI.
@@ -23,7 +24,8 @@ func (r *Root) DefaultDuration() time.Duration {
 
 // NewRootProfile returns a new root x509 Certificate profile.
 func NewRootProfile(name string, withOps ...WithOption) (Profile, error) {
-	crt := defaultRootTemplate(name)
+	pkixName, _ := pkiutils.ParseSubject(name)
+	crt := defaultRootTemplate(pkixName)
 	return NewRootProfileWithTemplate(crt, withOps...)
 }
 
@@ -38,7 +40,7 @@ func NewRootProfileWithTemplate(crt *x509.Certificate, withOps ...WithOption) (P
 	return p, nil
 }
 
-func defaultRootTemplate(cn string) *x509.Certificate {
+func defaultRootTemplate(sub pkix.Name) *x509.Certificate {
 	notBefore := time.Now()
 	return &x509.Certificate{
 		IsCA:                  true,
@@ -48,7 +50,7 @@ func defaultRootTemplate(cn string) *x509.Certificate {
 		BasicConstraintsValid: true,
 		MaxPathLen:            1,
 		MaxPathLenZero:        false,
-		Issuer:                pkix.Name{CommonName: cn},
-		Subject:               pkix.Name{CommonName: cn},
+		Issuer:                sub,
+		Subject:               sub,
 	}
 }

--- a/utils/pkiutils/pkix.go
+++ b/utils/pkiutils/pkix.go
@@ -1,0 +1,62 @@
+package pkiutils
+
+import (
+	"crypto/x509/pkix"
+	"strings"
+)
+
+// ParseSubject takes a subject and converts it into a pkix.Name object.
+//
+// If the subject follows the standard form of a distinguished name such
+// as CN=myhost,O=my company,C=US then it is parsed into individual fields
+// in a pkix.Name object.
+//
+// If it does not match the pattern then the subject is just returned as
+// the CommonName of the pkix.Name object.
+//
+// The following DN fields are supported:
+//    CN: CommonName
+//    OU: OrganizationalUnit
+//     O: Organization
+//     L: Locality
+//    ST: Province (also S, P or SP are allowed)
+//     C: Country
+//
+// If an unknown field is encountered, the entire subject is treated as
+// the CN.
+func ParseSubject(s string) (pkix.Name, bool) {
+	subject := pkix.Name{}
+
+	// assume it's a DN to start (avoiding very complex regex issues)
+	fields := strings.Split(s, ",")
+	isDN := true
+	for _, field := range fields {
+		pair := strings.SplitN(strings.TrimSpace(field), "=", 2)
+		switch pair[0] {
+		case "C":
+			subject.Country = []string{pair[1]}
+		case "ST", "S", "SP", "P":
+			subject.Province = []string{pair[1]}
+		case "L":
+			subject.Locality = []string{pair[1]}
+		case "O":
+			subject.Organization = []string{pair[1]}
+		case "OU":
+			subject.OrganizationalUnit = []string{pair[1]}
+		case "CN":
+			subject.CommonName = pair[1]
+		default:
+			isDN = false // this is not a DN
+		}
+	}
+
+	if !isDN {
+		subject.Country = []string{}
+		subject.Province = []string{}
+		subject.Locality = []string{}
+		subject.Organization = []string{}
+		subject.OrganizationalUnit = []string{}
+		subject.CommonName = s
+	}
+	return subject, isDN
+}


### PR DESCRIPTION
### Description
This code adds support for using DNs for certificate subjects rather than just creating a simple subject with a CN field.

If the subject of a certificate request follows the standard form of a distinguished name, for example, `CN=myhost,OU=my org,O=my copmany,L=New York,ST=New York,C=US`, then the subject is parsed and each field is added to the pkix.Name object used by functions.

If the subject does not match or an unknown field is encountered, the entire subject is treated as the CN as was the previous behavior.

The following DN fields are supported by this PR:
- **CN**: CommonName
- **OU**: OrganizationalUnit
- **O**: Organization
- **L**: Locality
- **ST**: Province (also accepts **S**, **P**, or **SP**)
- **C**: Country

This is pretty standard behavior for certificate subjects.

One other minor change is that according to the CA/B forum, a CN should always be added to the SAN attribute of any leaf certificate or CSR so some minor changes to that behavior are added as well.
