### PR TITLE
Allow configuration of browser used for OAuth on macOS.

### DIFF
--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -199,6 +199,11 @@ $ step oauth --client-id my-client-id --client-secret my-client-secret \
 				Usage:  "Allows the use of insecure flows.",
 				Hidden: true,
 			},
+			cli.StringFlag{
+				Name:   "browser",
+				Usage:  "Path to browser that to use for OAuth flow (macOS only).",
+				Hidden: true,
+			},
 			flags.RedirectURL,
 		},
 		Action: oauthCmd,
@@ -215,6 +220,7 @@ func oauthCmd(c *cli.Context) error {
 		Implicit:         c.Bool("implicit"),
 		CallbackListener: c.String("listen"),
 		TerminalRedirect: c.String("redirect-url"),
+		Browser:          c.String("browser"),
 	}
 	if err := opts.Validate(); err != nil {
 		return err
@@ -343,6 +349,7 @@ type options struct {
 	Implicit         bool
 	CallbackListener string
 	TerminalRedirect string
+	Browser          string
 }
 
 // Validate validates the options.
@@ -374,6 +381,7 @@ type oauth struct {
 	implicit         bool
 	CallbackListener string
 	terminalRedirect string
+	browser          string
 	errCh            chan error
 	tokCh            chan *token
 }
@@ -411,6 +419,7 @@ func newOauth(provider, clientID, clientSecret, authzEp, tokenEp, scope string, 
 			implicit:         opts.Implicit,
 			CallbackListener: opts.CallbackListener,
 			terminalRedirect: opts.TerminalRedirect,
+			browser:          opts.Browser,
 			errCh:            make(chan error),
 			tokCh:            make(chan *token),
 		}, nil
@@ -447,6 +456,7 @@ func newOauth(provider, clientID, clientSecret, authzEp, tokenEp, scope string, 
 			implicit:         opts.Implicit,
 			CallbackListener: opts.CallbackListener,
 			terminalRedirect: opts.TerminalRedirect,
+			browser:          opts.Browser,
 			errCh:            make(chan error),
 			tokCh:            make(chan *token),
 		}, nil
@@ -531,7 +541,7 @@ func (o *oauth) DoLoopbackAuthorization() (*token, error) {
 		return nil, err
 	}
 
-	if err := exec.OpenInBrowser(authURL); err != nil {
+	if err := exec.OpenInBrowser(authURL, o.browser); err != nil {
 		fmt.Fprintln(os.Stderr, "Cannot open a web browser on your platform.")
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "Open a local web browser and visit:")

--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -201,7 +201,7 @@ $ step oauth --client-id my-client-id --client-secret my-client-secret \
 			},
 			cli.StringFlag{
 				Name:   "browser",
-				Usage:  "Path to browser that to use for OAuth flow (macOS only).",
+				Usage:  "Path to browser for OAuth flow (macOS only).",
 				Hidden: true,
 			},
 			flags.RedirectURL,

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -100,11 +100,15 @@ func RunWithPid(pidFile, name string, arg ...string) {
 }
 
 // OpenInBrowser opens the given url on a web browser
-func OpenInBrowser(url string) error {
+func OpenInBrowser(url string, browser string) error {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
-		cmd = exec.Command("open", url)
+		if browser == "" {
+			cmd = exec.Command("open", url)
+		} else {
+			cmd = exec.Command("open", "-a", browser, url)
+		}
 	case "linux":
 		if IsWSL() {
 			cmd = exec.Command("rundll32.exe", "url.dll,FileProtocolHandler", url)


### PR DESCRIPTION
### Description
Allow users to specify which browser is used for OAuth flows. This is only implemented for macOS for now. The tool we're using on Linux (`xdg-open`) doesn't seem to have any simple way to set which browser is used (it always uses your system's default browser). It may be possible to extend this to Windows, but I haven't looked yet. For now I've made this a hidden option since it seems pretty niche and it's not documented, etc.

To configure which browser is used you can pass the `--browser /Path/To/Browser.app` flag into `step oauth`. For other subcommands that depend on `step oauth`, like `step ssh proxycommand` and `step ca certificate`, you can set the `STEP_BROWSER=/Path/To/Browser.app` environment variable or set `"browser": "/Path/To/Browser.app"` in your `defaults.json` (which is normally at `~/.step/config/defaults.json`).

Known issue: if you set the path to something invalid (e.g., `STEP_BROWSER=not-a-browser step oauth`), `step oauth` will fail silently. We should probably fix this before un-hiding this flag (if we ever un-hide it).