### PR TITLE
Always specify a Proxy in all custom transports.

### DIFF
--- a/command/ca/renew.go
+++ b/command/ca/renew.go
@@ -383,6 +383,7 @@ func newRenewer(ctx *cli.Context, caURL string, cert tls.Certificate, rootFile s
 	}
 
 	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			Certificates:             []tls.Certificate{cert},
 			RootCAs:                  rootCAs,

--- a/command/ca/revoke.go
+++ b/command/ca/revoke.go
@@ -439,6 +439,7 @@ func (f *revokeFlow) Revoke(ctx *cli.Context, serial, token string) error {
 			return err
 		}
 		tr = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				RootCAs:                  rootCAs,
 				PreferServerCipherSuites: true,

--- a/command/ca/root.go
+++ b/command/ca/root.go
@@ -109,6 +109,7 @@ func rootAction(ctx *cli.Context) error {
 
 func getInsecureTransport() *http.Transport {
 	return &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 }


### PR DESCRIPTION
### Description
This PR changes all the custom transports being used to add `Proxy: http.ProxyFromEnvironment`

Related to smallstep/certificates#535
Full fix requires smallstep/certificates#540
