### PR TITLE
Add support for cloud CAS in step ca init.

### DIFF
--- a/cmd/step/main.go
+++ b/cmd/step/main.go
@@ -29,6 +29,10 @@ import (
 	_ "github.com/smallstep/cli/command/path"
 	_ "github.com/smallstep/cli/command/ssh"
 
+	// Enabled cas interfaces.
+	_ "github.com/smallstep/certificates/cas/cloudcas"
+	_ "github.com/smallstep/certificates/cas/softcas"
+
 	// Profiling and debugging
 	_ "net/http/pprof"
 )

--- a/command/ca/init.go
+++ b/command/ca/init.go
@@ -175,17 +175,9 @@ func initAction(ctx *cli.Context) (err error) {
 		if err != nil {
 			return err
 		}
-		file := ctx.String("credentials-file")
-		if !ctx.IsSet("credentials-file") {
-			file, err = ui.Prompt("What credentials file would you like to use? [leave empty if using a service account]",
-				ui.WithValue(ctx.String("credentials-file")))
-			if err != nil {
-				return err
-			}
-		}
 		p.SetAuthorityOptions(&apiv1.Options{
 			Type:                 ctx.String("ra"),
-			CredentialsFile:      file,
+			CredentialsFile:      ctx.String("credentials-file"),
 			CertificateAuthority: iss,
 		})
 	}

--- a/command/ca/init.go
+++ b/command/ca/init.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/smallstep/certificates/cas/apiv1"
 	"github.com/smallstep/certificates/pki"
 	"github.com/smallstep/cli/command"
 	"github.com/smallstep/cli/crypto/pemutil"
@@ -75,6 +76,27 @@ func initCommand() cli.Command {
 				Name:  "with-ca-url",
 				Usage: `<URI> of the Step Certificate Authority to write in defaults.json`,
 			},
+			cli.StringFlag{
+				Name:  "ra",
+				Usage: `The registration authority <name> to use. Currently only "CloudCAS" is supported.`,
+			},
+			cli.StringFlag{
+				Name: "issuer",
+				Usage: `The registration authority issuer <name> to use.
+
+: If CloudCAS is used, this flag should be the resource name of the
+intermediate certificate to use. This has the format
+'projects/\\*/locations/\\*/certificateAuthorities/\\*'.`,
+			},
+			cli.StringFlag{
+				Name: "credentials-file",
+				Usage: `The registration authority credentials <file> to use.
+
+: If CloudCAS is used, this flag should be the path to a service account key.
+It can also be set using the 'GOOGLE_APPLICATION_CREDENTIALS=path'
+environment variable or the default service account in an instance in Google
+Cloud.`,
+			},
 			cli.BoolFlag{
 				Name:  "no-db",
 				Usage: `Generate a CA configuration without the DB stanza. No persistence layer.`,
@@ -94,6 +116,7 @@ func initAction(ctx *cli.Context) (err error) {
 	caURL := ctx.String("with-ca-url")
 	root := ctx.String("root")
 	key := ctx.String("key")
+	ra := strings.ToLower(ctx.String("ra"))
 	switch {
 	case len(root) > 0 && len(key) == 0:
 		return errs.RequiredWithFlag(ctx, "root", "key")
@@ -106,6 +129,8 @@ func initAction(ctx *cli.Context) (err error) {
 		if rootKey, err = pemutil.Read(key); err != nil {
 			return err
 		}
+	case ra != "" && ra != apiv1.CloudCAS:
+		return errs.InvalidFlagValue(ctx, "ra", ctx.String("ra"), "CloudCAS")
 	}
 
 	configure := !ctx.Bool("pki")
@@ -137,10 +162,29 @@ func initAction(ctx *cli.Context) (err error) {
 		return err
 	}
 
-	name, err := ui.Prompt("What would you like to name your new PKI? (e.g. Smallstep)",
-		ui.WithValidateNotEmpty(), ui.WithValue(ctx.String("name")))
-	if err != nil {
-		return err
+	var name string
+	if ra == "" {
+		name, err = ui.Prompt("What would you like to name your new PKI? (e.g. Smallstep)",
+			ui.WithValidateNotEmpty(), ui.WithValue(ctx.String("name")))
+		if err != nil {
+			return err
+		}
+	} else {
+		iss, err := ui.Prompt("What certificate authority would you like to use? (e.g. projects/ca/locations/us-west1/certificateAuthorities/intermediate-ca)",
+			ui.WithValidateNotEmpty(), ui.WithValue(ctx.String("issuer")))
+		if err != nil {
+			return err
+		}
+		file, err := ui.Prompt("What credentials file would you like to use? [leave empty if using a service account]",
+			ui.WithValue(ctx.String("credentials-file")))
+		if err != nil {
+			return err
+		}
+		p.SetAuthorityOptions(&apiv1.Options{
+			Type:                 ctx.String("ra"),
+			CredentialsFile:      file,
+			CertificateAuthority: iss,
+		})
 	}
 
 	if configure {
@@ -199,32 +243,40 @@ func initAction(ctx *cli.Context) (err error) {
 		}
 	}
 
-	// Generate root certificate if not set.
-	if rootCrt == nil && rootKey == nil {
-		fmt.Println()
-		fmt.Print("Generating root certificate... \n")
+	if ra == "" {
+		// Generate root certificate if not set.
+		if rootCrt == nil && rootKey == nil {
+			fmt.Println()
+			fmt.Print("Generating root certificate... \n")
 
-		rootCrt, rootKey, err = p.GenerateRootCertificate(name+" Root CA", pass)
+			rootCrt, rootKey, err = p.GenerateRootCertificate(name+" Root CA", pass)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println("all done!")
+		} else {
+			fmt.Println()
+			fmt.Print("Copying root certificate... \n")
+			// Do not copy key in STEPPATH
+			if err = p.WriteRootCertificate(rootCrt, nil, nil); err != nil {
+				return err
+			}
+			fmt.Println("all done!")
+		}
+
+		fmt.Println()
+		fmt.Print("Generating intermediate certificate... \n")
+
+		err = p.GenerateIntermediateCertificate(name+" Intermediate CA", rootCrt, rootKey, pass)
 		if err != nil {
 			return err
 		}
-
-		fmt.Println("all done!")
 	} else {
-		fmt.Println()
-		fmt.Print("Copying root certificate... \n")
-		if err = p.WriteRootCertificate(rootCrt, rootKey, pass); err != nil {
+		// Attempt to get the root certificate from RA.
+		if err := p.GetCertificateAuthority(); err != nil {
 			return err
 		}
-		fmt.Println("all done!")
-	}
-
-	fmt.Println()
-	fmt.Print("Generating intermediate certificate... \n")
-
-	err = p.GenerateIntermediateCertificate(name+" Intermediate CA", rootCrt, rootKey, pass)
-	if err != nil {
-		return err
 	}
 
 	if ctx.Bool("ssh") {

--- a/command/ca/init.go
+++ b/command/ca/init.go
@@ -175,10 +175,13 @@ func initAction(ctx *cli.Context) (err error) {
 		if err != nil {
 			return err
 		}
-		file, err := ui.Prompt("What credentials file would you like to use? [leave empty if using a service account]",
-			ui.WithValue(ctx.String("credentials-file")))
-		if err != nil {
-			return err
+		file := ctx.String("credentials-file")
+		if !ctx.IsSet("credentials-file") {
+			file, err = ui.Prompt("What credentials file would you like to use? [leave empty if using a service account]",
+				ui.WithValue(ctx.String("credentials-file")))
+			if err != nil {
+				return err
+			}
 		}
 		p.SetAuthorityOptions(&apiv1.Options{
 			Type:                 ctx.String("ra"),

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/samfoo/ansi v0.0.0-20160124022901-b6bd2ded7189
 	github.com/shurcooL/sanitized_anchor_name v1.0.0
 	github.com/smallstep/assert v0.0.0-20200723003110-82e2b9b3b262
-	github.com/smallstep/certificates v0.16.0-rc.1.0.20201016001420-683823341609
+	github.com/smallstep/certificates v0.16.0-rc.1.0.20201020015530-341dc1c3ea9a
 	github.com/smallstep/certinfo v1.4.0
 	github.com/smallstep/truststore v0.9.6
 	github.com/smallstep/zcrypto v0.0.0-20200203191936-fbc32cf76bce

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/samfoo/ansi v0.0.0-20160124022901-b6bd2ded7189
 	github.com/shurcooL/sanitized_anchor_name v1.0.0
 	github.com/smallstep/assert v0.0.0-20200723003110-82e2b9b3b262
-	github.com/smallstep/certificates v0.16.0-rc.1.0.20201020015530-341dc1c3ea9a
+	github.com/smallstep/certificates v0.16.0-rc.1.0.20201021010023-426f8469741e
 	github.com/smallstep/certinfo v1.4.0
 	github.com/smallstep/truststore v0.9.6
 	github.com/smallstep/zcrypto v0.0.0-20200203191936-fbc32cf76bce

--- a/go.sum
+++ b/go.sum
@@ -591,6 +591,8 @@ github.com/smallstep/certificates v0.16.0-rc.1.0.20201016001420-683823341609 h1:
 github.com/smallstep/certificates v0.16.0-rc.1.0.20201016001420-683823341609/go.mod h1:aO+CoC3RnGZIiOKdrwH1+mTo1f1EhQYUa6IHsMyXwpU=
 github.com/smallstep/certificates v0.16.0-rc.1.0.20201020015530-341dc1c3ea9a h1:QRgcgG4efWnU3z/5/hUU5ewAW/LXlan5HL8sdHa6aKg=
 github.com/smallstep/certificates v0.16.0-rc.1.0.20201020015530-341dc1c3ea9a/go.mod h1:aO+CoC3RnGZIiOKdrwH1+mTo1f1EhQYUa6IHsMyXwpU=
+github.com/smallstep/certificates v0.16.0-rc.1.0.20201021010023-426f8469741e h1:YBVAue/8c14Z0sITD/+Dwdfh1csz02LhFlddi1rx0hM=
+github.com/smallstep/certificates v0.16.0-rc.1.0.20201021010023-426f8469741e/go.mod h1:aO+CoC3RnGZIiOKdrwH1+mTo1f1EhQYUa6IHsMyXwpU=
 github.com/smallstep/certinfo v1.3.0 h1:DAW0OxOdVIdAgsF/JN5Ro4ZApnTVfYqfaNYK7u5/obg=
 github.com/smallstep/certinfo v1.3.0/go.mod h1:1gQJekdPwPvUwFWGTi7bZELmQT09cxC9wJ0VBkBNiwU=
 github.com/smallstep/certinfo v1.4.0 h1:NhR0qJ8jvfqBUI0NmOn1KF9Hka7I1dcRHgqW4/t2FRY=
@@ -1063,6 +1065,7 @@ google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.32.0 h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=
 google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.0 h1:IBKSUNL2uBS2DkJBncPP+TwT0sp9tgA8A75NjHt6umg=
+google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
 google.golang.org/grpc/examples v0.0.0-20201013205100-7745e521ff61 h1:zcMNuFDCTmXQYnkqX89N6cyPbwWyj7ZN3ERf4k5Knp4=
 google.golang.org/grpc/examples v0.0.0-20201013205100-7745e521ff61/go.mod h1:Lh55/1hxmVHEkOvSIQ2uj0P12QyOCUNyRwnUlSS13hw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/go.sum
+++ b/go.sum
@@ -589,6 +589,8 @@ github.com/smallstep/certificates v0.16.0-rc.1.0.20201014015345-6a7b564ef94f h1:
 github.com/smallstep/certificates v0.16.0-rc.1.0.20201014015345-6a7b564ef94f/go.mod h1:aO+CoC3RnGZIiOKdrwH1+mTo1f1EhQYUa6IHsMyXwpU=
 github.com/smallstep/certificates v0.16.0-rc.1.0.20201016001420-683823341609 h1:KHsK6VgrbRXF2WGpKhaxN4TJNxFqTLPEHdE703WqnuM=
 github.com/smallstep/certificates v0.16.0-rc.1.0.20201016001420-683823341609/go.mod h1:aO+CoC3RnGZIiOKdrwH1+mTo1f1EhQYUa6IHsMyXwpU=
+github.com/smallstep/certificates v0.16.0-rc.1.0.20201020015530-341dc1c3ea9a h1:QRgcgG4efWnU3z/5/hUU5ewAW/LXlan5HL8sdHa6aKg=
+github.com/smallstep/certificates v0.16.0-rc.1.0.20201020015530-341dc1c3ea9a/go.mod h1:aO+CoC3RnGZIiOKdrwH1+mTo1f1EhQYUa6IHsMyXwpU=
 github.com/smallstep/certinfo v1.3.0 h1:DAW0OxOdVIdAgsF/JN5Ro4ZApnTVfYqfaNYK7u5/obg=
 github.com/smallstep/certinfo v1.3.0/go.mod h1:1gQJekdPwPvUwFWGTi7bZELmQT09cxC9wJ0VBkBNiwU=
 github.com/smallstep/certinfo v1.4.0 h1:NhR0qJ8jvfqBUI0NmOn1KF9Hka7I1dcRHgqW4/t2FRY=


### PR DESCRIPTION
### Description
This PR adds support for CloudCAS in step ca init.

Now it's possible to start the ca.json configuration running `step ca init --ra cloudCAS`. The intermediate resource can be passed with the flag `--issuer` and the optional credentials file with `--credentials-file`.

Requires https://github.com/smallstep/certificates/pull/402