### PR TITLE
Clarify comments and add requested principal

### DIFF
--- a/command/ssh/login.go
+++ b/command/ssh/login.go
@@ -202,7 +202,6 @@ func loginAction(ctx *cli.Context) error {
 	// provisioner is responsible for setting default principals by using an
 	// identity function.
 	if email, ok := tokenHasEmail(token); ok {
-		principals = []string{}
 		subject = email
 	}
 

--- a/command/ssh/login.go
+++ b/command/ssh/login.go
@@ -198,9 +198,9 @@ func loginAction(ctx *cli.Context) error {
 		identityKey = key
 	}
 
-	// NOTE: For OIDC tokens the subject should be always the email. The
-	// provisioner is responsible to setting the principals by using an identity
-	// function.
+	// NOTE: For OIDC tokens the subject should always be the email. The
+	// provisioner is responsible for loading and setting the principals with
+	// the application of an Identity function.
 	if email, ok := tokenHasEmail(token); ok {
 		subject = email
 	}

--- a/command/ssh/login.go
+++ b/command/ssh/login.go
@@ -202,6 +202,7 @@ func loginAction(ctx *cli.Context) error {
 	// provisioner is responsible for setting default principals by using an
 	// identity function.
 	if email, ok := tokenHasEmail(token); ok {
+		principals = []string{}
 		subject = email
 	}
 

--- a/command/ssh/login.go
+++ b/command/ssh/login.go
@@ -198,9 +198,9 @@ func loginAction(ctx *cli.Context) error {
 		identityKey = key
 	}
 
-	// NOTE: For OIDC token the principals should be completely empty. The OIDC
-	// provisioner is responsible for setting default principals by using an
-	// identity function.
+	// NOTE: For OIDC tokens the subject should be always the email. The
+	// provisioner is responsible to setting the principals by using an identity
+	// function.
 	if email, ok := tokenHasEmail(token); ok {
 		subject = email
 	}

--- a/command/ssh/proxycommand.go
+++ b/command/ssh/proxycommand.go
@@ -143,9 +143,9 @@ func doLoginIfNeeded(ctx *cli.Context, subject string) error {
 		return err
 	}
 
-	// NOTE: For OIDC token the principals should be completely empty. The OIDC
-	// provisioner is responsible for setting default principals by using an
-	// identity function.
+	// NOTE: For OIDC tokens the subject should be always the email. The
+	// provisioner is responsible to setting the principals by using an identity
+	// function.
 	if email, ok := tokenHasEmail(token); ok {
 		subject = email
 	}

--- a/command/ssh/proxycommand.go
+++ b/command/ssh/proxycommand.go
@@ -147,6 +147,7 @@ func doLoginIfNeeded(ctx *cli.Context, subject string) error {
 	// provisioner is responsible for setting default principals by using an
 	// identity function.
 	if email, ok := tokenHasEmail(token); ok {
+		principals = []string{}
 		subject = email
 	}
 

--- a/command/ssh/proxycommand.go
+++ b/command/ssh/proxycommand.go
@@ -143,9 +143,9 @@ func doLoginIfNeeded(ctx *cli.Context, subject string) error {
 		return err
 	}
 
-	// NOTE: For OIDC tokens the subject should be always the email. The
-	// provisioner is responsible to setting the principals by using an identity
-	// function.
+	// NOTE: For OIDC tokens the subject should always be the email. The
+	// provisioner is responsible for loading and setting the principals with
+	// the application of an Identity function.
 	if email, ok := tokenHasEmail(token); ok {
 		subject = email
 	}

--- a/command/ssh/proxycommand.go
+++ b/command/ssh/proxycommand.go
@@ -147,7 +147,6 @@ func doLoginIfNeeded(ctx *cli.Context, subject string) error {
 	// provisioner is responsible for setting default principals by using an
 	// identity function.
 	if email, ok := tokenHasEmail(token); ok {
-		principals = []string{}
 		subject = email
 	}
 

--- a/command/ssh/ssh.go
+++ b/command/ssh/ssh.go
@@ -272,6 +272,9 @@ func createPrincipalsFromSubject(subject string) []string {
 		if local := subject[:i]; !strings.EqualFold(local, name) {
 			principals = append(principals, local)
 		}
+	}
+	// Append the original subject if different.
+	if subject != name {
 		principals = append(principals, subject)
 	}
 	return principals


### PR DESCRIPTION
### Description

~~OIDC provisioners use an identity function to get the principals for a given email, so there's no need to provide principals.
Moreover, if the email and principal does not match `step ssh proxycommand` will fail if the username does not match the email address.~~

~~For an unknown reason this feature was removed in an unrelated commit smallstep/cli@2c9b200~~

This PR clarifies some comments about the use of the email as a subject in OIDC provisioners and appends to the list of principals the requested one if different being case sensitive.

Fixes: smallstep/certificates#550