### PR TITLE
Add armv6 for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ binary-linux:
 binary-linux-arm64:
 	$(call BUNDLE_MAKE,linux,arm64,,$(BINARY_OUTPUT)linux.arm64/)
 
+binary-linux-armv6:
+	$(call BUNDLE_MAKE,linux,arm,6,$(BINARY_OUTPUT)linux.armv6/)
+
 binary-linux-armv7:
 	$(call BUNDLE_MAKE,linux,arm,7,$(BINARY_OUTPUT)linux.armv7/)
 
@@ -115,9 +118,10 @@ define BUNDLE
 	$(q) ./make/bundle.sh $(1) "$(BINARY_OUTPUT)$(2)" "$(RELEASE)" "$(VERSION)" "$(3)" "$(4)" "$(5)"
 endef
 
-bundle-linux: binary-linux binary-linux-arm64 binary-linux-armv7 binary-linux-mips
+bundle-linux: binary-linux binary-linux-arm64 binary-linux-armv6 binary-linux-armv7 binary-linux-mips
 	$(call BUNDLE,,linux,linux,amd64,step)
 	$(call BUNDLE,,linux.arm64,linux,arm64,step)
+	$(call BUNDLE,,linux.armv6,linux,armv6,step)
 	$(call BUNDLE,,linux.armv7,linux,armv7,step)
 	$(call BUNDLE,,linux.mips,linux,mips,step)
 


### PR DESCRIPTION
### Description
This PR extends ARM support to armv6. (Original issue in #221)

I tested the built binary on the venerable RPi2 that provides DNS on my home network