### PR TITLE
add support for TLS Server Name Indication

### DIFF
--- a/command/certificate/fingerprint.go
+++ b/command/certificate/fingerprint.go
@@ -75,6 +75,10 @@ authenticity of the remote server.
 				Usage: `Use an insecure client to retrieve a remote peer certificate. Useful for
 debugging invalid certificates remotely.`,
 			},
+			cli.StringFlag{
+				Name:  "servername",
+				Usage: `TLS Server Name Indication that should be sent to request a specific certificate for validation.`,
+			},
 		},
 	}
 }
@@ -85,17 +89,18 @@ func fingerprintAction(ctx *cli.Context) error {
 	}
 
 	var (
-		certs    []*x509.Certificate
-		roots    = ctx.String("roots")
-		bundle   = ctx.Bool("bundle")
-		insecure = ctx.Bool("insecure")
-		crtFile  = ctx.Args().First()
+		certs      []*x509.Certificate
+		serverName = ctx.String("servername")
+		roots      = ctx.String("roots")
+		bundle     = ctx.Bool("bundle")
+		insecure   = ctx.Bool("insecure")
+		crtFile    = ctx.Args().First()
 	)
 
 	if addr, isURL, err := trimURL(crtFile); err != nil {
 		return err
 	} else if isURL {
-		certs, err = getPeerCertificates(addr, roots, insecure)
+		certs, err = getPeerCertificates(addr, serverName, roots, insecure)
 		if err != nil {
 			return err
 		}

--- a/command/certificate/inspect.go
+++ b/command/certificate/inspect.go
@@ -22,7 +22,7 @@ func inspectCommand() cli.Command {
 		Action: cli.ActionFunc(inspectAction),
 		Usage:  `print certificate or CSR details in human readable format`,
 		UsageText: `**step certificate inspect** <crt_file>
-[**--bundle**] [**--short**] [**--format**=<format>] [**--roots**=<root-bundle>]`,
+[**--bundle**] [**--short**] [**--format**=<format>] [**--roots**=<root-bundle>] [**--servername**=<servername>]`,
 		Description: `**step certificate inspect** prints the details of a certificate
 or CSR in a human readable format. Output from the inspect command is printed to
 STDERR instead of STDOUT unless. This is an intentional barrier to accidental
@@ -172,6 +172,10 @@ if the input bundle includes any PEM that does not have type CERTIFICATE.`,
 				Usage: `Use an insecure client to retrieve a remote peer certificate. Useful for
 debugging invalid certificates remotely.`,
 			},
+			cli.StringFlag{
+				Name:  "servername",
+				Usage: `TLS Server Name Indication that should be sent to request a specific certificate for validation.`,
+			},
 		},
 	}
 }
@@ -182,12 +186,13 @@ func inspectAction(ctx *cli.Context) error {
 	}
 
 	var (
-		crtFile  = ctx.Args().Get(0)
-		bundle   = ctx.Bool("bundle")
-		format   = ctx.String("format")
-		roots    = ctx.String("roots")
-		short    = ctx.Bool("short")
-		insecure = ctx.Bool("insecure")
+		crtFile    = ctx.Args().Get(0)
+		bundle     = ctx.Bool("bundle")
+		format     = ctx.String("format")
+		roots      = ctx.String("roots")
+		serverName = ctx.String("servername")
+		short      = ctx.Bool("short")
+		insecure   = ctx.Bool("insecure")
 	)
 
 	if format != "text" && format != "json" {
@@ -202,7 +207,7 @@ func inspectAction(ctx *cli.Context) error {
 	if addr, isURL, err := trimURL(crtFile); err != nil {
 		return err
 	} else if isURL {
-		peerCertificates, err := getPeerCertificates(addr, roots, insecure)
+		peerCertificates, err := getPeerCertificates(addr, serverName, roots, insecure)
 		if err != nil {
 			return err
 		}

--- a/command/certificate/lint.go
+++ b/command/certificate/lint.go
@@ -18,7 +18,7 @@ func lintCommand() cli.Command {
 		Name:      "lint",
 		Action:    cli.ActionFunc(lintAction),
 		Usage:     `lint certificate details`,
-		UsageText: `**step certificate lint** <crt_file> [**--roots**=<root-bundle>]`,
+		UsageText: `**step certificate lint** <crt_file> [**--roots**=<root-bundle>] [**--servername**=<servername>]`,
 		Description: `**step certificate lint** checks a certificate for common
 errors and outputs the result in JSON format.
 
@@ -84,6 +84,10 @@ authenticity of the remote server.
 				Usage: `Use an insecure client to retrieve a remote peer certificate. Useful for
 debugging invalid certificates remotely.`,
 			},
+			cli.StringFlag{
+				Name:  "servername",
+				Usage: `TLS Server Name Indication that should be sent to request a specific certificate for validation.`,
+			},
 		},
 	}
 }
@@ -94,15 +98,16 @@ func lintAction(ctx *cli.Context) error {
 	}
 
 	var (
-		crtFile  = ctx.Args().Get(0)
-		roots    = ctx.String("roots")
-		insecure = ctx.Bool("insecure")
-		block    *pem.Block
+		crtFile    = ctx.Args().Get(0)
+		roots      = ctx.String("roots")
+		serverName = ctx.String("servername")
+		insecure   = ctx.Bool("insecure")
+		block      *pem.Block
 	)
 	if addr, isURL, err := trimURL(crtFile); err != nil {
 		return err
 	} else if isURL {
-		peerCertificates, err := getPeerCertificates(addr, roots, insecure)
+		peerCertificates, err := getPeerCertificates(addr, serverName, roots, insecure)
 		if err != nil {
 			return err
 		}

--- a/command/certificate/remote.go
+++ b/command/certificate/remote.go
@@ -18,11 +18,12 @@ var urlPrefixes = []string{"https://", "tcp://", "tls://"}
 // If the address does not contain a port then default to port 443.
 //
 // Params
-//   *addr*:     e.g. smallstep.com
-//   *roots*:    a file, a directory, or a comma-separated list of files.
-//   *insecure*: do not verify that the server's certificate has been signed by
-//               a trusted root
-func getPeerCertificates(addr, roots string, insecure bool) ([]*x509.Certificate, error) {
+//   *addr*:       can be a host (e.g. smallstep.com) or an IP (e.g. 127.0.0.1)
+//   *serverName*: use a specific Server Name Indication (e.g. smallstep.com)
+//   *roots*:      a file, a directory, or a comma-separated list of files.
+//   *insecure*:   do not verify that the server's certificate has been signed by
+//                 a trusted root
+func getPeerCertificates(addr, serverName, roots string, insecure bool) ([]*x509.Certificate, error) {
 	var (
 		err     error
 		rootCAs *x509.CertPool
@@ -39,6 +40,9 @@ func getPeerCertificates(addr, roots string, insecure bool) ([]*x509.Certificate
 	tlsConfig := &tls.Config{RootCAs: rootCAs}
 	if insecure {
 		tlsConfig.InsecureSkipVerify = true
+	}
+	if serverName != "" {
+		tlsConfig.ServerName = serverName
 	}
 	conn, err := tls.Dial("tcp", addr, tlsConfig)
 	if err != nil {

--- a/command/certificate/verify.go
+++ b/command/certificate/verify.go
@@ -86,6 +86,10 @@ authenticity of the remote server.
     **directory**
 	:  Relative or full path to a directory. Every PEM encoded certificate from each file in the directory will be used for path validation.`,
 			},
+			cli.StringFlag{
+				Name:  "servername",
+				Usage: `TLS Server Name Indication that should be sent to request a specific certificate for validation.`,
+			},
 		},
 	}
 }
@@ -98,6 +102,7 @@ func verifyAction(ctx *cli.Context) error {
 	var (
 		crtFile          = ctx.Args().Get(0)
 		host             = ctx.String("host")
+		serverName       = ctx.String("servername")
 		roots            = ctx.String("roots")
 		intermediatePool = x509.NewCertPool()
 		rootPool         *x509.CertPool
@@ -107,7 +112,7 @@ func verifyAction(ctx *cli.Context) error {
 	if addr, isURL, err := trimURL(crtFile); err != nil {
 		return err
 	} else if isURL {
-		peerCertificates, err := getPeerCertificates(addr, roots, false)
+		peerCertificates, err := getPeerCertificates(addr, serverName, roots, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Added the ability use TLS Server Name Indication (SNI) to specify
which certificate the server should send. This can be useful when
the server supports multiple certificates or when the DNS doesn't
match the IP address (e.g. in development scenarios) but we still
want certificate validation to be performed.

This option was added to all commands that support a remote fetch
of a peer certificate. These commands include:
  - `fingerprint`
  - `inspect`
  - `lint`
  - `verify`

Fixes #295 
