### PR TITLE
[action] goreleaser remove cgo env var

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,9 +7,7 @@ before:
     - go mod download
     # - go generate ./...
 builds:
-  - env:
-      - CGO_ENABLED=0
-    goos:
+  - goos:
       - linux
       - windows
       - darwin


### PR DESCRIPTION
- this env var isn't actually doing anything, it should be
  CGO_OVERRIDE=CGO_ENABLED=0
- CGO_ENABLED=0 by default already

