### PR TITLE
Support -sk key types in ssh inspect; refactor inspection code

### DIFF
--- a/crypto/sshutil/inspect.go
+++ b/crypto/sshutil/inspect.go
@@ -1,16 +1,9 @@
 package sshutil
 
 import (
-	"crypto/dsa"
-	"crypto/ecdsa"
-	"crypto/ed25519"
-	"crypto/rsa"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -94,24 +87,11 @@ func (c *CertificateInspect) Validity() string {
 }
 
 func inspectPublicKey(key ssh.PublicKey) (string, string, error) {
-	pub, err := PublicKey(key)
+	fp := ssh.FingerprintSHA256(key)
+	typ, _, err := publicKeyTypeAndSize(key)
 	if err != nil {
 		return "", "", err
 	}
 
-	sum := sha256.Sum256(key.Marshal())
-	fp := "SHA256:" + base64.RawStdEncoding.EncodeToString(sum[:])
-
-	switch k := pub.(type) {
-	case *dsa.PublicKey:
-		return "DSA", fp, nil
-	case *rsa.PublicKey:
-		return "RSA", fp, nil
-	case *ecdsa.PublicKey:
-		return "ECDSA", fp, nil
-	case ed25519.PublicKey:
-		return "ED25519", fp, nil
-	default:
-		return "", "", errors.Errorf("unsupported public key %T", k)
-	}
+	return typ, fp, nil
 }

--- a/crypto/sshutil/sshutil.go
+++ b/crypto/sshutil/sshutil.go
@@ -62,6 +62,26 @@ func PublicKey(key ssh.PublicKey) (crypto.PublicKey, error) {
 	}
 }
 
+// Fingerprint returns the key size, fingerprint, comment and algorithm of a
+// public key.
+func Fingerprint(in []byte) (string, error) {
+	key, comment, _, _, err := ssh.ParseAuthorizedKey(in)
+	if err != nil {
+		return "", errors.Wrap(err, "error parsing public key")
+	}
+	if comment == "" {
+		comment = "no comment"
+	}
+
+	// set typ, size
+	typ, size, err := publicKeyTypeAndSize(key)
+	if err != nil {
+		return "", errors.Wrap(err, "error determining key type and size")
+	}
+
+	return fmt.Sprintf("%d %s %s (%s)", size, ssh.FingerprintSHA256(key), comment, typ), nil
+}
+
 func publicKeyTypeAndSize(key ssh.PublicKey) (string, int, error) {
 	var isCert bool
 	if cert, ok := key.(*ssh.Certificate); ok {
@@ -115,26 +135,6 @@ func publicKeyTypeAndSize(key ssh.PublicKey) (string, int, error) {
 	}
 
 	return typ, size, nil
-}
-
-// Fingerprint returns the key size, fingerprint, comment and algorithm of a
-// public key.
-func Fingerprint(in []byte) (string, error) {
-	key, comment, _, _, err := ssh.ParseAuthorizedKey(in)
-	if err != nil {
-		return "", errors.Wrap(err, "error parsing public key")
-	}
-	if comment == "" {
-		comment = "no comment"
-	}
-
-	// set typ, size
-	typ, size, err := publicKeyTypeAndSize(key)
-	if err != nil {
-		return "", errors.Wrap(err, "error determining key type and size")
-	}
-
-	return fmt.Sprintf("%d %s %s (%s)", size, ssh.FingerprintSHA256(key), comment, typ), nil
 }
 
 func parseString(in []byte) (out, rest []byte, ok bool) {

--- a/crypto/sshutil/sshutil.go
+++ b/crypto/sshutil/sshutil.go
@@ -51,9 +51,9 @@ func PublicKey(key ssh.PublicKey) (crypto.PublicKey, error) {
 	switch key.Type() {
 	case ssh.KeyAlgoRSA:
 		return parseRSA(in)
-	case ssh.KeyAlgoECDSA256, ssh.KeyAlgoECDSA384, ssh.KeyAlgoECDSA521:
+	case ssh.KeyAlgoECDSA256, ssh.KeyAlgoECDSA384, ssh.KeyAlgoECDSA521, ssh.KeyAlgoSKECDSA256:
 		return parseECDSA(in)
-	case ssh.KeyAlgoED25519:
+	case ssh.KeyAlgoED25519, ssh.KeyAlgoSKED25519:
 		return parseED25519(in)
 	case ssh.KeyAlgoDSA:
 		return parseDSA(in)
@@ -62,17 +62,7 @@ func PublicKey(key ssh.PublicKey) (crypto.PublicKey, error) {
 	}
 }
 
-// Fingerprint returns the key size, fingerprint, comment and algorithm of a
-// public key.
-func Fingerprint(in []byte) (string, error) {
-	key, comment, _, _, err := ssh.ParseAuthorizedKey(in)
-	if err != nil {
-		return "", errors.Wrap(err, "error parsing public key")
-	}
-	if comment == "" {
-		comment = "no comment"
-	}
-
+func publicKeyTypeAndSize(key ssh.PublicKey) (string, int, error) {
 	var isCert bool
 	if cert, ok := key.(*ssh.Certificate); ok {
 		key = cert.Key
@@ -88,36 +78,60 @@ func Fingerprint(in []byte) (string, error) {
 		typ, size = "ECDSA", 384
 	case ssh.KeyAlgoECDSA521:
 		typ, size = "ECDSA", 521
+	case ssh.KeyAlgoSKECDSA256:
+		typ, size = "SK-ECDSA", 256
 	case ssh.KeyAlgoED25519:
 		typ, size = "ED25519", 256
+	case ssh.KeyAlgoSKED25519:
+		typ, size = "SK-ED25519", 256
 	case ssh.KeyAlgoRSA:
 		typ = "RSA"
 		_, in, ok := parseString(key.Marshal())
 		if !ok {
-			return "", errors.New("public key is invalid")
+			return "", 0, errors.New("public key is invalid")
 		}
 		k, err := parseRSA(in)
 		if err != nil {
-			return "", err
+			return "", 0, err
 		}
 		size = 8 * k.Size()
 	case ssh.KeyAlgoDSA:
 		typ = "DSA"
 		_, in, ok := parseString(key.Marshal())
 		if !ok {
-			return "", errors.New("public key is invalid")
+			return "", 0, errors.New("public key is invalid")
 		}
 		k, err := parseDSA(in)
 		if err != nil {
-			return "", err
+			return "", 0, err
 		}
 		size = k.Parameters.P.BitLen()
 	default:
-		return "", errors.Errorf("public key %s is not supported", key.Type())
+		return "", 0, errors.Errorf("public key %s is not supported", key.Type())
 	}
 
 	if isCert {
 		typ = typ + "-CERT"
+	}
+
+	return typ, size, nil
+}
+
+// Fingerprint returns the key size, fingerprint, comment and algorithm of a
+// public key.
+func Fingerprint(in []byte) (string, error) {
+	key, comment, _, _, err := ssh.ParseAuthorizedKey(in)
+	if err != nil {
+		return "", errors.Wrap(err, "error parsing public key")
+	}
+	if comment == "" {
+		comment = "no comment"
+	}
+
+	// set typ, size
+	typ, size, err := publicKeyTypeAndSize(key)
+	if err != nil {
+		return "", errors.Wrap(err, "error determining key type and size")
 	}
 
 	return fmt.Sprintf("%d %s %s (%s)", size, ssh.FingerprintSHA256(key), comment, typ), nil

--- a/crypto/sshutil/sshutil.go
+++ b/crypto/sshutil/sshutil.go
@@ -1,7 +1,11 @@
 package sshutil
 
 import (
+	"crypto"
 	"crypto/dsa"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rsa"
 	"encoding/binary"
 	"fmt"
@@ -35,6 +39,27 @@ func ParseCertificate(in []byte) (*ssh.Certificate, error) {
 		return nil, errors.Errorf("error parsing certificate: %T is not a certificate", pub)
 	}
 	return cert, nil
+}
+
+// PublicKey returns the Go's crypto.PublicKey of an ssh.PublicKey.
+func PublicKey(key ssh.PublicKey) (crypto.PublicKey, error) {
+	_, in, ok := parseString(key.Marshal())
+	if !ok {
+		return nil, errors.New("public key is invalid")
+	}
+
+	switch key.Type() {
+	case ssh.KeyAlgoRSA:
+		return parseRSA(in)
+	case ssh.KeyAlgoECDSA256, ssh.KeyAlgoECDSA384, ssh.KeyAlgoECDSA521, ssh.KeyAlgoSKECDSA256:
+		return parseECDSA(in)
+	case ssh.KeyAlgoED25519, ssh.KeyAlgoSKED25519:
+		return parseED25519(in)
+	case ssh.KeyAlgoDSA:
+		return parseDSA(in)
+	default:
+		return nil, errors.Errorf("public key %s is not supported", key.Type())
+	}
 }
 
 func publicKeyTypeAndSize(key ssh.PublicKey) (string, int, error) {
@@ -170,4 +195,50 @@ func parseRSA(in []byte) (*rsa.PublicKey, error) {
 	key.E = int(e)
 	key.N = w.N
 	return &key, nil
+}
+
+// parseECDSA parses an ECDSA key according to RFC 5656, section 3.1.
+func parseECDSA(in []byte) (*ecdsa.PublicKey, error) {
+	var w struct {
+		Curve    string
+		KeyBytes []byte
+		Rest     []byte `ssh:"rest"`
+	}
+
+	if err := ssh.Unmarshal(in, &w); err != nil {
+		return nil, errors.Wrap(err, "error unmarshalling public key")
+	}
+
+	key := new(ecdsa.PublicKey)
+
+	switch w.Curve {
+	case "nistp256":
+		key.Curve = elliptic.P256()
+	case "nistp384":
+		key.Curve = elliptic.P384()
+	case "nistp521":
+		key.Curve = elliptic.P521()
+	default:
+		return nil, errors.Errorf("unsupported curve %s", w.Curve)
+	}
+
+	key.X, key.Y = elliptic.Unmarshal(key.Curve, w.KeyBytes)
+	if key.X == nil || key.Y == nil {
+		return nil, errors.New("invalid curve point")
+	}
+
+	return key, nil
+}
+
+func parseED25519(in []byte) (ed25519.PublicKey, error) {
+	var w struct {
+		KeyBytes []byte
+		Rest     []byte `ssh:"rest"`
+	}
+
+	if err := ssh.Unmarshal(in, &w); err != nil {
+		return nil, errors.Wrap(err, "error unmarshalling public key")
+	}
+
+	return ed25519.PublicKey(w.KeyBytes), nil
 }


### PR DESCRIPTION
I've added support for the new `-sk` key types in `step ssh inspect`. Also was able to refactor the inspection code. Between `crypto/sshutil/inspect.go` and `crypto/sshutil/sshutil.go` there were two ways of determining public key type, size, and fingerprint. Now there's just one.

Here's a cert signed by an SK-ECDSA key to test with:

````
ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgNydgSUva3aquOZKH1YPLmUUsdSfNGT3ip5z3G+U2urYAAAADAQABAAABAQDIQqOkTPD8L2xGTHhv8hrUm8qIvz9eoI2oq72s4hGlcPIPp6kEegma0wV8gAzjd3zT39V9bzwyN471tjG+45yNF1NbJiNQ72rLPwLz0FZ5zJfULZ6coqNYDF30B7URs/pGATHeU/ChcszrD33v2HWAbP1C/YzCLjarqk2NRFJOSLcee88pQeOWaCQhkazFMQG3a8N5nw31S9L5CkIUxp0XavsQONSk1WEbifDOekoheVc0+nfYX7nluZlm0zILsKm6107+rva9gwRWZvF1eRH6omTTF76CNsTT9Ed7HcdlDB+1ItXZiLycXMJ5Uga1dAtGECpWJVNFUWns9xxjD4AxAAAAAAAAAAAAAAABAAAAOHVidW50dUBlYzItMTgtMTkxLTk5LTE0Ny51cy1lYXN0LTIuY29tcHV0ZS5hbWF6b25hd3MuY29tAAAACgAAAAZ1YnVudHUAAAAAXvEssAAAAABg0Q8bAAAAAAAAAIIAAAAVcGVybWl0LVgxMS1mb3J3YXJkaW5nAAAAAAAAABdwZXJtaXQtYWdlbnQtZm9yd2FyZGluZwAAAAAAAAAWcGVybWl0LXBvcnQtZm9yd2FyZGluZwAAAAAAAAAKcGVybWl0LXB0eQAAAAAAAAAOcGVybWl0LXVzZXItcmMAAAAAAAAAAAAAAH8AAAAic2stZWNkc2Etc2hhMi1uaXN0cDI1NkBvcGVuc3NoLmNvbQAAAAhuaXN0cDI1NgAAAEEEj9hseuAR7LEe1TnVF41UAufoEMfx4m0CLwwTnxk5u471p03G6fiQyzUdWfpb6p3CNEu4MBfLoDyI8/W/U8q48gAAAARzc2g6AAAAeAAAACJzay1lY2RzYS1zaGEyLW5pc3RwMjU2QG9wZW5zc2guY29tAAAASQAAACEA/xUwZ/quc1yKYEDMOCfaIja+jRKUEON4ZaRwYiYyDRMAAAAgX3418jk6JrpihXKRgh+yakXsbLFggfZ3qrjWOp4GhUcBAAAABQ== carl-step
````