### PR TITLE
Get docker buildx working on both darwin & linux

### DIFF
--- a/make/docker.mk
+++ b/make/docker.mk
@@ -6,18 +6,32 @@
 # binary is copied to a new image that is optimized for size.
 #########################################
 
+# Testing: output images to out/ with -o out, like this:
+# docker buildx build . --progress plain -t step-cli:master  -f docker/Dockerfile --platform linux/amd64,linux/arm/v7,linux/386,linux/arm64 -o out
+
+ifeq (, $(shell which docker))
+	DOCKER_CLIENT_OS := linux
+else
+	DOCKER_CLIENT_OS := $(strip $(shell docker version -f '{{.Client.Os}}'))
+endif
+
+DOCKER_PLATFORMS = linux/amd64,linux/386,linux/arm,linux/arm64
+DOCKER_IMAGE_NAME = smallstep/step-cli
+
 docker-prepare:
 	# Ensure, we can build for ARM architecture
+ifeq (linux,$(DOCKER_CLIENT_OS))
 	[ -f /proc/sys/fs/binfmt_misc/qemu-arm ] || docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+endif
 
 	# Register buildx builder
 	mkdir -p $$HOME/.docker/cli-plugins
 
-	wget -O $$HOME/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64
-	chmod +x $$HOME/.docker/cli-plugins/docker-buildx
+	docker buildx >/dev/null || \
+		wget -O $$HOME/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.$(DOCKER_CLIENT_OS)-amd64 && \
+		chmod +x $$HOME/.docker/cli-plugins/docker-buildx
 
-	$$HOME/.docker/cli-plugins/docker-buildx create --name mybuilder --platform amd64 --platform arm || true
-	$$HOME/.docker/cli-plugins/docker-buildx use mybuilder
+	docker buildx create --use --name mybuilder --platform="$(DOCKER_PLATFORMS)" || true
 
 .PHONY: docker-prepare
 
@@ -39,13 +53,11 @@ docker-login:
 # Targets for different type of builds
 #################################################
 
-DOCKER_IMAGE_NAME = smallstep/step-cli
-PLATFORMS = --platform amd64 --platform 386 --platform arm --platform arm64
 
 define DOCKER_BUILDX
 	# $(1) -- Image Tag
 	# $(2) -- Push (empty is no push | --push will push to dockerhub)
-	$$HOME/.docker/cli-plugins/docker-buildx build . --progress plain -t $(DOCKER_IMAGE_NAME):$(1) -f docker/Dockerfile $(PLATFORMS) $(2)
+	docker buildx build . --progress plain -t $(DOCKER_IMAGE_NAME):$(1) -f docker/Dockerfile --platform="$(DOCKER_PLATFORMS)" $(2)
 endef
 
 # For non-master builds don't build the docker containers.

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -27,11 +27,11 @@ endif
 	# Register buildx builder
 	mkdir -p $$HOME/.docker/cli-plugins
 
-	docker buildx >/dev/null || \
-		wget -O $$HOME/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.$(DOCKER_CLIENT_OS)-amd64 && \
-		chmod +x $$HOME/.docker/cli-plugins/docker-buildx
+	test -f $$HOME/.docker/cli-plugins/docker-buildx || \
+		(wget -q -O $$HOME/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.$(DOCKER_CLIENT_OS)-amd64 && \
+		chmod +x $$HOME/.docker/cli-plugins/docker-buildx)
 
-	docker buildx create --use --name mybuilder --platform="$(DOCKER_PLATFORMS)" || true
+	$$HOME/.docker/cli-plugins/docker-buildx create --use --name mybuilder --platform="$(DOCKER_PLATFORMS)" || true
 
 .PHONY: docker-prepare
 
@@ -57,7 +57,7 @@ docker-login:
 define DOCKER_BUILDX
 	# $(1) -- Image Tag
 	# $(2) -- Push (empty is no push | --push will push to dockerhub)
-	docker buildx build . --progress plain -t $(DOCKER_IMAGE_NAME):$(1) -f docker/Dockerfile --platform="$(DOCKER_PLATFORMS)" $(2)
+	$$HOME/.docker/cli-plugins/docker-buildx build . --progress plain -t $(DOCKER_IMAGE_NAME):$(1) -f docker/Dockerfile --platform="$(DOCKER_PLATFORMS)" $(2)
 endef
 
 # For non-master builds don't build the docker containers.


### PR DESCRIPTION
This is a parallel update of the Docker makefile to support `buildx` on Darwin, from https://github.com/smallstep/certificates/pull/346
