### PR TITLE
Allow verification of any type of certs.

### DIFF
--- a/command/certificate/verify.go
+++ b/command/certificate/verify.go
@@ -171,7 +171,7 @@ func verifyAction(ctx *cli.Context) error {
 		// Support verification of any type of cert.
 		//
 		// TODO: add something like --purpose client,server,... and configure
-		// this property according.
+		// this property accordingly.
 		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
 

--- a/command/certificate/verify.go
+++ b/command/certificate/verify.go
@@ -168,6 +168,11 @@ func verifyAction(ctx *cli.Context) error {
 		DNSName:       host,
 		Roots:         rootPool,
 		Intermediates: intermediatePool,
+		// Support verification of any type of cert.
+		//
+		// TODO: add something like --purpose client,server,... and configure
+		// this property according.
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
 
 	if _, err := cert.Verify(opts); err != nil {


### PR DESCRIPTION
### Description

This change allows to validate any type of cert, no matter the extended key usage of it. Previously only certs with server auth were considered valid.

In the future we should add some kind of 'purpose' flag and configure the verify options accordingly.

Related to #467