### PR TITLE
Make step uid and gid configurable with docker arguments

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,10 +12,12 @@ FROM alpine
 
 ENV STEP="/home/step"
 ENV STEPPATH="/home/step"
+ARG STEPUID=1000
+ARG STEPGID=1000
 
 RUN apk add --no-cache bash curl \
-        && addgroup -g 1000 step \
-        && adduser -D -u 1000 -G step step \
+        && addgroup -g ${STEPGID} step \
+        && adduser -D -u ${STEPUID} -G step step \
         && chown step:step /home/step
 
 COPY --from=builder /src/bin/step "/usr/local/bin/step"


### PR DESCRIPTION
### Description
This PR allows to create step-cli containers using custom uid and gid for the step user using docker build's `--build-arg` flags.