### PR TITLE
Make empty STDIN work for `crypto jwt sign` when no input is specified

### DIFF
--- a/command/crypto/jwt/sign.go
+++ b/command/crypto/jwt/sign.go
@@ -476,6 +476,11 @@ func readPayload(filename string) (interface{}, error) {
 
 	v := make(map[string]interface{})
 	if err := json.NewDecoder(r).Decode(&v); err != nil {
+		// Some CI platforms will feed an empty pipe as STDIN.
+		// In that case we should treat it as a valid empty JSON.
+		if filename == "" && errors.Is(err, io.EOF) {
+			return v, nil
+		}
 		if filename == "" || filename == "-" {
 			return nil, errors.Wrap(err, "error decoding JSON from STDIN")
 		}


### PR DESCRIPTION
### Description
Some CI platforms will feed us an empty pipe as STDIN (i.e. GitHub Actions). This means that the following command — which would work fine locally — will fail on the CI:
```
$ step crypto jwt sign --key key.pem --subtle
error decoding JSON from STDIN: EOF
```

This PR ensures that if no payload is specified and STDIN is empty, we treat it as a valid empty JSON. This is consistent with the current behaviour when STDIN is not a pipe.