### PR TITLE
Add a `p12` command to create PKCS12 store files

### DIFF
--- a/command/certificate/certificate.go
+++ b/command/certificate/certificate.go
@@ -92,6 +92,7 @@ $ step certificate uninstall root-ca.crt
 			keyCommand(),
 			installCommand(),
 			uninstallCommand(),
+			p12Command(),
 		},
 	}
 

--- a/command/certificate/p12.go
+++ b/command/certificate/p12.go
@@ -1,0 +1,140 @@
+package certificate
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+
+	"github.com/pkg/errors"
+	"github.com/smallstep/cli/command"
+	"github.com/smallstep/cli/crypto/pemutil"
+	"github.com/smallstep/cli/errs"
+	"github.com/smallstep/cli/flags"
+	"github.com/smallstep/cli/ui"
+	"github.com/smallstep/cli/utils"
+	"github.com/urfave/cli"
+
+	"software.sslmate.com/src/go-pkcs12"
+)
+
+func p12Command() cli.Command {
+	return cli.Command{
+		Name:      "p12",
+		Action:    command.ActionFunc(p12Action),
+		Usage:     `package a certificate and keys into a .p12 file`,
+		UsageText: `step certificate p12 <p12_path> [<crt_path>] [<key_path>] [**--ca**=<ca_crt_path>] [**--password**=<password>]`,
+		Description: `**step certificate p12** creates a .p12 (PFX / PKCS12)
+		file containing certificates and keys. This can then be used to import
+		into Windows / Firefox / Java applications.
+
+## EXIT CODES
+
+This command returns 0 on success and \>0 if any error occurs.
+
+## EXAMPLES
+
+Package a certificate and private key together:
+
+'''
+$ step certificate p12 foo.p12 foo.crt foo.key
+'''
+
+Package a certificate and private key together, and include an intermediate certificate:
+
+'''
+$ step certificate p12 foo.p12 foo.crt foo.key --ca intermediate.crt
+'''
+
+Package a CA certificate into a "trust store" for Java applications
+
+'''
+$ step certificate p12 trust.p12 --ca ca.crt
+'''
+`,
+		Flags: []cli.Flag{
+			cli.StringSliceFlag{
+				Name: "ca",
+				Usage: `Add a CA or intermediate certificate to the .p12 file. Use the '--ca'
+flag multiple times to add multiple CAs or intermediates.`,
+			},
+			cli.StringFlag{
+				Name:  "password",
+				Usage: `Set the password to encrypt the .p12 file.`,
+			},
+			flags.Force,
+		},
+	}
+}
+
+func p12Action(ctx *cli.Context) error {
+	if err := errs.MinMaxNumberOfArguments(ctx, 1, 3); err != nil {
+		return err
+	}
+
+	p12File := ctx.Args().Get(0)
+	crtFile := ctx.Args().Get(1)
+	keyFile := ctx.Args().Get(2)
+	caFiles := ctx.StringSlice("ca")
+	password := ctx.String("password")
+	hasKeyAndCert := crtFile != "" && keyFile != ""
+
+	//If either key or cert are provided, both must be provided
+	if !hasKeyAndCert && (crtFile != "" || keyFile != "") {
+		return errs.MissingArguments(ctx, "key_file")
+	}
+
+	//If no key and cert are provided, ca files must be provided
+	if !hasKeyAndCert && len(caFiles) == 0 {
+		return errors.Errorf("flag '--%s' must be provided when no <crt_path> and <key_path> are present", "ca")
+	}
+
+	x509CAs := []*x509.Certificate{}
+	for _, caFile := range caFiles {
+		x509CA, err := pemutil.ReadCertificate(caFile)
+		if err != nil {
+			return errors.Wrap(err, "error reading CA certificate")
+		}
+		x509CAs = append(x509CAs, x509CA)
+	}
+
+	if password == "" {
+		pass, err := ui.PromptPassword("Please enter a password to encrypt the .p12 file")
+		if err != nil {
+			return errors.Wrap(err, "error reading password")
+		}
+		password = string(pass)
+	}
+
+	var pkcs12Data []byte
+	var err error
+
+	if hasKeyAndCert {
+		//If we have a key and certificate, we're making an identity store
+		x509Cert, err := pemutil.ReadCertificate(crtFile)
+		if err != nil {
+			return errors.Wrap(err, "error reading certificate")
+		}
+
+		key, err := pemutil.Read(keyFile)
+		if err != nil {
+			return errors.Wrap(err, "error reading key")
+		}
+
+		pkcs12Data, err = pkcs12.Encode(rand.Reader, key, x509Cert, x509CAs, password)
+		if err != nil {
+			return errs.Wrap(err, "failed to encode PKCS12 data")
+		}
+	} else {
+		//If we have only --ca flags, we're making a trust store
+		pkcs12Data, err = pkcs12.EncodeTrustStore(rand.Reader, x509CAs, password)
+		if err != nil {
+			return errs.Wrap(err, "failed to encode PKCS12 data")
+		}
+	}
+
+	if err := utils.WriteFile(p12File, pkcs12Data, 0600); err != nil {
+		return err
+	}
+
+	ui.Printf("Your .p12 bundle has been saved as %s.\n", p12File)
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e
 	gopkg.in/square/go-jose.v2 v2.5.1
+	software.sslmate.com/src/go-pkcs12 v0.0.0-20200830195227-52f69702a001
 )
 
 // replace github.com/smallstep/certificates => ../certificates

--- a/go.sum
+++ b/go.sum
@@ -908,6 +908,8 @@ mvdan.cc/unparam v0.0.0-20191111180625-960b1ec0f2c2/go.mod h1:rCqoQrfAmpTX/h2APc
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+software.sslmate.com/src/go-pkcs12 v0.0.0-20200830195227-52f69702a001 h1:AVd6O+azYjVQYW1l55IqkbL8/JxjrLtO6q4FCmV8N5c=
+software.sslmate.com/src/go-pkcs12 v0.0.0-20200830195227-52f69702a001/go.mod h1:/xvNRWUqm0+/ZMiF4EX00vrSCMsE4/NHb+Pt3freEeQ=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4 h1:JPJh2pk3+X4lXAkZIk2RuE/7/FoK9maXw+TNPJhVS/c=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
 sourcegraph.com/sqs/pbtypes v1.0.0 h1:f7lAwqviDEGvON4kRv0o5V7FT/IQK+tbkF664XMbP3o=


### PR DESCRIPTION
### Description
This PR adds a `step certificate p12` subcommand to support bundling keys and certificates together into PKCS12 / p12 / pfx files, as discussed in #244 

These are commonly used for installing client certificates into Firefox / Windows, and for configuring server certificates for Java applications.

The arguments / options are an attempt at being easy to use, without forcing the user to understand all the different types of p12 that exist.

A password is specifiable on the CLI as one is required for .p12, but is a bit pointless as the encryption is weak. The author of the upstream library this PR uses suggests using a nominal password then protecting the result file using a stronger external method:
https://github.com/SSLMate/go-pkcs12/blob/master/pkcs12.go#L33