### PR TITLE
Allow more url variations in step certificate inspect

### DIFF
--- a/command/certificate/inspect.go
+++ b/command/certificate/inspect.go
@@ -196,7 +196,7 @@ func inspectAction(ctx *cli.Context) error {
 	var block *pem.Block
 	var blocks []*pem.Block
 	//check if address is www.example.com
-	if !strings.HasPrefix(crtFile, "https://") && strings.Contains(crtFile, ".com") {
+	if !strings.HasPrefix(crtFile, "https://") && strings.Contains(crtFile, "www.") {
 		crtFile = "https://" + crtFile
 	}
 	if addr, isURL, err := trimURL(crtFile); err != nil {

--- a/command/certificate/inspect.go
+++ b/command/certificate/inspect.go
@@ -195,7 +195,6 @@ func inspectAction(ctx *cli.Context) error {
 
 	var block *pem.Block
 	var blocks []*pem.Block
-	//check if address is www.example.com
 	if !strings.HasPrefix(crtFile, "https://") && strings.Contains(crtFile, "www.") {
 		crtFile = "https://" + crtFile
 	}

--- a/command/certificate/inspect.go
+++ b/command/certificate/inspect.go
@@ -199,6 +199,7 @@ func inspectAction(ctx *cli.Context) error {
 	if !strings.HasPrefix(crtFile, "https://") && strings.Contains(crtFile, "www.") {
 		crtFile = "https://" + crtFile
 	}
+
 	if addr, isURL, err := trimURL(crtFile); err != nil {
 		return err
 	} else if isURL {

--- a/command/certificate/inspect.go
+++ b/command/certificate/inspect.go
@@ -6,9 +6,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io"
-	"os"
-
 	"github.com/pkg/errors"
 	"github.com/smallstep/certinfo"
 	"github.com/smallstep/cli/errs"
@@ -16,6 +13,9 @@ import (
 	"github.com/smallstep/cli/utils"
 	zx509 "github.com/smallstep/zcrypto/x509"
 	"github.com/urfave/cli"
+	"io"
+	"os"
+	"strings"
 )
 
 func inspectCommand() cli.Command {
@@ -195,6 +195,11 @@ func inspectAction(ctx *cli.Context) error {
 
 	var block *pem.Block
 	var blocks []*pem.Block
+	//check if address is www.example.com
+	if !strings.HasPrefix(crtFile, "https://") && strings.Contains(crtFile, "www.") {
+		crtFile = "https://" + crtFile
+	}
+
 	if addr, isURL, err := trimURL(crtFile); err != nil {
 		return err
 	} else if isURL {

--- a/command/certificate/inspect.go
+++ b/command/certificate/inspect.go
@@ -196,7 +196,7 @@ func inspectAction(ctx *cli.Context) error {
 	var block *pem.Block
 	var blocks []*pem.Block
 	//check if address is www.example.com
-	if !strings.HasPrefix(crtFile, "https://") && strings.HasSuffix(crtFile, ".com") {
+	if !strings.HasPrefix(crtFile, "https://") && strings.Contains(crtFile, ".com") {
 		crtFile = "https://" + crtFile
 	}
 	if addr, isURL, err := trimURL(crtFile); err != nil {

--- a/command/certificate/inspect.go
+++ b/command/certificate/inspect.go
@@ -196,10 +196,9 @@ func inspectAction(ctx *cli.Context) error {
 	var block *pem.Block
 	var blocks []*pem.Block
 	//check if address is www.example.com
-	if !strings.HasPrefix(crtFile, "https://") && strings.Contains(crtFile, "www.") {
+	if !strings.HasPrefix(crtFile, "https://") && strings.HasSuffix(crtFile, ".com") {
 		crtFile = "https://" + crtFile
 	}
-
 	if addr, isURL, err := trimURL(crtFile); err != nil {
 		return err
 	} else if isURL {


### PR DESCRIPTION
Closes #275. The inspect command now allows www.example.com and www.example.com:443 to be given as a URL to inspect.
