### PR TITLE
Megan/expiration

### DIFF
--- a/command/certificate/certificate.go
+++ b/command/certificate/certificate.go
@@ -14,7 +14,7 @@ func init() {
 		Description: `**step certificate** command group provides facilities for creating
 certificate signing requests (CSRs), creating self-signed certificates
 (e.g., for use as a root certificate authority), generating leaf or
-intermediate CA certificate by signing a CSR, validating certificates,
+intermediate CA certificate by signing a CSR, validating certificates, check expiration of certificate,
 renewing certificates, generating certificate bundles, and key-wrapping
 of private keys.
 

--- a/command/certificate/certificate.go
+++ b/command/certificate/certificate.go
@@ -14,7 +14,7 @@ func init() {
 		Description: `**step certificate** command group provides facilities for creating
 certificate signing requests (CSRs), creating self-signed certificates
 (e.g., for use as a root certificate authority), generating leaf or
-intermediate CA certificate by signing a CSR, validating certificates, checking certificate verdancy,
+intermediate CA certificate by signing a CSR, validating certificates,
 renewing certificates, generating certificate bundles, and key-wrapping
 of private keys.
 
@@ -87,6 +87,7 @@ $ step certificate uninstall root-ca.crt
 			inspectCommand(),
 			fingerprintCommand(),
 			lintCommand(),
+			needsRenewalCommand(),
 			signCommand(),
 			verifyCommand(),
 			keyCommand(),

--- a/command/certificate/certificate.go
+++ b/command/certificate/certificate.go
@@ -14,7 +14,7 @@ func init() {
 		Description: `**step certificate** command group provides facilities for creating
 certificate signing requests (CSRs), creating self-signed certificates
 (e.g., for use as a root certificate authority), generating leaf or
-intermediate CA certificate by signing a CSR, validating certificates, checking certificate expiration,
+intermediate CA certificate by signing a CSR, validating certificates, checking certificate verdancy,
 renewing certificates, generating certificate bundles, and key-wrapping
 of private keys.
 

--- a/command/certificate/inspect.go
+++ b/command/certificate/inspect.go
@@ -168,6 +168,7 @@ authenticity of the remote server.
     **directory**
 	:  Relative or full path to a directory. Every PEM encoded certificate from each file in the directory will be used for path validation.`,
 			},
+			flags.ServerName,
 			cli.BoolFlag{
 				Name: `bundle`,
 				Usage: `Print all certificates in the order in which they appear in the bundle.
@@ -184,7 +185,6 @@ if the input bundle includes any PEM that does not have type CERTIFICATE.`,
 				Usage: `Use an insecure client to retrieve a remote peer certificate. Useful for
 debugging invalid certificates remotely.`,
 			},
-			flags.ServerName,
 		},
 	}
 }

--- a/command/certificate/needsRenewal.go
+++ b/command/certificate/needsRenewal.go
@@ -2,14 +2,14 @@ package certificate
 
 import (
 	"crypto/x509"
-	"encoding/pem"
-	"github.com/pkg/errors"
-	"github.com/smallstep/cli/errs"
-	"github.com/urfave/cli"
-	"io/ioutil"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/smallstep/cli/crypto/pemutil"
+	"github.com/smallstep/cli/errs"
+	"github.com/urfave/cli"
 )
 
 const defaultPercentUsedThreshold = 66
@@ -19,46 +19,55 @@ func needsRenewalCommand() cli.Command {
 		Name:      "needs-renewal",
 		Action:    cli.ActionFunc(needsRenewalAction),
 		Usage:     `Check if a certificate needs to be renewed`,
-		UsageText: `**step certificate needs-renewal** <crt_file or host_name> [**--expires-in**=<duration>]`,
-		Description: `**step certificate needs-renewal** returns '0' if the certificate needs to be renewed based on it's remaining lifetime. 
-		Returns '1' if the certificate is within it's validity lifetime bounds and does not need to be renewed. 
-		Returns '255' for any other error. By default, if a certificate "needs renewal" when it has passed 66% of it's allotted lifetime. 
+		UsageText: `**step certificate needs-renewal** <cert_file or host_name> [**--expires-in**=<duration>]`,
+		Description: `**step certificate needs-renewal** returns '0' if the certificate needs to be renewed based on it's remaining lifetime.
+		Returns '1' if the certificate is within it's validity lifetime bounds and does not need to be renewed.
+		Returns '255' for any other error. By default, a certificate "needs renewal" when it has passed 66% of it's allotted lifetime.
 		This threshold can be adjusted using the '--expires-in' flag.
+
 ## POSITIONAL ARGUMENTS
-<cert_file or hostname> The path to a certificate to validate OR a hostname with protocol prefix.
+
+<cert_file or hostname>
+:  The path to a certificate OR a hostname with protocol prefix.
 
 ## EXIT CODES
 
 This command returns '0' if the certificate needs renewal, '1' if the certificate does not need renewal, and '255' for any error.
 
 ## EXAMPLES
-Check certificate for renewal using custom directory: 
+
+Check certificate for renewal using custom directory:
 '''
-$ step certificate needs-renewal ./certificate.crt 
+$ step certificate needs-renewal ./certificate.crt
 '''
+
 Check certificate for renewal using a hostname:
 $ step certificate needs-renewal https://smallstep.com
 '''
+
 Check if certificate will expire within a given time:
 $ step certificate needs-renewal ./certificate.crt --expires-in 1h15m
 '''
+
 Check if certificate from hostname will expire within a given time:
 $ step certificate needs-renewal https://smallstep.com --expires-in 1h15m
 '''
-Check if certificate has passed a percentage of its lifetime: 
+
+Check if certificate has passed 75 percent of it's lifetime:
 $ step certificate needs-renewal ./certificate.crt --expires-in 75%
 '''
-Check if certificate from a hostname has passed a percentage of its lifetime:
+
+Check if certificate from a hostname has passed 75 percent of it's lifetime:
 $ step certificate needs-renewal https://smallstep.com --expires-in 75%
 `,
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name: "expires-in",
-				Usage: `Check if the certificate expires in given time duration
-				using <percent|duration>. With <percent>, must be followed by "%".
-				With <duration>, it is a sequence of decimal numbers, each with optional
-				fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid
-				time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
+				Usage: `Check if the certificate expires within the given time window
+using <percent|duration>. If using <percent>, the input must be followed by a "%"
+character. If using <duration>, the input must be a sequence of decimal numbers,
+each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
+Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
 			},
 		},
 	}
@@ -68,91 +77,73 @@ func needsRenewalAction(ctx *cli.Context) error {
 	if err := errs.NumberOfArguments(ctx, 1); err != nil {
 		return err
 	}
+
 	var (
+		err        error
 		crtFile    = ctx.Args().Get(0)
 		expiresIn  = ctx.String("expires-in")
 		roots      = ctx.String("roots")
 		serverName = ctx.String("servername")
 	)
 
-	var blocks []*pem.Block
-	var block *pem.Block
+	var certs []*x509.Certificate
 	if addr, isURL, err := trimURL(crtFile); err != nil {
 		return errs.NewExitError(err, 255)
 	} else if isURL {
-		peerCertificates, err := getPeerCertificates(addr, serverName, roots, false)
+		certs, err = getPeerCertificates(addr, serverName, roots, false)
 		if err != nil {
 			return errs.NewExitError(err, 255)
 		}
-		for _, crt := range peerCertificates {
-			blocks = append(blocks, &pem.Block{
-				Type:  "CERTIFICATE",
-				Bytes: crt.Raw,
-			})
-		}
-
 	} else {
-		crtBytes, err := ioutil.ReadFile(crtFile)
+		certs, err = pemutil.ReadCertificateBundle(crtFile)
 		if err != nil {
 			return errs.NewExitError(err, 255)
 		}
-
-		// The first certificate PEM in the file is our leaf Certificate.
-		// Any certificate after the first is added to the list of Intermediate
-		// certificates used for path validation.
-		for len(crtBytes) > 0 {
-			block, crtBytes = pem.Decode(crtBytes)
-			if block == nil {
-				return errs.NewExitError(errors.Errorf("%s contains an invalid PEM block", crtFile), 255)
-			}
-			if block.Type != "CERTIFICATE" {
-				continue
-			}
-
-			blocks = append(blocks, block)
-		}
-		if block == nil {
-			return errs.NewExitError(errors.Errorf("%s contains no PEM certificate blocks", crtFile), 255)
-		}
-
 	}
 
-	for _, block := range blocks {
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return errs.NewExitError(errors.WithStack(err), 255)
+	var (
+		percentThreshold int
+		duration         time.Duration
+		isPercent        = expiresIn == "" || strings.HasSuffix(expiresIn, "%")
+	)
+
+	if isPercent {
+		var percentThreshold int
+		if expiresIn == "" {
+			percentThreshold = defaultPercentUsedThreshold
+		} else {
+			percentThreshold, err = strconv.Atoi(strings.TrimSuffix(expiresIn, "%"))
+			if err != nil {
+				return errs.NewExitError(err, 255)
+			}
 		}
-		var remainingValidity = time.Until(cert.NotAfter)
-		var totalValidity = cert.NotAfter.Sub(cert.NotBefore)
-		var percentUsed = (1 - remainingValidity.Minutes()/totalValidity.Minutes()) * 100
+		if percentThreshold > 100 || percentThreshold < 0 {
+			return errs.NewExitError(errors.Errorf("Percentage must be in range 0-100"), 255)
+		}
+	} else {
+		duration, err = time.ParseDuration(expiresIn)
+		if err != nil {
+			return errs.NewExitError(err, 255)
+		}
+	}
 
-		if expiresIn == "" || strings.Contains(expiresIn, "%") {
-			var threshold int
-			if expiresIn == "" {
-				threshold = defaultPercentUsedThreshold
-			} else {
-				threshold, err = strconv.Atoi(strings.TrimSuffix(expiresIn, "%"))
-				if err != nil {
-					return errs.NewExitError(err, 255)
-				}
-			}
-			if threshold > 100 || threshold < 0 {
-				return errs.NewExitError(errors.Errorf("Percentage must be in range 0-100"), 255)
-			}
+	for _, cert := range certs {
 
-			if int(percentUsed) >= threshold {
+		remainingValidity := time.Until(cert.NotAfter)
+
+		if isPercent {
+			totalValidity := cert.NotAfter.Sub(cert.NotBefore)
+			percentUsed := (1 - remainingValidity.Minutes()/totalValidity.Minutes()) * 100
+
+			if int(percentUsed) >= percentThreshold {
 				return nil
 			}
 		} else {
-			duration, err := time.ParseDuration(expiresIn)
-
-			if err != nil {
-				return errs.NewExitError(err, 255)
-			} else if duration.Minutes() > remainingValidity.Minutes() {
+			if duration >= remainingValidity {
 				return nil
 			}
 		}
 	}
 
-	return errs.NewExitError(errors.Errorf("Certificate does not need renewal"), 1)
+	return errs.NewExitError(errors.Errorf("certificate does not need renewal"), 1)
 }

--- a/command/certificate/needsRenewal.go
+++ b/command/certificate/needsRenewal.go
@@ -1,0 +1,163 @@
+package certificate
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"github.com/pkg/errors"
+	"github.com/smallstep/cli/errs"
+	"github.com/urfave/cli"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func needsRenewalCommand() cli.Command {
+	return cli.Command{
+		Name:      "needs-renewal",
+		Action:    cli.ActionFunc(needsRenewalAction),
+		Usage:     `Check if a certificate needs to be renewed`,
+		UsageText: `**step certificate needs-renewal** <crt_file or host_name> [**--expires-in <duration>]`,
+		Description: `**step certificate needs-renewal** Checks certificate expiration from file or from a host if 
+		the certificate is over 66% of its lifetime. If the certificate needs renewal this command will return '0'.
+		If the certificate is not far enough into its life, it will return '1'. If validation fails, or if an error occurs, 
+		this command will produce a non-zero return value.
+## POSITIONAL ARGUMENTS
+
+<crt_file>
+: The path to a certificate to validate.
+
+<host_name>
+: Address of remote host 
+
+## EXIT CODES
+
+This command returns 0 if needing renewal, or returns 1 if the certificate does not need renewal. It will return 255 if any errors occurred
+
+## EXAMPLES
+Check certificate for renewal using custom directory 
+'''
+$ step certificate needs-renewal ./certificate.crt 
+'''
+Check certificate for renewal using a host
+$ step certificate needs-renewal https://smallstep.com
+'''
+Check if certificate will expire within a given time
+$ step certificate needs-renewal ./certificate.crt --expires-in 1h15m
+'''
+Check if certificate from host will expire within a given time
+$ step certificate needs-renewal https://smallstep.com --expires-in 1h15m
+'''
+Check if certificate has passed a percentage of its lifetime 
+$ step certificate needs-renewal ./certificate.crt --expires-in 75%
+'''
+Check if certificate from a host has passed a percentage of its lifetime
+$ step certificate needs-renewal https://smallstep.com --expires-in 75%
+`,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name: "expires-in",
+				Usage: `Check if the certificate expires in given time duration
+				using <percent|duration>. For <percent>, must be followed by "%".
+				With <duration>, it is a sequence of decimal numbers, each with optional
+				fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid
+				time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
+			},
+		},
+	}
+}
+
+func needsRenewalAction(ctx *cli.Context) error {
+	if err := errs.NumberOfArguments(ctx, 1); err != nil {
+		return err
+	}
+	var (
+		crtFile    = ctx.Args().Get(0)
+		expiresIn  = ctx.String("expires-in")
+		roots      = ctx.String("roots")
+		serverName = ctx.String("servername")
+		cert       *x509.Certificate
+	)
+
+	if addr, isURL, err := trimURL(crtFile); err != nil {
+		return err
+	} else if isURL {
+		peerCertificates, err := getPeerCertificates(addr, serverName, roots, false)
+		if err != nil {
+			return errs.NewExitError(err, 255)
+		}
+		cert = peerCertificates[0]
+
+	} else {
+		crtBytes, err := ioutil.ReadFile(crtFile)
+		if err != nil {
+			return errs.NewExitError(err, 255)
+		}
+
+		var block *pem.Block
+		// The first certificate PEM in the file is our leaf Certificate.
+		// Any certificate after the first is added to the list of Intermediate
+		// certificates used for path validation.
+		for len(crtBytes) > 0 {
+			block, crtBytes = pem.Decode(crtBytes)
+			if block == nil {
+				return errs.NewExitError(errors.Errorf("%s contains an invalid PEM block", crtFile), 255)
+			}
+			if block.Type != "CERTIFICATE" {
+				continue
+			}
+			if cert == nil {
+				cert, err = x509.ParseCertificate(block.Bytes)
+				if err != nil {
+					return errs.NewExitError(errors.WithStack(err), 255)
+				}
+			}
+		}
+		if cert == nil {
+			return errs.NewExitError(errors.Errorf("%s contains no PEM certificate blocks", crtFile), 255)
+		}
+
+	}
+	var remainingValidity = time.Until(cert.NotAfter)
+	var totalValidity = cert.NotAfter.Sub(cert.NotBefore)
+	var percentUsed = (1 - remainingValidity.Minutes()/totalValidity.Minutes()) * 100
+
+	if expiresIn != "" {
+		if strings.Contains(expiresIn, "%") {
+			percentageInput, err := strconv.Atoi(strings.ReplaceAll(expiresIn, "%", ""))
+
+			if err != nil {
+				return errs.NewExitError(err, 255)
+			}
+			if percentageInput > 100 || percentageInput < 0 {
+				return errs.NewExitError(errors.Errorf("Percentage must be in range 0-100"), 255)
+			}
+
+			if percentageInput > int(percentUsed) {
+				return nil
+			}
+			os.Exit(1)
+
+		} else {
+			duration, err := time.ParseDuration(expiresIn)
+
+			if err != nil {
+				return errs.NewExitError(err, 255)
+			} else if duration.Minutes() > remainingValidity.Minutes() {
+				return nil
+			}
+			os.Exit(1)
+		}
+	} else {
+		if percentUsed >= 66 {
+			return nil
+		} else if percentUsed < 66 {
+			os.Exit(1)
+		} else {
+			return errs.NewExitError(errors.Errorf("Can not determine remaining lifetime on certificate %s", crtFile), 255)
+		}
+	}
+
+	return nil
+}

--- a/command/certificate/needsRenewal.go
+++ b/command/certificate/needsRenewal.go
@@ -21,7 +21,7 @@ func needsRenewalCommand() cli.Command {
 		Usage:     `Check if a certificate needs to be renewed`,
 		UsageText: `**step certificate needs-renewal** <cert_file or host_name> [**--expires-in**=<duration>]`,
 		Description: `**step certificate needs-renewal** returns '0' if the certificate needs to be renewed based on it's remaining lifetime.
-		Returns '1' if the certificate is within it's validity lifetime bounds and does not need to be renewed.
+		Returns '1'  the certificate is within it's validity lifetime bounds and does not need to be renewed.
 		Returns '255' for any other error. By default, a certificate "needs renewal" when it has passed 66% of it's allotted lifetime.
 		This threshold can be adjusted using the '--expires-in' flag.
 
@@ -79,18 +79,16 @@ func needsRenewalAction(ctx *cli.Context) error {
 	}
 
 	var (
-		err        error
-		crtFile    = ctx.Args().Get(0)
-		expiresIn  = ctx.String("expires-in")
-		roots      = ctx.String("roots")
-		serverName = ctx.String("servername")
+		err       error
+		crtFile   = ctx.Args().Get(0)
+		expiresIn = ctx.String("expires-in")
 	)
 
 	var certs []*x509.Certificate
 	if addr, isURL, err := trimURL(crtFile); err != nil {
 		return errs.NewExitError(err, 255)
 	} else if isURL {
-		certs, err = getPeerCertificates(addr, serverName, roots, false)
+		certs, err = getPeerCertificates(addr, "", "", false)
 		if err != nil {
 			return errs.NewExitError(err, 255)
 		}
@@ -108,7 +106,6 @@ func needsRenewalAction(ctx *cli.Context) error {
 	)
 
 	if isPercent {
-		var percentThreshold int
 		if expiresIn == "" {
 			percentThreshold = defaultPercentUsedThreshold
 		} else {

--- a/command/certificate/needsRenewal.go
+++ b/command/certificate/needsRenewal.go
@@ -7,59 +7,55 @@ import (
 	"github.com/smallstep/cli/errs"
 	"github.com/urfave/cli"
 	"io/ioutil"
-	"os"
 	"strconv"
 	"strings"
 	"time"
 )
+
+const defaultPercentUsedThreshold = 66
 
 func needsRenewalCommand() cli.Command {
 	return cli.Command{
 		Name:      "needs-renewal",
 		Action:    cli.ActionFunc(needsRenewalAction),
 		Usage:     `Check if a certificate needs to be renewed`,
-		UsageText: `**step certificate needs-renewal** <crt_file or host_name> [**--expires-in <duration>]`,
-		Description: `**step certificate needs-renewal** Checks certificate expiration from file or from a host if 
-		the certificate is over 66% of its lifetime. If the certificate needs renewal this command will return '0'.
-		If the certificate is not far enough into its life, it will return '1'. If validation fails, or if an error occurs, 
-		this command will produce a non-zero return value.
+		UsageText: `**step certificate needs-renewal** <crt_file or host_name> [**--expires-in**=<duration>]`,
+		Description: `**step certificate needs-renewal** returns '0' if the certificate needs to be renewed based on it's remaining lifetime. 
+		Returns '1' if the certificate is within it's validity lifetime bounds and does not need to be renewed. 
+		Returns '255' for any other error. By default, if a certificate "needs renewal" when it has passed 66% of it's allotted lifetime. 
+		This threshold can be adjusted using the '--expires-in' flag.
 ## POSITIONAL ARGUMENTS
-
-<crt_file>
-: The path to a certificate to validate.
-
-<host_name>
-: Address of remote host 
+<cert_file or hostname> The path to a certificate to validate OR a hostname with protocol prefix.
 
 ## EXIT CODES
 
-This command returns 0 if needing renewal, or returns 1 if the certificate does not need renewal. It will return 255 if any errors occurred
+This command returns '0' if the certificate needs renewal, '1' if the certificate does not need renewal, and '255' for any error.
 
 ## EXAMPLES
-Check certificate for renewal using custom directory 
+Check certificate for renewal using custom directory: 
 '''
 $ step certificate needs-renewal ./certificate.crt 
 '''
-Check certificate for renewal using a host
+Check certificate for renewal using a hostname:
 $ step certificate needs-renewal https://smallstep.com
 '''
-Check if certificate will expire within a given time
+Check if certificate will expire within a given time:
 $ step certificate needs-renewal ./certificate.crt --expires-in 1h15m
 '''
-Check if certificate from host will expire within a given time
+Check if certificate from hostname will expire within a given time:
 $ step certificate needs-renewal https://smallstep.com --expires-in 1h15m
 '''
-Check if certificate has passed a percentage of its lifetime 
+Check if certificate has passed a percentage of its lifetime: 
 $ step certificate needs-renewal ./certificate.crt --expires-in 75%
 '''
-Check if certificate from a host has passed a percentage of its lifetime
+Check if certificate from a hostname has passed a percentage of its lifetime:
 $ step certificate needs-renewal https://smallstep.com --expires-in 75%
 `,
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name: "expires-in",
 				Usage: `Check if the certificate expires in given time duration
-				using <percent|duration>. For <percent>, must be followed by "%".
+				using <percent|duration>. With <percent>, must be followed by "%".
 				With <duration>, it is a sequence of decimal numbers, each with optional
 				fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid
 				time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
@@ -77,17 +73,23 @@ func needsRenewalAction(ctx *cli.Context) error {
 		expiresIn  = ctx.String("expires-in")
 		roots      = ctx.String("roots")
 		serverName = ctx.String("servername")
-		cert       *x509.Certificate
 	)
 
+	var blocks []*pem.Block
+	var block *pem.Block
 	if addr, isURL, err := trimURL(crtFile); err != nil {
-		return err
+		return errs.NewExitError(err, 255)
 	} else if isURL {
 		peerCertificates, err := getPeerCertificates(addr, serverName, roots, false)
 		if err != nil {
 			return errs.NewExitError(err, 255)
 		}
-		cert = peerCertificates[0]
+		for _, crt := range peerCertificates {
+			blocks = append(blocks, &pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: crt.Raw,
+			})
+		}
 
 	} else {
 		crtBytes, err := ioutil.ReadFile(crtFile)
@@ -95,7 +97,6 @@ func needsRenewalAction(ctx *cli.Context) error {
 			return errs.NewExitError(err, 255)
 		}
 
-		var block *pem.Block
 		// The first certificate PEM in the file is our leaf Certificate.
 		// Any certificate after the first is added to the list of Intermediate
 		// certificates used for path validation.
@@ -107,38 +108,41 @@ func needsRenewalAction(ctx *cli.Context) error {
 			if block.Type != "CERTIFICATE" {
 				continue
 			}
-			if cert == nil {
-				cert, err = x509.ParseCertificate(block.Bytes)
-				if err != nil {
-					return errs.NewExitError(errors.WithStack(err), 255)
-				}
-			}
+
+			blocks = append(blocks, block)
 		}
-		if cert == nil {
+		if block == nil {
 			return errs.NewExitError(errors.Errorf("%s contains no PEM certificate blocks", crtFile), 255)
 		}
 
 	}
-	var remainingValidity = time.Until(cert.NotAfter)
-	var totalValidity = cert.NotAfter.Sub(cert.NotBefore)
-	var percentUsed = (1 - remainingValidity.Minutes()/totalValidity.Minutes()) * 100
 
-	if expiresIn != "" {
-		if strings.Contains(expiresIn, "%") {
-			percentageInput, err := strconv.Atoi(strings.ReplaceAll(expiresIn, "%", ""))
+	for _, block := range blocks {
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return errs.NewExitError(errors.WithStack(err), 255)
+		}
+		var remainingValidity = time.Until(cert.NotAfter)
+		var totalValidity = cert.NotAfter.Sub(cert.NotBefore)
+		var percentUsed = (1 - remainingValidity.Minutes()/totalValidity.Minutes()) * 100
 
-			if err != nil {
-				return errs.NewExitError(err, 255)
+		if expiresIn == "" || strings.Contains(expiresIn, "%") {
+			var threshold int
+			if expiresIn == "" {
+				threshold = defaultPercentUsedThreshold
+			} else {
+				threshold, err = strconv.Atoi(strings.TrimSuffix(expiresIn, "%"))
+				if err != nil {
+					return errs.NewExitError(err, 255)
+				}
 			}
-			if percentageInput > 100 || percentageInput < 0 {
+			if threshold > 100 || threshold < 0 {
 				return errs.NewExitError(errors.Errorf("Percentage must be in range 0-100"), 255)
 			}
 
-			if percentageInput > int(percentUsed) {
+			if int(percentUsed) >= threshold {
 				return nil
 			}
-			os.Exit(1)
-
 		} else {
 			duration, err := time.ParseDuration(expiresIn)
 
@@ -147,17 +151,8 @@ func needsRenewalAction(ctx *cli.Context) error {
 			} else if duration.Minutes() > remainingValidity.Minutes() {
 				return nil
 			}
-			os.Exit(1)
-		}
-	} else {
-		if percentUsed >= 66 {
-			return nil
-		} else if percentUsed < 66 {
-			os.Exit(1)
-		} else {
-			return errs.NewExitError(errors.Errorf("Can not determine remaining lifetime on certificate %s", crtFile), 255)
 		}
 	}
 
-	return nil
+	return errs.NewExitError(errors.Errorf("Certificate does not need renewal"), 1)
 }

--- a/command/certificate/needsRenewal.go
+++ b/command/certificate/needsRenewal.go
@@ -2,6 +2,7 @@ package certificate
 
 import (
 	"crypto/x509"
+	"github.com/smallstep/cli/flags"
 	"strconv"
 	"strings"
 	"time"
@@ -16,10 +17,11 @@ const defaultPercentUsedThreshold = 66
 
 func needsRenewalCommand() cli.Command {
 	return cli.Command{
-		Name:      "needs-renewal",
-		Action:    cli.ActionFunc(needsRenewalAction),
-		Usage:     `Check if a certificate needs to be renewed`,
-		UsageText: `**step certificate needs-renewal** <cert_file or host_name> [**--expires-in**=<duration>]`,
+		Name:   "needs-renewal",
+		Action: cli.ActionFunc(needsRenewalAction),
+		Usage:  `Check if a certificate needs to be renewed`,
+		UsageText: `**step certificate needs-renewal** <cert_file or host_name> [**--expires-in**=<duration>] [**--roots**=<root-bundle>]
+[**--servername**=<servername>]`,
 		Description: `**step certificate needs-renewal** returns '0' if the certificate needs to be renewed based on it's remaining lifetime.
 		Returns '1'  the certificate is within it's validity lifetime bounds and does not need to be renewed.
 		Returns '255' for any other error. By default, a certificate "needs renewal" when it has passed 66% of it's allotted lifetime.
@@ -37,28 +39,60 @@ This command returns '0' if the certificate needs renewal, '1' if the certificat
 ## EXAMPLES
 
 Check certificate for renewal using custom directory:
+
 '''
 $ step certificate needs-renewal ./certificate.crt
 '''
 
 Check certificate for renewal using a hostname:
+
+'''
 $ step certificate needs-renewal https://smallstep.com
 '''
 
 Check if certificate will expire within a given time:
+
+'''
 $ step certificate needs-renewal ./certificate.crt --expires-in 1h15m
 '''
 
 Check if certificate from hostname will expire within a given time:
+
+'''
 $ step certificate needs-renewal https://smallstep.com --expires-in 1h15m
 '''
 
 Check if certificate has passed 75 percent of it's lifetime:
+
+'''
 $ step certificate needs-renewal ./certificate.crt --expires-in 75%
 '''
 
 Check if certificate from a hostname has passed 75 percent of it's lifetime:
+
+'''
 $ step certificate needs-renewal https://smallstep.com --expires-in 75%
+'''
+
+Check a remote certificate using a custom root certificate:
+
+'''
+$ step certificate needs-renewal https://smallstep.com --roots ./root-ca.crt
+'''
+
+Check a remote certificate using a custom list of root certificates:
+
+'''
+$ step certificate needs-renewal https://smallstep.com \
+--roots "./root-ca.crt,./root-ca2.crt,/root-ca3.crt"
+'''
+
+Check a remote certificate using a custom directory of root certificates:
+
+'''
+$ step certificate needs-renewal https://smallstep.com \
+--roots "./path/to/root/certificates/"
+'''
 `,
 		Flags: []cli.Flag{
 			cli.StringFlag{
@@ -69,6 +103,23 @@ character. If using <duration>, the input must be a sequence of decimal numbers,
 each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
 Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
 			},
+			cli.StringFlag{
+				Name: "roots",
+				Usage: `Root certificate(s) that will be used to verify the
+authenticity of the remote server.
+
+: <roots> is a case-sensitive string and may be one of:
+
+    **file**
+	:  Relative or full path to a file. All certificates in the file will be used for path validation.
+
+    **list of files**
+	:  Comma-separated list of relative or full file paths. Every PEM encoded certificate from each file will be used for path validation.
+
+    **directory**
+	:  Relative or full path to a directory. Every PEM encoded certificate from each file in the directory will be used for path validation.`,
+			},
+			flags.ServerName,
 		},
 	}
 }
@@ -79,16 +130,18 @@ func needsRenewalAction(ctx *cli.Context) error {
 	}
 
 	var (
-		err       error
-		crtFile   = ctx.Args().Get(0)
-		expiresIn = ctx.String("expires-in")
+		err        error
+		crtFile    = ctx.Args().Get(0)
+		expiresIn  = ctx.String("expires-in")
+		roots      = ctx.String("roots")
+		serverName = ctx.String("servername")
 	)
 
 	var certs []*x509.Certificate
 	if addr, isURL, err := trimURL(crtFile); err != nil {
 		return errs.NewExitError(err, 255)
 	} else if isURL {
-		certs, err = getPeerCertificates(addr, "", "", false)
+		certs, err = getPeerCertificates(addr, serverName, roots, false)
 		if err != nil {
 			return errs.NewExitError(err, 255)
 		}

--- a/command/certificate/verify.go
+++ b/command/certificate/verify.go
@@ -72,7 +72,7 @@ $ step certificate verify ./certificate.crt --roots ./root-certificates/
 Verify the remaining validity of a certificate using a custom root certificate and host for path validation:
 
 '''
-$ step certificate verify ./certificate.crt --host smallstep.com --expire
+$ step certificate verify ./certificate.crt --host smallstep.com --verdancy
 '''
 `,
 		Flags: []cli.Flag{
@@ -81,7 +81,7 @@ $ step certificate verify ./certificate.crt --host smallstep.com --expire
 				Usage: `Check whether the certificate is for the specified host.`,
 			},
 			cli.BoolFlag{
-				Name:  "expire",
+				Name:  "verdancy",
 				Usage: `Check the remaining certificate validity until expiration`,
 			},
 			cli.StringFlag{
@@ -113,7 +113,7 @@ func verifyAction(ctx *cli.Context) error {
 	var (
 		crtFile          = ctx.Args().Get(0)
 		host             = ctx.String("host")
-		expire           = ctx.Bool("expire")
+		verdancy         = ctx.Bool("verdancy")
 		serverName       = ctx.String("servername")
 		roots            = ctx.String("roots")
 		intermediatePool = x509.NewCertPool()
@@ -178,7 +178,7 @@ func verifyAction(ctx *cli.Context) error {
 		}
 	}
 
-	if expire {
+	if verdancy {
 
 		var remainingValidity = time.Until(cert.NotAfter).Hours()
 		var totalValidity = cert.NotAfter.Sub(cert.NotBefore).Hours()
@@ -201,7 +201,7 @@ func verifyAction(ctx *cli.Context) error {
 		} else if percentUsed < 1 {
 			fmt.Printf("%s 0 %s\n", green, reset)
 		} else {
-			return errors.Errorf("Failure to determine expiration time for certificate")
+			return errors.Errorf("Failure to determine verdancy for certificate")
 		}
 
 		/*if percentUsed >= 100 {

--- a/command/certificate/verify.go
+++ b/command/certificate/verify.go
@@ -25,6 +25,7 @@ func verifyCommand() cli.Command {
 validation algorithm for x.509 certificates defined in RFC 5280. If the
 certificate is valid this command will return '0'. If validation fails, or if
 an error occurs, this command will produce a non-zero return value.
+		
 
 ## POSITIONAL ARGUMENTS
 
@@ -195,7 +196,7 @@ func verifyAction(ctx *cli.Context) error {
 		} else if percentIntoLifeTime < 1 {
 			fmt.Println("\033[32m", "Leaf is less than 1% through its lifetime.", "\033[0m")
 		} else {
-			fmt.Println("Error")
+			return errors.Errorf("failure to determine expiration time for certificate")
 		}
 
 		return nil

--- a/command/certificate/verify.go
+++ b/command/certificate/verify.go
@@ -180,10 +180,10 @@ func verifyAction(ctx *cli.Context) error {
 
 	if expire {
 
-		remainingValidiy := time.Until(cert.NotAfter)
-		totalValidity := cert.NotAfter.Sub(cert.NotBefore)
+		var remainingValidity = time.Until(cert.NotAfter).Hours()
+		var totalValidity = cert.NotAfter.Sub(cert.NotBefore).Hours()
 
-		percentUsed := ((totalValidity.Hours() - remainingValidity.Hours()) / totalValidity.Hours()) * 100
+		var percentUsed = int((1 - remainingValidity/totalValidity) * 100)
 
 		red := "\033[31m"
 		green := "\033[32m"

--- a/command/certificate/verify.go
+++ b/command/certificate/verify.go
@@ -3,9 +3,9 @@ package certificate
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"io/ioutil"
 	"time"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/smallstep/cli/crypto/x509util"
@@ -80,7 +80,7 @@ $ step certificate verify ./certificate.crt --host smallstep.com --expire
 				Usage: `Check whether the certificate is for the specified host.`,
 			},
 			cli.BoolFlag{
-				Name: "expire",
+				Name:  "expire",
 				Usage: `Checks the certificate time till expiration`,
 			},
 			cli.StringFlag{
@@ -177,30 +177,29 @@ func verifyAction(ctx *cli.Context) error {
 		}
 	}
 
-        if expire {
+	if expire {
 
-                NowTillEndOfCert := time.Until(cert.NotAfter)
-                totalLifeTimeOfCert := cert.NotAfter.Sub(cert.NotBefore)
+		NowTillEndOfCert := time.Until(cert.NotAfter)
+		totalLifeTimeOfCert := cert.NotAfter.Sub(cert.NotBefore)
 
-                percentIntoLifeTime := ((totalLifeTimeOfCert.Hours() - NowTillEndOfCert.Hours()) / totalLifeTimeOfCert.Hours()) * 100
+		percentIntoLifeTime := ((totalLifeTimeOfCert.Hours() - NowTillEndOfCert.Hours()) / totalLifeTimeOfCert.Hours()) * 100
 
-                if percentIntoLifeTime >= 100 {
-                        fmt.Println("\033[31m", "This certificate has already expired.", "\033[0m") //"\033[__m" are color codes
-                } else if percentIntoLifeTime > 90 {
-                        fmt.Println("\033[31m", "Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
-                } else if percentIntoLifeTime > 66 && percentIntoLifeTime < 90 {
-                        fmt.Println("\033[33m", "Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
-                } else if percentIntoLifeTime < 66 && percentIntoLifeTime > 1 {
-                        fmt.Println("\033[32m", "Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
-                } else if percentIntoLifeTime < 1 {
-                        fmt.Println("\033[32m", "Leaf is less than 1% through its lifetime.", "\033[0m")
-                } else {
-                        fmt.Println("Error")
-                }
+		if percentIntoLifeTime >= 100 {
+			fmt.Println("\033[31m", "This certificate has already expired.", "\033[0m") //"\033[__m" are color codes
+		} else if percentIntoLifeTime > 90 {
+			fmt.Println("\033[31m", "Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
+		} else if percentIntoLifeTime > 66 && percentIntoLifeTime < 90 {
+			fmt.Println("\033[33m", "Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
+		} else if percentIntoLifeTime < 66 && percentIntoLifeTime > 1 {
+			fmt.Println("\033[32m", "Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
+		} else if percentIntoLifeTime < 1 {
+			fmt.Println("\033[32m", "Leaf is less than 1% through its lifetime.", "\033[0m")
+		} else {
+			fmt.Println("Error")
+		}
 
-                return nil
-        }
-
+		return nil
+	}
 
 	opts := x509.VerifyOptions{
 		DNSName:       host,

--- a/command/certificate/verify.go
+++ b/command/certificate/verify.go
@@ -113,7 +113,7 @@ func verifyAction(ctx *cli.Context) error {
 	var (
 		crtFile          = ctx.Args().Get(0)
 		host             = ctx.String("host")
-		expire         = ctx.Bool("expire")
+		expire           = ctx.Bool("expire")
 		serverName       = ctx.String("servername")
 		roots            = ctx.String("roots")
 		intermediatePool = x509.NewCertPool()
@@ -189,7 +189,7 @@ func verifyAction(ctx *cli.Context) error {
 		green := "\033[32m"
 		yellow := "\033[33m"
 		reset := "\033[0m"
-		
+
 		if percentUsed >= 100 {
 			fmt.Printf("%s 3 %s\n", red, reset) //should be brown
 		} else if percentUsed > 90 {

--- a/command/certificate/verify.go
+++ b/command/certificate/verify.go
@@ -81,7 +81,7 @@ $ step certificate verify ./certificate.crt --host smallstep.com --expire
 				Usage: `Check whether the certificate is for the specified host.`,
 			},
 			cli.BoolFlag{
-				Name:  "validity",
+				Name:  "expire",
 				Usage: `Check the remaining certificate validity until expiration`,
 			},
 			cli.StringFlag{
@@ -113,7 +113,7 @@ func verifyAction(ctx *cli.Context) error {
 	var (
 		crtFile          = ctx.Args().Get(0)
 		host             = ctx.String("host")
-		validity         = ctx.Bool("validity")
+		expire         = ctx.Bool("expire")
 		serverName       = ctx.String("servername")
 		roots            = ctx.String("roots")
 		intermediatePool = x509.NewCertPool()
@@ -178,7 +178,7 @@ func verifyAction(ctx *cli.Context) error {
 		}
 	}
 
-	if validity {
+	if expire {
 
 		remainingValidiy := time.Until(cert.NotAfter)
 		totalValidity := cert.NotAfter.Sub(cert.NotBefore)
@@ -191,18 +191,32 @@ func verifyAction(ctx *cli.Context) error {
 		reset := "\033[0m"
 		
 		if percentUsed >= 100 {
-			fmt.Println(red, "This certificate has already expired.", reset)
+			fmt.Printf("%s 3 %s\n", red, reset) //should be brown
 		} else if percentUsed > 90 {
-			fmt.Printf(red,"Leaf is", int(percentUsed), "% through its lifetime.", reset)
-		} else if percentUsed > 66 && percent < 90 {
-			fmt.Printf(yellow,"Leaf is", int(percentUsed), "% through its lifetime.", reset)
-		} else if percentUsed < 66 && percent > 1 {
-			fmt.Printf(green,"Leaf is", int(percentUsed), "% through its lifetime.", reset)
-		} else if percentUsed < 1{
-			fmt.Printf(green,"Leaf is less than 1% through its lifetime.", reset)
+			fmt.Printf("%s 2 %s\n", red, reset)
+		} else if percentUsed > 66 && percentUsed < 90 {
+			fmt.Printf("%s 1 %s\n", yellow, reset)
+		} else if percentUsed < 66 && percentUsed > 1 {
+			fmt.Printf("%s 0 %s\n", green, reset)
+		} else if percentUsed < 1 {
+			fmt.Printf("%s 0 %s\n", green, reset)
 		} else {
-			return errors.Errorf("failure to determine expiration time for certificate")
+			return errors.Errorf("Failure to determine expiration time for certificate")
 		}
+
+		/*if percentUsed >= 100 {
+			fmt.Println("This certificate has already expired.")
+		} else if percentUsed > 90 {
+			fmt.Printf("%sCertificate is %d percent through its lifetime.%s\n", red, percentUsed, reset)
+		} else if percentUsed > 66 && percentUsed < 90 {
+			fmt.Printf("%sCertificate is %d percent through its lifetime.%s\n", yellow, percentUsed, reset)
+		} else if percentUsed < 66 && percentUsed > 1 {
+			fmt.Printf("%sCertificate is %d percent through its lifetime.%s\n", green, percentUsed, reset)
+		} else if percentUsed < 1 {
+			fmt.Printf("%sCertificate is %d percent through its lifetime.%s\n", green, percentUsed, reset)
+		} else {
+			return errors.Errorf("Failure to determine expiration time for certificate")
+		}*/
 
 		return nil
 	}

--- a/command/certificate/verify.go
+++ b/command/certificate/verify.go
@@ -176,30 +176,31 @@ func verifyAction(ctx *cli.Context) error {
 			errors.Wrapf(err, "failure to load root certificate pool from input path '%s'", roots)
 		}
 	}
-	
-	if expire {
 
-		NowTillEndOfCert := time.Until(cert.NotAfter)
-		totalLifeTimeOfCert := cert.NotAfter.Sub(cert.NotBefore)
+        if expire {
 
-		percentIntoLifeTime  := ((totalLifeTimeOfCert.Hours() - NowTillEndOfCert.Hours()) / totalLifeTimeOfCert.Hours()) * 100
+                NowTillEndOfCert := time.Until(cert.NotAfter)
+                totalLifeTimeOfCert := cert.NotAfter.Sub(cert.NotBefore)
 
-		if percentIntoLifeTime >= 100 {
-			fmt.Println("\033[31m", "This certificate has already expired.", "\033[0m") //"\033[__m" are color codes
-		} else if percentIntoLifeTime > 90 {
-			fmt.Println("\033[31m","Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
-		} else if percentIntoLifeTime > 66 && percentIntoLifeTime < 90 {
-			fmt.Println("\033[33m","Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
-		} else if percentIntoLifeTime < 66 && percentIntoLifeTime > 1 {
-			fmt.Println("\033[32m","Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
-		} else if percentIntoLifeTime < 1{
-			fmt.Println("\033[32m","Leaf is less than 1% through its lifetime.", "\033[0m")
-		} else {
-			fmt.Println("Error")
-		}
+                percentIntoLifeTime := ((totalLifeTimeOfCert.Hours() - NowTillEndOfCert.Hours()) / totalLifeTimeOfCert.Hours()) * 100
 
-		return nil
-	}
+                if percentIntoLifeTime >= 100 {
+                        fmt.Println("\033[31m", "This certificate has already expired.", "\033[0m") //"\033[__m" are color codes
+                } else if percentIntoLifeTime > 90 {
+                        fmt.Println("\033[31m", "Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
+                } else if percentIntoLifeTime > 66 && percentIntoLifeTime < 90 {
+                        fmt.Println("\033[33m", "Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
+                } else if percentIntoLifeTime < 66 && percentIntoLifeTime > 1 {
+                        fmt.Println("\033[32m", "Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
+                } else if percentIntoLifeTime < 1 {
+                        fmt.Println("\033[32m", "Leaf is less than 1% through its lifetime.", "\033[0m")
+                } else {
+                        fmt.Println("Error")
+                }
+
+                return nil
+        }
+
 
 	opts := x509.VerifyOptions{
 		DNSName:       host,

--- a/command/certificate/verify.go
+++ b/command/certificate/verify.go
@@ -185,16 +185,21 @@ func verifyAction(ctx *cli.Context) error {
 
 		percentIntoLifeTime := ((totalLifeTimeOfCert.Hours() - NowTillEndOfCert.Hours()) / totalLifeTimeOfCert.Hours()) * 100
 
+		colorRed := "\033[31m"
+		colorGreen := "\033[32m"
+		colorYellow := "\033[33m"
+		colorReset := "\033[0m"
+		
 		if percentIntoLifeTime >= 100 {
-			fmt.Println("\033[31m", "This certificate has already expired.", "\033[0m") //"\033[__m" are color codes
+			fmt.Println(colorRed, "This certificate has already expired.", colorReset)
 		} else if percentIntoLifeTime > 90 {
-			fmt.Println("\033[31m", "Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
+			fmt.Printf(colorRed,"Leaf is", int(percentIntoLifeTime), "% through its lifetime.", colorReset)
 		} else if percentIntoLifeTime > 66 && percentIntoLifeTime < 90 {
-			fmt.Println("\033[33m", "Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
+			fmt.Printf(colorYellow,"Leaf is", int(percentIntoLifeTime), "% through its lifetime.", colorReset)
 		} else if percentIntoLifeTime < 66 && percentIntoLifeTime > 1 {
-			fmt.Println("\033[32m", "Leaf is", int(percentIntoLifeTime), "% through its lifetime.", "\033[0m")
-		} else if percentIntoLifeTime < 1 {
-			fmt.Println("\033[32m", "Leaf is less than 1% through its lifetime.", "\033[0m")
+			fmt.Printf(colorGreen,"Leaf is", int(percentIntoLifeTime), "% through its lifetime.", colorReset)
+		} else if percentIntoLifeTime < 1{
+			fmt.Printf(colorGreen,"Leaf is less than 1% through its lifetime.", colorReset)
 		} else {
 			return errors.Errorf("failure to determine expiration time for certificate")
 		}


### PR DESCRIPTION
Fixes issue #398 , added flag that allows you to check how much longer until a certificate is about to expire, along with the color coding the outputs based on if it is about to expire/expired (red), close (yellow), or still has under 66% of its life used (green). added to description how to use this function.