### PR TITLE
Migrate to GH Discussions tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here's a quick example, combining `step oauth` and `step crypto` to get and veri
 
 ![Animated terminal showing step in practice](https://smallstep.com/images/blog/2018-08-07-unfurl.gif)
 
-**Questions? Find us [on gitter](https://gitter.im/smallstep/community).**
+**Questions? Ask us on [GitHub Discussions](https://github.com/smallstep/certificates/discussions).**
 
 [Website](https://smallstep.com) |
 [Documentation](https://smallstep.com/docs/cli) |
@@ -370,7 +370,7 @@ software and use it to verify the TOTP token:
 
 ## Community
 
-* [Connect with `step` users on Gitter](https://gitter.im/smallstep)
+* [Connect with `step` users on GitHub Discussions](https://github.com/smallstep/certificates/discussions)
 * [Open an issue](https://github.com/smallstep/cli/issues/new/choose) and tell us what features you'd like to see
 * [Follow Smallstep on Twitter](https://twitter.com/smallsteplabs)
 

--- a/command/crypto/nacl/sign.go
+++ b/command/crypto/nacl/sign.go
@@ -24,9 +24,6 @@ func signCommand() cli.Command {
 		Description: `**step crypto nacl sign** command group uses public-key cryptography to sign and
 verify messages. The implementation is based on NaCl's crypto_sign function.
 
-NaCl crypto_sign function is designed to meet the standard notion of
-unforgeability for a public-key signature scheme under chosen-message attacks.
-
 NaCl crypto_sign is crypto_sign_edwards25519sha512batch, a particular
 combination of Curve25519 in Edwards form and SHA-512 into a signature scheme
 suitable for high-speed batch verification. This function is conjectured to meet
@@ -36,7 +33,7 @@ These commands are interoperable with NaCl: https://nacl.cr.yp.to/sign.html
 
 ## EXAMPLES
 
-Create a keypair for verifying amd signing messages:
+Create a keypair for verifying and signing messages:
 '''
 $ step crypto nacl sign keypair nacl.sign.pub nacl.sign.priv
 '''

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -23,8 +23,7 @@ cli` in use (`step version`) and your operating system.
 
 ## Asking Support Questions
 
-Users and developers can ask questions on [Gitter](https://gitter.im/smallstep/community)
-Please don't use the GitHub issue tracker to ask questions.
+Users and developers can ask questions on [GitHub Discussions](https://github.com/smallstep/certificates/discussions).
 
 ## Code Contribution
 

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -126,7 +126,7 @@ This documentation is available online at https://smallstep.com/docs/cli
 
 The **step** utility is not instrumented for usage statistics. It does not phone home.
 But your feedback is extremely valuable. Any information you can provide regarding how you’re using **step** helps.
-Please send us a sentence or two, good or bad: **feedback@smallstep.com** or join https://gitter.im/smallstep/community.
+Please send us a sentence or two, good or bad: **feedback@smallstep.com** or ask in [GitHub Discussions](https://github.com/smallstep/certificates/discussions).
 {{end}}
 `
 


### PR DESCRIPTION
For simplicity we only have Discussions enabled on smallstep/certificates, so I'm linking to that.
