### PR TITLE
Provisioner password flags

### DIFF
--- a/command/ca/ca.go
+++ b/command/ca/ca.go
@@ -149,12 +149,6 @@ challenge validation requests.`,
 		Usage: "The provisioner <kid> to use.",
 	}
 
-	passwordFileFlag = cli.StringFlag{
-		Name: "password-file",
-		Usage: `The path to the <file> containing the password to decrypt the one-time token
-generating key.`,
-	}
-
 	sshHostFlag = cli.BoolFlag{
 		Name:  "host",
 		Usage: `Create a host certificate instead of a user certificate.`,

--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -148,12 +148,7 @@ multiple SANs. The '--san' flag and the '--token' flag are mutually exclusive.`,
 			flags.Root,
 			flags.Token,
 			flags.Provisioner,
-			cli.StringFlag{
-				Name: "provisioner-password-file",
-				Usage: `The path to the <file> containing the password to decrypt the one-time token
-				generating key.`,
-			},
-			flags.PasswordFile,
+			flags.ProvisionerPasswordFile,
 			flags.KTY,
 			flags.Curve,
 			flags.Size,
@@ -186,17 +181,12 @@ func certificateAction(ctx *cli.Context) error {
 	tok := ctx.String("token")
 	offline := ctx.Bool("offline")
 	sans := ctx.StringSlice("san")
-	provisionerPasswordFile := ctx.String("provisioner-password-file")
 
 	// offline and token are incompatible because the token is generated before
 	// the start of the offline CA.
 	if offline && len(tok) != 0 {
 		return errs.IncompatibleFlagWithFlag(ctx, "offline", "token")
 	}
-
-	// Hack to make the flag "password-file" the content of
-	// "provisioner-password-file" so the token command works as expected
-	ctx.Set("password-file", provisionerPasswordFile)
 
 	// certificate flow unifies online and offline flows on a single api
 	flow, err := cautils.NewCertificateFlow(ctx)

--- a/command/ca/sign.go
+++ b/command/ca/sign.go
@@ -22,8 +22,9 @@ func signCertificateCommand() cli.Command {
 		Action: command.ActionFunc(signCertificateAction),
 		Usage:  "generate a new certificate signing a certificate request",
 		UsageText: `**step ca sign** <csr-file> <crt-file>
-[**--token**=<token>] [**--issuer**=<name>] [**--ca-url**=<uri>] [**--root**=<path>]
+[**--token**=<token>] [**--issuer**=<name>] [**--provisioner-password-file=<file>]
 [**--not-before**=<time|duration>] [**--not-after**=<time|duration>]
+[**--ca-url**=<uri>] [**--root**=<path>]
 [**--set**=<key=value>] [**--set-file**=<path>]
 [**--acme**=<uri>] [**--standalone**] [**--webroot**=<path>]
 [**--contact**=<email>] [**--http-listen**=<address>] [**--console**]
@@ -112,6 +113,7 @@ $ step ca sign foo.csr foo.crt \
 			flags.Root,
 			flags.Token,
 			flags.Provisioner,
+			flags.ProvisionerPasswordFile,
 			flags.NotBefore,
 			flags.NotAfter,
 			flags.TemplateSet,

--- a/command/ca/token.go
+++ b/command/ca/token.go
@@ -141,7 +141,6 @@ $ step ca token my-remote.hostname remote_ecdsa --ssh --host
 		Flags: []cli.Flag{
 			certNotAfterFlag,
 			certNotBeforeFlag,
-			passwordFileFlag,
 			provisionerKidFlag,
 			cli.StringSliceFlag{
 				Name: "san",
@@ -166,6 +165,7 @@ multiple principals.`,
 			flags.Offline,
 			flags.Root,
 			flags.Provisioner,
+			flags.ProvisionerPasswordFileWithAlias,
 			flags.X5cCert,
 			flags.X5cKey,
 			flags.SSHPOPCert,

--- a/utils/cautils/token_flow.go
+++ b/utils/cautils/token_flow.go
@@ -113,6 +113,8 @@ func NewTokenFlow(ctx *cli.Context, tokType int, subject string, sans []string, 
 	}
 
 	switch p := p.(type) {
+	case *provisioner.JWK: // Get the step standard JWT.
+		return generateJWKToken(ctx, p, tokType, tokAttrs)
 	case *provisioner.OIDC: // Run step oauth.
 		return generateOIDCToken(ctx, p)
 	case *provisioner.X5C: // Get a JWT with an X5C header and signature.
@@ -132,12 +134,8 @@ func NewTokenFlow(ctx *cli.Context, tokType int, subject string, sans []string, 
 		return p.GetIdentityToken(subject, caURL)
 	case *provisioner.ACME: // Return an error with the provisioner ID.
 		return "", &ErrACMEToken{p.GetName()}
-	default: // Default is assumed to be a standard JWT.
-		jwkP, ok := p.(*provisioner.JWK)
-		if !ok {
-			return "", errors.Errorf("unknown provisioner type %T", p)
-		}
-		return generateJWKToken(ctx, jwkP, tokType, tokAttrs)
+	default:
+		return "", errors.Errorf("unknown provisioner type %T", p)
 	}
 }
 

--- a/utils/cautils/token_generator.go
+++ b/utils/cautils/token_generator.go
@@ -236,8 +236,11 @@ func generateSSHPOPToken(ctx *cli.Context, p *provisioner.SSHPOP, tokType int, t
 //    b) Online-mode: get the provisioner private key from the CA.
 func loadJWK(ctx *cli.Context, p *provisioner.JWK, tokAttrs tokenAttrs) (jwk *jose.JSONWebKey, kid string, err error) {
 	var opts []jose.Option
-	if passwordFile := ctx.String("password-file"); len(passwordFile) != 0 {
-		opts = append(opts, jose.WithPasswordFile(passwordFile))
+	switch {
+	case ctx.String("provisioner-password-file") != "":
+		opts = append(opts, jose.WithPasswordFile(ctx.String("provisioner-password-file")))
+	case ctx.String("password-file") != "":
+		opts = append(opts, jose.WithPasswordFile(ctx.String("password-file")))
 	}
 
 	if keyFile := ctx.String("key"); len(keyFile) == 0 {


### PR DESCRIPTION
### Description

This PR adds support for `--provisioner-password-flag` in `step ca sign`. It also adds that alias to `step ca token`.

Note that I also removed `--password-file` in `step ca certificate`; it was there just because it was a hack to allow its use. I didn't add it as an alias if we want to reuse it for encrypting the generated key.

Fixes #378