### PR TITLE
Add no-password to step certificate p12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
           cp ./output/binary/windows/bin/step ./.releases/step-windows-${{ needs.create_release.outputs.version }}.exe
       - name: Upload s3
         id: upload-s3
-        uses: jakejarvis/s3-sync-action@be0c4ab # v0.5.1
+        uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --acl public-read --follow-symlinks
         env:
@@ -152,7 +152,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Download Existing Installer
         id: download
-        uses: prewk/s3-cp-action@667b442 # v0.1.1
+        uses: prewk/s3-cp-action@v0.1.1
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -164,7 +164,7 @@ jobs:
         run: sed -i -e "s~step-windows-.*.exe~step-windows-foo.exe~g" ./install-step.ps1
       - name: Upload and Overwrite
         id: upload
-        uses: prewk/s3-cp-action@667b442 # v0.1.1
+        uses: prewk/s3-cp-action@v0.1.1
         with:
           args: --acl public-read --follow-symlinks
         env:
@@ -243,7 +243,7 @@ jobs:
         id: update_refrence
         run: ./bin/step help --markdown ./docs/step-cli/reference
       - name: Push changes
-        uses: ad-m/github-push-action@40bf560
+        uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.PAT }}
           branch: 'master'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         id: lintTestBuild
         run: V=1 make -j1 bootstrap all
       - name: Codecov
-        uses: codecov/codecov-action@1fc7722 # v1.1.1
+        uses: codecov/codecov-action@v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           file: ./coverage.out # optional

--- a/command/certificate/p12.go
+++ b/command/certificate/p12.go
@@ -51,7 +51,7 @@ Package a CA certificate into a "trust store" for Java applications:
 $ step certificate p12 trust.p12 --ca ca.crt
 '''
 
-Package a certificate and private key with a blank password:
+Package a certificate and private key with an empty password:
 
 '''
 $ step certificate p12 --no-password --insecure foo.p12 foo.crt foo.key

--- a/command/certificate/p12.go
+++ b/command/certificate/p12.go
@@ -49,6 +49,12 @@ Package a CA certificate into a "trust store" for Java applications:
 
 '''
 $ step certificate p12 trust.p12 --ca ca.crt
+'''
+
+Package a certificate and private key with a blank password:
+
+'''
+$ step certificate p12 --no-password --insecure foo.p12 foo.crt foo.key
 '''`,
 		Flags: []cli.Flag{
 			cli.StringSliceFlag{
@@ -61,7 +67,9 @@ multiple CAs or intermediates.`,
 				Name:  "password-file",
 				Usage: `The path to the <file> containing the password to encrypt the .p12 file.`,
 			},
+			flags.NoPassword,
 			flags.Force,
+			flags.Insecure,
 		},
 	}
 }
@@ -87,6 +95,14 @@ func p12Action(ctx *cli.Context) error {
 		return errors.Errorf("flag '--%s' must be provided when no <crt_path> and <key_path> are present", "ca")
 	}
 
+	// Validate flags
+	switch {
+	case ctx.String("password-file") != "" && ctx.Bool("no-password"):
+		return errs.IncompatibleFlagWithFlag(ctx, "no-password", "password-file")
+	case ctx.Bool("no-password") && !ctx.Bool("insecure"):
+		return errs.RequiredInsecureFlag(ctx, "no-password")
+	}
+
 	x509CAs := []*x509.Certificate{}
 	for _, caFile := range caFiles {
 		x509Bundle, err := pemutil.ReadCertificateBundle(caFile)
@@ -96,26 +112,26 @@ func p12Action(ctx *cli.Context) error {
 		x509CAs = append(x509CAs, x509Bundle...)
 	}
 
-	var password string
 	var err error
-
-	if passwordFile := ctx.String("password-file"); passwordFile != "" {
-		password, err = utils.ReadStringPasswordFromFile(passwordFile)
-		if err != nil {
-			return err
+	var password string
+	if !ctx.Bool("no-password") {
+		if passwordFile := ctx.String("password-file"); passwordFile != "" {
+			password, err = utils.ReadStringPasswordFromFile(passwordFile)
+			if err != nil {
+				return err
+			}
 		}
-	}
 
-	if password == "" {
-		pass, err := ui.PromptPassword("Please enter a password to encrypt the .p12 file")
-		if err != nil {
-			return errors.Wrap(err, "error reading password")
+		if password == "" {
+			pass, err := ui.PromptPassword("Please enter a password to encrypt the .p12 file")
+			if err != nil {
+				return errors.Wrap(err, "error reading password")
+			}
+			password = string(pass)
 		}
-		password = string(pass)
 	}
 
 	var pkcs12Data []byte
-
 	if hasKeyAndCert {
 		//If we have a key and certificate, we're making an identity store
 		x509CertBundle, err := pemutil.ReadCertificateBundle(crtFile)


### PR DESCRIPTION
### Description

This PR adds the flags `--no-password --insecure` to `step certificate p12` to encrypt a PKCS#12 archive with a blank password.

Fixes #414