### PR TITLE
Add support for JSON Web Keys in step crypto key commands

### DIFF
--- a/command/crypto/key/fingerprint.go
+++ b/command/crypto/key/fingerprint.go
@@ -144,6 +144,10 @@ func fingerprintAction(ctx *cli.Context) error {
 		if key, err = pemutil.ParseSSH(b); err != nil {
 			return err
 		}
+	case isJWK(b):
+		if key, err = parseJWK(ctx, b); err != nil {
+			return err
+		}
 	default: // assuming DER format
 		if key, err = pemutil.ParseDER(b); err != nil {
 			return err

--- a/command/crypto/key/inspect.go
+++ b/command/crypto/key/inspect.go
@@ -89,6 +89,10 @@ func inspectAction(ctx *cli.Context) error {
 		if key, err = pemutil.ParseSSH(b); err != nil {
 			return err
 		}
+	case isJWK(b):
+		if key, err = parseJWK(ctx, b); err != nil {
+			return err
+		}
 	default: // assume DER format
 		if key, err = pemutil.ParseDER(b); err != nil {
 			return err


### PR DESCRIPTION
### Description
The following commands now support keys in JWK format.
```
step crypto key fingerprint
step crypto key format
step crypto key inspect
```