### PR TITLE
Add local part of an email and email as a principals.

### DIFF
--- a/command/ssh/certificate.go
+++ b/command/ssh/certificate.go
@@ -251,7 +251,7 @@ func certificateAction(ctx *cli.Context) error {
 		if isHost {
 			principals = append(principals, subject)
 		} else {
-			principals = append(principals, provisioner.SanitizeSSHUserPrincipal(subject))
+			principals = createPrincipalsFromSubject(subject)
 		}
 	}
 

--- a/command/ssh/login.go
+++ b/command/ssh/login.go
@@ -80,8 +80,7 @@ func loginAction(ctx *cli.Context) error {
 
 	// Arguments
 	subject := ctx.Args().First()
-	user := provisioner.SanitizeSSHUserPrincipal(subject)
-	principals := []string{user}
+	principals := createPrincipalsFromSubject(subject)
 
 	// Flags
 	token := ctx.String("token")

--- a/command/ssh/proxycommand.go
+++ b/command/ssh/proxycommand.go
@@ -129,6 +129,7 @@ func doLoginIfNeeded(ctx *cli.Context, subject string) error {
 		return err
 	}
 
+	// There's not need to sanitize the principal, it should come from ssh.
 	principals := []string{subject}
 
 	// Make sure the validAfter is in the past. It avoids `Certificate

--- a/command/ssh/ssh.go
+++ b/command/ssh/ssh.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/smallstep/certificates/api"
@@ -258,4 +259,20 @@ func debugErr(err error) error {
 		Err: err,
 		Msg: "An error occurred in the step process. Please contact an administrator.",
 	}
+}
+
+// createPrincipalsFromSubject create default principals names for a subject. By
+// default it would be the sanitized version of the subject, but if the subject
+// is an email it will add the local part if it's different and the email
+// address.
+func createPrincipalsFromSubject(subject string) []string {
+	name := provisioner.SanitizeSSHUserPrincipal(subject)
+	principals := []string{name}
+	if i := strings.LastIndex(subject, "@"); i >= 0 {
+		if local := subject[:i]; !strings.EqualFold(local, name) {
+			principals = append(principals, local)
+		}
+		principals = append(principals, subject)
+	}
+	return principals
 }

--- a/go.sum
+++ b/go.sum
@@ -675,6 +675,7 @@ golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 h1:DZhuSZLsGlFL4CmhA8BcRA
 golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de h1:ikNHVSjEfnvz6sxdSPCaPt572qowuyMDMJLLm3Db3ig=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee h1:4yd7jl+vXjalO5ztz6Vc1VADv+S/80LGJmyl1ROJ2AI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=


### PR DESCRIPTION
### Description
For user certificates, if an email is passed as a principal, we will include in the principals list the email, and the local-part. This imitates the behavior for OIDC provisioners on other provisioners like JWK.

On `step ssh certificate` we will only include them if no principals are passed using the `--principal` flag.

Fixes #389