### PR TITLE
Allow to configure the identity argument in defaults.json

### DIFF
--- a/command/ssh/login.go
+++ b/command/ssh/login.go
@@ -58,6 +58,7 @@ $ step ssh login --not-after 1h joe@smallstep.com
 		Flags: []cli.Flag{
 			flags.Token,
 			sshAddUserFlag,
+			flags.Identity,
 			flags.Provisioner,
 			flags.ProvisionerPasswordFileWithAlias,
 			flags.NotBefore,
@@ -74,12 +75,17 @@ $ step ssh login --not-after 1h joe@smallstep.com
 }
 
 func loginAction(ctx *cli.Context) error {
-	if err := errs.NumberOfArguments(ctx, 1); err != nil {
+	if err := errs.MinMaxNumberOfArguments(ctx, 0, 1); err != nil {
 		return err
 	}
 
 	// Arguments
 	subject := ctx.Args().First()
+	if subject == "" {
+		if subject = ctx.String("identity"); subject == "" {
+			return errs.TooFewArguments(ctx)
+		}
+	}
 	principals := createPrincipalsFromSubject(subject)
 
 	// Flags

--- a/command/ssh/logout.go
+++ b/command/ssh/logout.go
@@ -57,6 +57,7 @@ $ step ssh logout --all
 				Name:  "all",
 				Usage: "Removes all the keys stored in the SSH agent.",
 			},
+			flags.Identity,
 			flags.CaURL,
 			flags.Root,
 			flags.Offline,
@@ -70,11 +71,13 @@ func logoutAction(ctx *cli.Context) error {
 		return err
 	}
 
-	subject := ctx.Args().First()
-
 	all := ctx.Bool("all")
-	if ctx.NArg() == 0 && !all {
-		return errs.TooFewArguments(ctx)
+	subject := ctx.Args().First()
+	if subject == "" {
+		subject = ctx.String("identity")
+		if subject == "" && !all {
+			return errs.TooFewArguments(ctx)
+		}
 	}
 
 	agent, err := sshutil.DialAgent()

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -269,6 +269,14 @@ the **--team** option. If the url contains <\<\>> placeholders, they are replace
 		Name:  "set-file",
 		Usage: "The <path> of a JSON file with the template data to send to the CA.",
 	}
+
+	// Identity is a cli.Flag used to be able to define the identity argument in
+	// defaults.json.
+	Identity = cli.StringFlag{
+		Name: "identity",
+		Usage: `The certificate identity. It is usually passed as a positional argument, but a
+flag exists so it can be configured in $STEPPATH/config/defaults.json.`,
+	}
 )
 
 // ParseTimeOrDuration is a helper that returns the time or the current time


### PR DESCRIPTION
### Description

This change adds the flags --identity=value to `step ssh login` and `step ssh logout` so we don't need to pass an extra argument if the identity is set in defaults.json or as an environment variable.

Fixes #369
