### PR TITLE
Clarify the use of the --redirect-url flag

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -272,10 +272,11 @@ be stored in the 'sshpop' header.`,
 the **--team** option. If the url contains <\<\>> placeholders, they are replaced with the team ID.`,
 	}
 
-	// RedirectURL is a cli.Flag used to pass the OAuth redirect URL.
+	// RedirectURL is a cli.Flag used to pass a url to redirect after an OAuth
+	// flow finishes..
 	RedirectURL = cli.StringFlag{
 		Name:  "redirect-url",
-		Usage: "Terminal OAuth redirect <url>.",
+		Usage: "The <url> to open in the system browser when the OAuth flow is successful.",
 	}
 
 	// ServerName is a cli.Flag used to set the TLS Server Name Indication in


### PR DESCRIPTION
### Description 

This PR changes the usage of the --redirect-url. This flag is used in the `step oauth` command and can also be used in the `step ca bootstrap` command to write it in the defaults.json file.

This flag won't have any effect on oob flows, but we cannot fail if both are used because it will cause errors on specific configurations where errors are not expected.

Fixes #510