### PR TITLE
Add json output to step ssh inspect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ coverage.txt
 output
 vendor
 step
+.idea

--- a/command/ssh/inspect.go
+++ b/command/ssh/inspect.go
@@ -68,7 +68,7 @@ func inspectAction(ctx *cli.Context) error {
 	}
 
 	var (
-		format     = ctx.String("format")
+		format = ctx.String("format")
 	)
 
 	if format != "text" && format != "json" {


### PR DESCRIPTION
Useful for implementing customizing `AuthorizedPrincipalsCommand`, e.g. for smallstep/certificate#547