### PR TITLE
Fix typo in ssh list command usage

### DIFF
--- a/command/ssh/list.go
+++ b/command/ssh/list.go
@@ -22,7 +22,7 @@ By default it prints key fingerprints, to list the raw key use the flag **--raw*
 
 ## POSITIONAL ARGUMENTS
 
-<ubject>
+<subject>
 :  Optional subject or comment to filter keys by.
 
 ## EXAMPLES


### PR DESCRIPTION
### Description

Fix a simple typo in the `subject` positional argument on the usage page of `step ssh list`