### PR TITLE
add linux/mips build target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,7 @@ builds:
       - arm
       - arm64
       - 386
+      - mips
     goarm:
       - 7
     ignore:

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,9 @@ binary-linux-arm64:
 binary-linux-armv7:
 	$(call BUNDLE_MAKE,linux,arm,7,$(BINARY_OUTPUT)linux.armv7/)
 
+binary-linux-mips:
+	$(call BUNDLE_MAKE,linux,mips,,$(BINARY_OUTPUT)linux.mips/)
+
 binary-darwin:
 	$(call BUNDLE_MAKE,darwin,amd64,,$(BINARY_OUTPUT)darwin/)
 
@@ -110,10 +113,11 @@ define BUNDLE
 	$(q) ./make/bundle.sh $(1) "$(BINARY_OUTPUT)$(2)" "$(RELEASE)" "$(VERSION)" "$(3)" "$(4)" "$(5)"
 endef
 
-bundle-linux: binary-linux binary-linux-arm64 binary-linux-armv7
+bundle-linux: binary-linux binary-linux-arm64 binary-linux-armv7 binary-linux-mips
 	$(call BUNDLE,,linux,linux,amd64,step)
 	$(call BUNDLE,,linux.arm64,linux,arm64,step)
 	$(call BUNDLE,,linux.armv7,linux,armv7,step)
+	$(call BUNDLE,,linux.mips,linux,mips,step)
 
 bundle-darwin: binary-darwin
 	$(call BUNDLE,,darwin,darwin,amd64,step)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Users and developers can ask questions on [GitHub Discussions](https://github.co
 
 ## Code Contribution
 
-'step cli` aims to become a fully featured toolkit for cryptographic primitives.
+`step cli` aims to become a fully featured toolkit for cryptographic primitives.
 We encourage all contributions that meet the following criteria:
 
 * fit naturally into a toolkit for creating and working with cryptographic


### PR DESCRIPTION
this allows e.g. some routers to make use of `step cli`

### Description

hey there! huge fan of step and y'all's drive to make this ecosystem better :)

this is a small change that just adds a `linux/mips` build target. the binary size that golang produces isn't ideal for some devices, but `step` is worth it :) there may be some easy wins there for the future, although i haven't done any homework there.