### PR TITLE
In Makefile always use the VERSION from ENV if not empty.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ci: test build
 
 # If TRAVIS_TAG is set then we know this ref has been tagged.
 ifdef TRAVIS_TAG
-VERSION := $(TRAVIS_TAG)
+VERSION ?= $(TRAVIS_TAG)
 NOT_RC  := $(shell echo $(VERSION) | grep -v -e -rc)
 	ifeq ($(NOT_RC),)
 PUSHTYPE := release-candidate
@@ -19,7 +19,7 @@ PUSHTYPE := release
 	endif
 # GITHUB Actions
 else ifdef GITHUB_REF
-VERSION := $(shell echo $(GITHUB_REF) | sed 's/^refs\/tags\///')
+VERSION ?= $(shell echo $(GITHUB_REF) | sed 's/^refs\/tags\///')
 NOT_RC  := $(shell echo $(VERSION) | grep -v -e -rc)
 	ifeq ($(NOT_RC),)
 PUSHTYPE := release-candidate


### PR DESCRIPTION
- Even when in CI e.g. github-action or travis

Fixes broken version in Homebrew. They're also using github actions so, `GITHUB_REF` is set and overrides our environment given VERSION variable.

