### PR TITLE
Step ca rekey Command

### DIFF
--- a/command/ca/ca.go
+++ b/command/ca/ca.go
@@ -72,6 +72,7 @@ $ step ca renew internal.crt internal.key \
 			bootstrapCommand(),
 			tokenCommand(),
 			certificateCommand(),
+			rekeyCertificateCommand(),
 			renewCertificateCommand(),
 			revokeCertificateCommand(),
 			provisioner.Command(),

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -188,7 +188,7 @@ Defaults to overwriting the <crt-file> positional argument.`,
 			},
 			cli.StringFlag{
 				Name: "out-key",
-				Usage: `The <file> where the new rekeyed private key will be saved to.
+				Usage: `The <file> where the new private key will be saved to.
  Defaults to overwriting the <key-file> positional argument.`,
 			},
 			cli.StringFlag{

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -215,22 +215,23 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 	givenPrivate := ctx.String("private-key")
 
 	outCert := ctx.String("out-cert")
+	outKey := ctx.String("out-key")
+	//check both flags are passed
+	if len(outCert) != 0 && len(outKey) == 0{
+		return errs.RequiredWithFlag(ctx, "out-cert", "out-key")
+	}
+	if len(outKey) !=0 && len(outCert) == 0{
+		return errs.RequiredWithFlag(ctx, "out-key", "out-cert")
+	}
+
 	if len(outCert) == 0 {
 		outCert = certFile
 	}
-
-	outKey := ctx.String("out-key")
 	if len(outKey) == 0 {
 		outKey = keyFile
 	}
 
-	//check both flags are passed
-	if len(outCert) != 0 {
-		return errs.RequiredWithFlag(ctx, "out-key", "out-cert")
-	}
-	if len(outKey) != 0 {
-		return errs.RequiredWithFlag(ctx, "out-cert", "out-key")
-	}
+
 
 	rootFile := ctx.String("root")
 	if len(rootFile) == 0 {

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -1,0 +1,63 @@
+package ca
+
+import (
+	"github.com/smallstep/cli/command"
+	"github.com/smallstep/cli/errs"
+	"github.com/urfave/cli"
+)
+
+func rekeyCertificateCommand() cli.Command {
+	return cli.Command{
+		Name:      "rekey",
+		Action:    command.ActionFunc(rekeyCertificateAction),
+		Usage:     "rekey a valid certificate",
+		UsageText: `**step ca renew** <crt-file> <key-file> 
+					[**--out**=<file>]`,
+Description:
+		`**step ca rekey** command rekeys the given certificate (with a request to the
+		certificate authority) and writes the new certificate to disk - either overwriting
+		<crt-file> or using a new file when the **--out**=<file> flag is used.
+
+## POSITIONAL ARGUMENTS
+
+<crt-file>
+:  The certificate in PEM format that we want to renew.
+
+<key-file>
+:  They private key file of the certificate.
+
+## EXAMPLES
+
+Rekey a certificate
+'''
+$ step ca rekey
+'''`,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "out,output-file",
+				Usage: "The new certificate <file> path. Defaults to overwriting the <crt-file> positional argument",
+			},
+		},
+	}
+}
+
+func rekeyCertificateAction(ctx *cli.Context) error {
+	err := errs.NumberOfArguments(ctx, 2)
+	if err != nil {
+		return err
+	}
+
+	args := ctx.Args()
+	certFile := args.Get(0)
+	keyFile := args.Get(1)
+
+	outFile := ctx.String("out")
+	if len(outFile) == 0 {
+		outFile = certFile
+	}
+
+
+
+
+	return nil
+}

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -313,7 +313,6 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 	// Do not renew if (cert.notAfter - now) > (expiresIn + jitter)
 	if expiresIn > 0 {
 		jitter := rand.Int63n(int64(expiresIn / 20))
-		//jitter := mathRand.Int63n(int64(expiresIn / 20))
 		if d := time.Until(leaf.NotAfter); d > expiresIn+time.Duration(jitter) {
 			ui.Printf("certificate not renewed: expires in %s\n", d.Round(time.Second))
 			return nil
@@ -321,7 +320,8 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 	}
 
 	if givenPrivate == "" {
-		_, priv , err := keyutil.GenerateDefaultKeyPair(); if err != nil {
+		_, priv, err := keyutil.GenerateDefaultKeyPair()
+		if err != nil {
 			return err
 		}
 		if _, err := renewer.Rekey(priv, outCert, outKey); err != nil {
@@ -330,7 +330,8 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 		ui.Printf("Your certificate and key has been saved in %s %s .\n", outCert, outKey)
 
 	} else {
-		priv, err := pemutil.Read(givenPrivate); if err != nil{
+		priv, err := pemutil.Read(givenPrivate)
+		if err != nil {
 			return err
 		}
 		if _, err := renewer.Rekey(priv, outCert, outKey); err != nil {

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -185,7 +185,7 @@ each with optional fraction and a unit suffix, such as "300ms", "1.5h", or "2h45
 Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
 			},
 			cli.StringFlag{
-				Name:  "out-crt",
+				Name:  "out-cert",
 				Usage: `Write the new rekeyed certificate into a specified new certificate file.`,
 			},
 			cli.StringFlag{
@@ -211,16 +211,15 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 	certFile := args.Get(0)
 	keyFile := args.Get(1)
 	passFile := ctx.String("password-file")
-	outKey := ctx.String("key-out")
+	outKey := ctx.String("out-key")
 	isDaemon := ctx.Bool("daemon")
 	execCmd := ctx.String("exec")
-	//crtDest := ctx.String("out-crt")
-	//keyDest := ctx.String("out-key")
-	//givenKey := ctx.String("private-key")
 
-	outFile := ctx.String("out")
-	if len(outFile) == 0 {
-		outFile = certFile
+
+
+	outCrt := ctx.String("out-cert")
+	if len(outCrt) == 0 {
+		outCrt = certFile
 	}
 
 	rootFile := ctx.String("root")
@@ -304,7 +303,7 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 		// Force is always enabled when daemon mode is used
 		ctx.Set("force", "true")
 		next := nextRenewDuration(leaf, expiresIn, renewPeriod)
-		return renewer.Daemon(outFile, next, expiresIn, renewPeriod, afterRenew)
+		return renewer.Daemon(outCrt, next, expiresIn, renewPeriod, afterRenew)
 	}
 
 	// Do not renew if (cert.notAfter - now) > (expiresIn + jitter)
@@ -317,11 +316,11 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 		}
 	}
 	pk, err := pemutil.Read(keyFile)
-	if _, err := renewer.Rekey(pk, outFile, outKey); err != nil {
-		//if _, err := renewer.Renew(outFile); err != nil {
+	if _, err := renewer.Rekey(pk, outCrt, outKey); err != nil {
+		//if _, err := renewer.Renew(outCrt); err != nil {
 		return err
 	}
 
-	ui.Printf("Your certificate has been saved in %s.\n", outFile)
+	ui.Printf("Your certificate has been saved in %s.\n", outCrt)
 	return afterRenew()
 }

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"github.com/smallstep/cli/crypto/pemutil"
 	"go.step.sm/crypto/keyutil"
 	"io/ioutil"
 	"math/rand"
@@ -202,7 +203,7 @@ if nothing is passed, default goes to generating a random pair.`,
 }
 
 func rekeyCertificateAction(ctx *cli.Context) error {
-	err := errs.MinMaxNumberOfArguments(ctx, 2, 3)
+	err := errs.NumberOfArguments(ctx, 2)
 	if err != nil {
 		return err
 	}
@@ -210,7 +211,6 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 	args := ctx.Args()
 	certFile := args.Get(0)
 	keyFile := args.Get(1)
-	privateKey := args.Get(2)
 	passFile := ctx.String("password-file")
 	isDaemon := ctx.Bool("daemon")
 	execCmd := ctx.String("exec")
@@ -330,7 +330,10 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 		ui.Printf("Your certificate and key has been saved in %s %s .\n", outCert, outKey)
 
 	} else {
-		if _, err := renewer.Rekey(privateKey, outCert, outKey); err != nil {
+		priv, err := pemutil.Read(givenPrivate); if err != nil{
+			return err
+		}
+		if _, err := renewer.Rekey(priv, outCert, outKey); err != nil {
 			return err
 		}
 		ui.Printf("Your certificate and key has been saved in %s %s .\n", outCert, outKey)

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"go.step.sm/crypto/keyutil"
 	"io/ioutil"
 	"math/rand"
 	//mathRand "math/rand"
@@ -12,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/smallstep/certificates/pki"
 	"github.com/smallstep/cli/command"
-	"github.com/smallstep/cli/crypto/pemutil"
 	"github.com/smallstep/cli/errs"
 	"github.com/smallstep/cli/flags"
 	"github.com/smallstep/cli/ui"
@@ -315,12 +315,32 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 			return nil
 		}
 	}
-	pk, err := pemutil.Read(keyFile)
-	if _, err := renewer.Rekey(pk, outCrt, outKey); err != nil {
+
+	//if keyFile == ""{
+	//	_, priv , err := keyutil.GenerateDefaultKeyPair(); if err != nil{
+	//		return err
+	//	}
+	//	if _, err := renewer.Rekey(priv, outCrt, outKey); err != nil {
+	//		//if _, err := renewer.Renew(outCrt); err != nil {
+	//		return err
+	//	}
+	//}else{
+	//	priv, err := pemutil.Read(keyFile); if err != nil{
+	//		return err
+	//	}
+	//	if _, err := renewer.Rekey(priv, outCrt, outKey); err != nil {
+	//		//if _, err := renewer.Renew(outCrt); err != nil {
+	//		return err
+	//	}
+	//}
+	_, priv , err := keyutil.GenerateDefaultKeyPair(); if err != nil{
+		return err
+	}
+	if _, err := renewer.Rekey(priv, outCrt, outKey); err != nil {
 		//if _, err := renewer.Renew(outCrt); err != nil {
 		return err
 	}
 
-	ui.Printf("Your certificate has been saved in %s.\n", outCrt)
+	ui.Printf("Your certificate and key has been saved in %s %s .\n", outCrt, outKey)
 	return afterRenew()
 }

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"github.com/smallstep/cli/crypto/pemutil"
 	"go.step.sm/crypto/keyutil"
 	"io/ioutil"
 	"math/rand"
@@ -209,7 +210,7 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 
 	args := ctx.Args()
 	certFile := args.Get(0)
-	keyFile := args.Get(1)
+	keyFile := ctx.String("private-key")
 	passFile := ctx.String("password-file")
 	outKey := ctx.String("out-key")
 	isDaemon := ctx.Bool("daemon")
@@ -316,30 +317,22 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 		}
 	}
 
-	//if keyFile == ""{
-	//	_, priv , err := keyutil.GenerateDefaultKeyPair(); if err != nil{
-	//		return err
-	//	}
-	//	if _, err := renewer.Rekey(priv, outCrt, outKey); err != nil {
-	//		//if _, err := renewer.Renew(outCrt); err != nil {
-	//		return err
-	//	}
-	//}else{
-	//	priv, err := pemutil.Read(keyFile); if err != nil{
-	//		return err
-	//	}
-	//	if _, err := renewer.Rekey(priv, outCrt, outKey); err != nil {
-	//		//if _, err := renewer.Renew(outCrt); err != nil {
-	//		return err
-	//	}
-	//}
-	_, priv , err := keyutil.GenerateDefaultKeyPair(); if err != nil{
-		return err
+	if keyFile == ""{
+		_, priv , err := keyutil.GenerateDefaultKeyPair(); if err != nil{
+			return err
+		}
+		if _, err := renewer.Rekey(priv, outCrt, outKey); err != nil {
+			return err
+		}
+	}else{
+		priv, err := pemutil.Read(keyFile); if err != nil{
+			return err
+		}
+		if _, err := renewer.Rekey(priv, outCrt, outKey); err != nil {
+			return err
+		}
 	}
-	if _, err := renewer.Rekey(priv, outCrt, outKey); err != nil {
-		//if _, err := renewer.Renew(outCrt); err != nil {
-		return err
-	}
+
 
 	ui.Printf("Your certificate and key has been saved in %s %s .\n", outCrt, outKey)
 	return afterRenew()

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -217,10 +217,10 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 	outCert := ctx.String("out-cert")
 	outKey := ctx.String("out-key")
 	//check both flags are passed
-	if len(outCert) != 0 && len(outKey) == 0{
+	if len(outCert) != 0 && len(outKey) == 0 {
 		return errs.RequiredWithFlag(ctx, "out-cert", "out-key")
 	}
-	if len(outKey) !=0 && len(outCert) == 0{
+	if len(outKey) != 0 && len(outCert) == 0 {
 		return errs.RequiredWithFlag(ctx, "out-key", "out-cert")
 	}
 
@@ -230,8 +230,6 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 	if len(outKey) == 0 {
 		outKey = keyFile
 	}
-
-
 
 	rootFile := ctx.String("root")
 	if len(rootFile) == 0 {

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -1,6 +1,14 @@
 package ca
 
 import (
+	"io/ioutil"
+	"math/rand"
+	//mathRand "math/rand"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/smallstep/certificates/pki"
 	"github.com/smallstep/cli/command"
@@ -9,24 +17,34 @@ import (
 	"github.com/smallstep/cli/flags"
 	"github.com/smallstep/cli/ui"
 	"github.com/urfave/cli"
-	"io/ioutil"
-	"math/rand"
-	"strconv"
-	"strings"
-	"time"
 )
 
 func rekeyCertificateCommand() cli.Command {
 	return cli.Command{
-		Name:      "rekey",
-		Action:    command.ActionFunc(rekeyCertificateAction),
-		Usage:     "rekey a valid certificate",
-		UsageText: `**step ca renew** <crt-file> <key-file> 
-					[**--out**=<file>]`,
-Description:
-		`**step ca rekey** command rekeys the given certificate (with a request to the
-		certificate authority) and writes the new certificate to disk - either overwriting
-		<crt-file> or using a new file when the **--out**=<file> flag is used.
+		Name:   "rekey",
+		Action: command.ActionFunc(rekeyCertificateAction),
+		Usage:  "rekey a valid certificate",
+		UsageText: `**step ca rekey** <crt-file> <key-file>
+[**--out-crt**=<file>] [**--out-key**=<file>] [**--private-key**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--password-file**=<file>]
+[**--out**=<file>] [**--expires-in**=<duration>] [**--force**]
+[**--expires-in**=<duration>] [**--pid**=<int>] [**--pid-file**=<file>]
+[**--signal**=<int>] [**--exec**=<string>] [**--daemon**]
+[**--renew-period**=<duration>]`,
+		Description: `
+**step ca rekey** command rekeys the given certificate (with a request to the
+certificate authority) and writes the new certificate to disk - either overwriting
+<crt-file> or using a new file when the **--out**=<file> flag is used.
+
+With the **--daemon** flag the command will periodically update the given
+certificate. By default, it will renew the certificate before 2/3 of the validity
+period of the certificate has elapsed. A random jitter is used to avoid multiple
+instances running at the same time. The amount of time between renewal and
+certificate expiration can be configured using the **--expires-in** flag, or a
+fixed period can be set with the **--renew-period** flag.
+
+The **--daemon** flag can be combined with **--pid**, **--signal**, or **--exec**
+to provide certificate reloads on your services.
 
 ## POSITIONAL ARGUMENTS
 
@@ -34,18 +52,150 @@ Description:
 :  The certificate in PEM format that we want to renew.
 
 <key-file>
-:  They private key file of the certificate.
+:  They key file of the certificate.
 
 ## EXAMPLES
 
-Rekey a certificate
+Rekey a certificate with the configured CA:
 '''
-$ step ca rekey
+$ step ca rekey internal.crt internal.key
+Would you like to overwrite internal.crt [Y/n]: y
+'''
+
+Rekey a certificate without overwriting the previous certificate:
+'''
+$ step ca rekey --out renewed.crt internal.crt internal.key
+'''
+
+Rekey a certificate forcing the overwrite of the previous certificate:
+'''
+$ step ca rekey --force internal.crt internal.key
+'''
+
+Rekey a certificate providing the <--ca-url> and <--root> flags:
+'''
+$ step ca rekey --ca-url https://ca.smallstep.com:9000 \
+  --root /path/to/root_ca.crt internal.crt internal.key
+Would you like to overwrite internal.crt [Y/n]: y
+'''
+
+Rekey skipped because it was too early:
+'''
+$ step ca rekey --expires-in 8h internal.crt internal.key
+certificate not renewed: expires in 10h52m5s
+'''
+
+Rekey the certificate before 2/3 of the validity has passed:
+'''
+$ step ca rekey --daemon internal.crt internal.key
+'''
+
+Rekey the certificate before 8 hours and 30m of the expiration time:
+'''
+$ step ca rekey --daemon --expires-in 8h30m internal.crt internal.key
+'''
+
+Rekey the certificate every 16h:
+'''
+$ step ca rekey --daemon --renew-period 16h internal.crt internal.key
+'''
+
+Rekey the certificate and reload nginx:
+'''
+$ step ca rekey --daemon --exec "nginx -s reload" internal.crt internal.key
+'''
+
+Rekey the certificate and convert it to DER:
+'''
+$ step ca renew --daemon --renew-period 16h \
+  --exec "step certificate format --force --out internal.der internal.crt" \
+  internal.crt internal.key
+'''
+
+Rekey a certificate using the offline mode, requires the configuration
+files, certificates, and keys created with **step ca init**:
+'''
+$ step ca rekey --offline internal.crt internal.key
+'''
+
+Rekey the certificate and write it to specified files:
+'''
+$ step ca rekey foo.crt foo.key --out-crt internal.crt --out-key internal.key
+'''
+
+Rekey the certificate using a given private key:
+'''
+$ step ca rekey  internal.crt internal.key --private-key foo.key
 '''`,
 		Flags: []cli.Flag{
+			flags.CaConfig,
+			flags.CaURL,
+			flags.Force,
+			flags.Offline,
+			flags.PasswordFile,
+			flags.Root,
 			cli.StringFlag{
 				Name:  "out,output-file",
 				Usage: "The new certificate <file> path. Defaults to overwriting the <crt-file> positional argument",
+			},
+			cli.StringFlag{
+				Name: "expires-in",
+				Usage: `The amount of time remaining before certificate expiration,
+at which point a renewal should be attempted. The certificate renewal will not
+be performed if the time to expiration is greater than the **--expires-in** value.
+A random jitter (duration/20) will be added to avoid multiple services hitting the
+renew endpoint at the same time. The <duration> is a sequence of decimal numbers,
+each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
+Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
+			},
+			cli.IntFlag{
+				Name: "pid",
+				Usage: `The process id to signal after the certificate has been renewed. By default the
+the SIGHUP (1) signal will be used, but this can be configured with the **--signal**
+flag.`,
+			},
+			cli.StringFlag{
+				Name: "pid-file",
+				Usage: `The <file> from which to read the process id that will be signaled after the certificate
+has been renewed. By default the the SIGHUP (1) signal will be used, but this can be configured with the **--signal**
+flag.`,
+			},
+			cli.IntFlag{
+				Name: "signal",
+				Usage: `The signal <number> to send to the selected PID, so it can reload the
+configuration and load the new certificate. Default value is SIGHUP (1)`,
+				Value: int(syscall.SIGHUP),
+			},
+			cli.StringFlag{
+				Name:  "exec",
+				Usage: "The <command> to run after the certificate has been renewed.",
+			},
+			cli.BoolFlag{
+				Name: "daemon",
+				Usage: `Run the renew command as a daemon, renewing and overwriting the certificate
+periodically. By default the daemon will renew a certificate before 2/3 of the
+time to expiration has elapsed. The period can be configured using the
+**--renew-period** or **--expires-in** flags.`,
+			},
+			cli.StringFlag{
+				Name: "renew-period",
+				Usage: `The period with which to schedule renewals of the certificate in daemon mode.
+Requires the **--daemon** flag. The <duration> is a sequence of decimal numbers,
+each with optional fraction and a unit suffix, such as "300ms", "1.5h", or "2h45m".
+Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
+			},
+			cli.StringFlag{
+				Name:  "out-crt",
+				Usage: `Write the new rekeyed certificate into a specified new certificate file.`,
+			},
+			cli.StringFlag{
+				Name:  "out-key",
+				Usage: `Write the new rekeyed private key into a specified new private key file.`,
+			},
+			cli.StringFlag{
+				Name: "private-key",
+				Usage: `Use a given private key to do the rekeying of a certificate and private key pair,
+if nothing is passed, default goes to generating a random pair.`,
 			},
 		},
 	}
@@ -64,6 +214,9 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 	outKey := ctx.String("key-out")
 	isDaemon := ctx.Bool("daemon")
 	execCmd := ctx.String("exec")
+	//crtDest := ctx.String("out-crt")
+	//keyDest := ctx.String("out-key")
+	//givenKey := ctx.String("private-key")
 
 	outFile := ctx.String("out")
 	if len(outFile) == 0 {
@@ -157,21 +310,18 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 	// Do not renew if (cert.notAfter - now) > (expiresIn + jitter)
 	if expiresIn > 0 {
 		jitter := rand.Int63n(int64(expiresIn / 20))
+		//jitter := mathRand.Int63n(int64(expiresIn / 20))
 		if d := time.Until(leaf.NotAfter); d > expiresIn+time.Duration(jitter) {
 			ui.Printf("certificate not renewed: expires in %s\n", d.Round(time.Second))
 			return nil
 		}
 	}
 	pk, err := pemutil.Read(keyFile)
-	if _, err := renewer.Rekey(pk,outFile,outKey); err != nil {
+	if _, err := renewer.Rekey(pk, outFile, outKey); err != nil {
+		//if _, err := renewer.Renew(outFile); err != nil {
 		return err
 	}
 
 	ui.Printf("Your certificate has been saved in %s.\n", outFile)
 	return afterRenew()
-
-
-
-
-	return nil
 }

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -183,7 +183,7 @@ Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
 			},
 			cli.StringFlag{
 				Name: "out-cert",
-				Usage: `The <file> where the new rekeyed certificate will be saved to.
+				Usage: `The <file> where the new certificate will be saved to.
 Defaults to overwriting the <crt-file> positional argument.`,
 			},
 			cli.StringFlag{

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -1,9 +1,20 @@
 package ca
 
 import (
+	"encoding/pem"
+	"github.com/pkg/errors"
+	"github.com/smallstep/certificates/api"
+	"github.com/smallstep/certificates/pki"
 	"github.com/smallstep/cli/command"
+	"github.com/smallstep/cli/crypto/pemutil"
 	"github.com/smallstep/cli/errs"
+	"github.com/smallstep/cli/flags"
+	"github.com/smallstep/cli/ui"
+	"github.com/smallstep/cli/utils"
 	"github.com/urfave/cli"
+	"math/rand"
+	"strconv"
+	"time"
 )
 
 func rekeyCertificateCommand() cli.Command {
@@ -50,14 +61,103 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 	args := ctx.Args()
 	certFile := args.Get(0)
 	keyFile := args.Get(1)
+	passFile := ctx.String("password-file")
 
 	outFile := ctx.String("out")
 	if len(outFile) == 0 {
 		outFile = certFile
 	}
 
+	rootFile := ctx.String("root")
+	if len(rootFile) == 0 {
+		rootFile = pki.GetRootCAPath()
+	}
+
+	caURL, err := flags.ParseCaURL(ctx)
+	if err != nil {
+		return err
+	}
+
+	var expiresIn, renewPeriod time.Duration
+	if s := ctx.String("expires-in"); len(s) > 0 {
+		if expiresIn, err = time.ParseDuration(s); err != nil {
+			return errs.InvalidFlagValue(ctx, "expires-in", s, "")
+		}
+	}
+	if s := ctx.String("renew-period"); len(s) > 0 {
+		if renewPeriod, err = time.ParseDuration(s); err != nil {
+			return errs.InvalidFlagValue(ctx, "renew-period", s, "")
+		}
+	}
+	if expiresIn > 0 && renewPeriod > 0 {
+		return errs.IncompatibleFlagWithFlag(ctx, "expires-in", "renew-period")
+	}
+
+	signum := ctx.Int("signal")
+	if ctx.IsSet("signal") && signum <= 0 {
+		return errs.InvalidFlagValue(ctx, "signal", strconv.Itoa(signum), "")
+	}
+
+	cert, err := tlsLoadX509KeyPair(certFile, keyFile, passFile)
+	if err != nil {
+		return err
+	}
+	leaf := cert.Leaf
+
+	if leaf.NotAfter.Before(time.Now()) {
+		return errors.New("cannot renew an expired certificate")
+	}
+	cvp := leaf.NotAfter.Sub(leaf.NotBefore)
+	if renewPeriod > 0 && renewPeriod >= cvp {
+		return errors.Errorf("flag '--renew-period' must be within (lower than) the certificate "+
+			"validity period; renew-period=%v, cert-validity-period=%v", renewPeriod, cvp)
+	}
+
+	renewer, err := newRenewer(ctx, caURL, cert, rootFile)
+	if err != nil {
+		return err
+	}
+
+
+	// Do not renew if (cert.notAfter - now) > (expiresIn + jitter)
+	if expiresIn > 0 {
+		jitter := rand.Int63n(int64(expiresIn / 20))
+		if d := time.Until(leaf.NotAfter); d > expiresIn+time.Duration(jitter) {
+			ui.Printf("certificate not renewed: expires in %s\n", d.Round(time.Second))
+			return nil
+		}
+	}
+
+	if _, err := renewer.Rekey(outFile); err != nil {
+		return err
+	}
+
+	ui.Printf("Your certificate has been saved in %s.\n", outFile)
 
 
 
 	return nil
+}
+func (r *renewer) Rekey(outFile string) (*api.SignResponse, error) {
+	resp, err := r.client.Renew(r.transport)
+	if err != nil {
+		return nil, errors.Wrap(err, "error renewing certificate")
+	}
+
+	if resp.CertChainPEM == nil || len(resp.CertChainPEM) == 0 {
+		resp.CertChainPEM = []api.Certificate{resp.ServerPEM, resp.CaPEM}
+	}
+	var data []byte
+	for _, certPEM := range resp.CertChainPEM {
+		pemblk, err := pemutil.Serialize(certPEM.Certificate)
+		if err != nil {
+			return nil, errors.Wrap(err, "error serializing certificate PEM")
+		}
+		data = append(data, pem.EncodeToMemory(pemblk)...)
+	}
+	if err := utils.WriteFile(outFile, data, 0600); err != nil {
+		return nil, errs.FileError(err, outFile)
+	}
+
+	return resp, nil
 }

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -226,6 +226,14 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 		outKey = keyFile
 	}
 
+	//check both flags are passed
+	if len(outCert) != 0 {
+		return errs.RequiredWithFlag(ctx, "out-key", "out-cert")
+	}
+	if len(outKey) != 0 {
+		return errs.RequiredWithFlag(ctx, "out-cert", "out-key")
+	}
+
 	rootFile := ctx.String("root")
 	if len(rootFile) == 0 {
 		rootFile = pki.GetRootCAPath()

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -335,7 +335,7 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 		if _, err := renewer.Rekey(priv, outCert, outKey); err != nil {
 			return err
 		}
-		ui.Printf("Your certificate and key has been saved in %s %s .\n", outCert, outKey)
+
 
 	} else {
 		priv, err := pemutil.Read(givenPrivate)
@@ -345,8 +345,8 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 		if _, err := renewer.Rekey(priv, outCert, outKey); err != nil {
 			return err
 		}
-		ui.Printf("Your certificate and key has been saved in %s %s .\n", outCert, outKey)
-
 	}
+	
+	ui.Printf("Your certificate and key has been saved in %s %s .\n", outCert, outKey)
 	return afterRenew()
 }

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -329,11 +329,14 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 			return err
 		}
 		priv, err = keys.GenerateKey(kty, crv, size)
+		if err != nil {
+			return err
+		}
 	} else {
 		priv, err = pemutil.Read(givenPrivate)
-	}
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
 	}
 	if _, err := renewer.Rekey(priv, outCert, outKey, ctx.IsSet("out-key") || givenPrivate == ""); err != nil {
 		return err

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -213,16 +213,8 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 	isDaemon := ctx.Bool("daemon")
 	execCmd := ctx.String("exec")
 	givenPrivate := ctx.String("private-key")
-
 	outCert := ctx.String("out-cert")
 	outKey := ctx.String("out-key")
-	//check both flags are passed
-	if len(outCert) != 0 && len(outKey) == 0 {
-		return errs.RequiredWithFlag(ctx, "out-cert", "out-key")
-	}
-	if len(outKey) != 0 && len(outCert) == 0 {
-		return errs.RequiredWithFlag(ctx, "out-key", "out-cert")
-	}
 
 	if len(outCert) == 0 {
 		outCert = certFile

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -33,11 +33,11 @@ func rekeyCertificateCommand() cli.Command {
 		Description: `
 **step ca rekey** command rekeys the given certificate (with a request to the
 certificate authority) and writes the new certificate and private key 
-to disk - either overwriting <crt-file> <key-file> or using a new file when
+to disk - either overwriting <crt-file> and <key-file> or writing to new files when
 the **--out-cert**=<file> and **--out-key**=<file> flags are used.
 
 With the **--daemon** flag the command will periodically update the given
-certificate. By default, it will renew the certificate before 2/3 of the validity
+certificate. By default, it will rekey the certificate before 2/3 of the validity
 period of the certificate has elapsed. A random jitter is used to avoid multiple
 instances running at the same time. The amount of time between renewal and
 certificate expiration can be configured using the **--expires-in** flag, or a

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -26,7 +26,7 @@ func rekeyCertificateCommand() cli.Command {
 	return cli.Command{
 		Name:   "rekey",
 		Action: command.ActionFunc(rekeyCertificateAction),
-		Usage:  "rekey a valid certificate",
+		Usage:  "rekey a certificate",
 		UsageText: `**step ca rekey** <crt-file> <key-file>
 [**--out-cert**=<file>] [**--out-key**=<file>] [**--private-key**=<file>]
 [**--ca-url**=<uri>] [**--root**=<file>] [**--password-file**=<file>]
@@ -329,16 +329,13 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 			return err
 		}
 		priv, err = keys.GenerateKey(kty, crv, size)
-		if err != nil {
-			return err
-		}
 	} else {
 		priv, err = pemutil.Read(givenPrivate)
 	}
 	if err != nil {
 		return err
 	}
-	if _, err := renewer.Rekey(priv, outCert, outKey); err != nil {
+	if _, err := renewer.Rekey(priv, outCert, outKey, ctx.IsSet("out-key") || givenPrivate == ""); err != nil {
 		return err
 	}
 

--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -213,12 +213,12 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 	isDaemon := ctx.Bool("daemon")
 	execCmd := ctx.String("exec")
 	givenPrivate := ctx.String("private-key")
-	outCert := ctx.String("out-cert")
-	outKey := ctx.String("out-key")
 
+	outCert := ctx.String("out-cert")
 	if len(outCert) == 0 {
 		outCert = certFile
 	}
+	outKey := ctx.String("out-key")
 	if len(outKey) == 0 {
 		outKey = keyFile
 	}

--- a/command/ca/renew.go
+++ b/command/ca/renew.go
@@ -472,7 +472,8 @@ func (r *renewer) Rekey(priv interface{}, outCert, outKey string) (*api.SignResp
 	if err := utils.WriteFile(outCert, data, 0600); err != nil {
 		return nil, errs.FileError(err, outCert)
 	}
-	_, err = pemutil.Serialize(priv, pemutil.ToFile(outKey, 0600)); if err != nil{
+	_, err = pemutil.Serialize(priv, pemutil.ToFile(outKey, 0600))
+	if err != nil {
 		return nil, err
 	}
 

--- a/command/ca/renew.go
+++ b/command/ca/renew.go
@@ -451,9 +451,10 @@ func (r *renewer) Renew(outFile string) (*api.SignResponse, error) {
 }
 
 func (r *renewer) Rekey(priv interface{}, outCert, outKey string) (*api.SignResponse, error) {
-	csr, err := x509.CreateCertificateRequest(cryptoRand.Reader, &x509.CertificateRequest{}, priv)
-	newCSR, err := x509.ParseCertificateRequest(csr)
-	resp, err := r.client.Rekey(&api.RekeyRequest{CsrPEM: newCSR}, r.transport)
+	csrBytes, err := x509.CreateCertificateRequest(cryptoRand.Reader, &x509.CertificateRequest{}, priv)
+	csr, err := x509.ParseCertificateRequest(csrBytes)
+	csrRequest := api.NewCertificateRequest(csr)
+	resp, err := r.client.Rekey(&api.RekeyRequest{CsrPEM: csrRequest}, r.transport)
 	if err != nil {
 		return nil, errors.Wrap(err, "error rekeying certificate")
 	}

--- a/command/ca/renew.go
+++ b/command/ca/renew.go
@@ -472,7 +472,8 @@ func (r *renewer) Rekey(priv interface{}, outCert, outKey string) (*api.SignResp
 	if err := utils.WriteFile(outCert, data, 0600); err != nil {
 		return nil, errs.FileError(err, outCert)
 	}
-	if err := utils.WriteFile(outKey, data, 0600); err != nil {
+	newPrivateKey, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err := utils.WriteFile(outKey, newPrivateKey, 0600); err != nil {
 		return nil, errs.FileError(err, outKey)
 	}
 	return resp, nil

--- a/command/ca/renew.go
+++ b/command/ca/renew.go
@@ -452,9 +452,14 @@ func (r *renewer) Renew(outFile string) (*api.SignResponse, error) {
 
 func (r *renewer) Rekey(priv interface{}, outCert, outKey string) (*api.SignResponse, error) {
 	csrBytes, err := x509.CreateCertificateRequest(cryptoRand.Reader, &x509.CertificateRequest{}, priv)
+	if err != nil {
+		return nil, err
+	}
 	csr, err := x509.ParseCertificateRequest(csrBytes)
-	csrRequest := api.NewCertificateRequest(csr)
-	resp, err := r.client.Rekey(&api.RekeyRequest{CsrPEM: csrRequest}, r.transport)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := r.client.Rekey(&api.RekeyRequest{CsrPEM: api.NewCertificateRequest(csr)}, r.transport)
 	if err != nil {
 		return nil, errors.Wrap(err, "error rekeying certificate")
 	}

--- a/command/ca/renew.go
+++ b/command/ca/renew.go
@@ -472,10 +472,10 @@ func (r *renewer) Rekey(priv interface{}, outCert, outKey string) (*api.SignResp
 	if err := utils.WriteFile(outCert, data, 0600); err != nil {
 		return nil, errs.FileError(err, outCert)
 	}
-	newPrivateKey, err := x509.MarshalPKCS8PrivateKey(priv)
-	if err := utils.WriteFile(outKey, newPrivateKey, 0600); err != nil {
-		return nil, errs.FileError(err, outKey)
+	_, err = pemutil.Serialize(priv, pemutil.ToFile(outKey, 0600)); if err != nil{
+		return nil, err
 	}
+
 	return resp, nil
 }
 

--- a/utils/cautils/client.go
+++ b/utils/cautils/client.go
@@ -27,6 +27,7 @@ type CaClient interface {
 	Sign(req *api.SignRequest) (*api.SignResponse, error)
 	Renew(tr http.RoundTripper) (*api.SignResponse, error)
 	Revoke(req *api.RevokeRequest, tr http.RoundTripper) (*api.RevokeResponse, error)
+	Rekey(req *api.RekeyRequest, tr http.RoundTripper) (*api.SignResponse, error)
 	SSHSign(req *api.SSHSignRequest) (*api.SSHSignResponse, error)
 	SSHRenew(req *api.SSHRenewRequest) (*api.SSHRenewResponse, error)
 	SSHRekey(req *api.SSHRekeyRequest) (*api.SSHRekeyResponse, error)

--- a/utils/cautils/offline.go
+++ b/utils/cautils/offline.go
@@ -275,7 +275,7 @@ func (c *OfflineCA) Rekey(req *api.RekeyRequest, rt http.RoundTripper) (*api.Sig
 		return nil, errors.Wrap(err, "error parsing certificate")
 	}
 	// renew cert using authority
-	certChain, err := c.authority.Rekey(peer,peer.PublicKey)
+	certChain, err := c.authority.Rekey(peer, peer.PublicKey)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/cautils/offline.go
+++ b/utils/cautils/offline.go
@@ -274,8 +274,9 @@ func (c *OfflineCA) Rekey(req *api.RekeyRequest, rt http.RoundTripper) (*api.Sig
 	if err != nil {
 		return nil, errors.Wrap(err, "error parsing certificate")
 	}
-	// renew cert using authority
-	certChain, err := c.authority.Rekey(peer, peer.PublicKey)
+	// rekey cert using authority
+
+	certChain, err := c.authority.Rekey(peer, req.CsrPEM.PublicKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #316 by adding `step ca rekey` as a command. 
Example Uses:

Rekey the certificate and write the certificate and newly generated private key to specified files:
`step ca rekey internal.crt internal.key --out-crt foo.crt --out-key foo.key
`
Rekey the certificate using a given private key:
`step ca rekey internal.crt internal.key --private-key foo.key`
--offline flag added on also works