### PR TITLE
Update tests to match current exception strings for malformed certs.

### DIFF
--- a/crypto/pemutil/pem_test.go
+++ b/crypto/pemutil/pem_test.go
@@ -259,7 +259,7 @@ func TestReadCertificateBundle(t *testing.T) {
 		{"testdata/notexists.crt", 0, errors.New("open testdata/notexists.crt failed: no such file or directory")},
 		{"testdata/badca.crt", 0, errors.New("error parsing testdata/badca.crt")},
 		{"testdata/badpem.crt", 0, errors.New("error decoding PEM: file 'testdata/badpem.crt' contains unexpected data")},
-		{"testdata/badder.crt", 0, errors.New("error parsing testdata/badder.crt: x509:")},
+		{"testdata/badder.crt", 0, errors.New("error parsing testdata/badder.crt::")},
 		{"testdata/openssl.p256.pem", 0, errors.New("error decoding PEM: file 'testdata/openssl.p256.pem' is not a certificate bundle")},
 	}
 

--- a/crypto/pemutil/pem_test.go
+++ b/crypto/pemutil/pem_test.go
@@ -259,7 +259,7 @@ func TestReadCertificateBundle(t *testing.T) {
 		{"testdata/notexists.crt", 0, errors.New("open testdata/notexists.crt failed: no such file or directory")},
 		{"testdata/badca.crt", 0, errors.New("error parsing testdata/badca.crt")},
 		{"testdata/badpem.crt", 0, errors.New("error decoding PEM: file 'testdata/badpem.crt' contains unexpected data")},
-		{"testdata/badder.crt", 0, errors.New("error parsing testdata/badder.crt::")},
+		{"testdata/badder.crt", 0, errors.New("error parsing testdata/badder.crt:")},
 		{"testdata/openssl.p256.pem", 0, errors.New("error decoding PEM: file 'testdata/openssl.p256.pem' is not a certificate bundle")},
 	}
 

--- a/crypto/pemutil/pem_test.go
+++ b/crypto/pemutil/pem_test.go
@@ -230,7 +230,7 @@ func TestReadCertificate(t *testing.T) {
 		{"testdata/notexists.crt", errors.New("open testdata/notexists.crt failed: no such file or directory")},
 		{"testdata/badca.crt", errors.New("error parsing testdata/badca.crt")},
 		{"testdata/badpem.crt", errors.New("error decoding testdata/badpem.crt: not a valid PEM encoded block")},
-		{"testdata/badder.crt", errors.New("error parsing testdata/badder.crt: asn1: syntax error: data truncated")},
+		{"testdata/badder.crt", errors.New("error parsing testdata/badder.crt: x509:")},
 		{"testdata/openssl.p256.pem", errors.New("error decoding PEM: file 'testdata/openssl.p256.pem' does not contain a certificate")},
 	}
 
@@ -259,7 +259,7 @@ func TestReadCertificateBundle(t *testing.T) {
 		{"testdata/notexists.crt", 0, errors.New("open testdata/notexists.crt failed: no such file or directory")},
 		{"testdata/badca.crt", 0, errors.New("error parsing testdata/badca.crt")},
 		{"testdata/badpem.crt", 0, errors.New("error decoding PEM: file 'testdata/badpem.crt' contains unexpected data")},
-		{"testdata/badder.crt", 0, errors.New("error parsing testdata/badder.crt: asn1: syntax error: data truncated")},
+		{"testdata/badder.crt", 0, errors.New("error parsing testdata/badder.crt: x509:")},
 		{"testdata/openssl.p256.pem", 0, errors.New("error decoding PEM: file 'testdata/openssl.p256.pem' is not a certificate bundle")},
 	}
 

--- a/crypto/pemutil/pem_test.go
+++ b/crypto/pemutil/pem_test.go
@@ -230,7 +230,7 @@ func TestReadCertificate(t *testing.T) {
 		{"testdata/notexists.crt", errors.New("open testdata/notexists.crt failed: no such file or directory")},
 		{"testdata/badca.crt", errors.New("error parsing testdata/badca.crt")},
 		{"testdata/badpem.crt", errors.New("error decoding testdata/badpem.crt: not a valid PEM encoded block")},
-		{"testdata/badder.crt", errors.New("error parsing testdata/badder.crt: x509:")},
+		{"testdata/badder.crt", errors.New("error parsing testdata/badder.crt:")},
 		{"testdata/openssl.p256.pem", errors.New("error decoding PEM: file 'testdata/openssl.p256.pem' does not contain a certificate")},
 	}
 

--- a/crypto/x509util/identity_test.go
+++ b/crypto/x509util/identity_test.go
@@ -26,7 +26,7 @@ func TestLoadIdentityFromDisk(t *testing.T) {
 			crtPath: testBadCert,
 			keyPath: "",
 			pass:    "",
-			err: errors.Errorf("error parsing %s: asn1: syntax error: trailing data",
+			err: errors.Errorf("error parsing %s: x509: trailing data",
 				testBadCert),
 		},
 		"error parsing rsa key": {

--- a/crypto/x509util/identity_test.go
+++ b/crypto/x509util/identity_test.go
@@ -26,7 +26,7 @@ func TestLoadIdentityFromDisk(t *testing.T) {
 			crtPath: testBadCert,
 			keyPath: "",
 			pass:    "",
-			err: errors.Errorf("error parsing %s: x509: trailing data",
+			err: errors.Errorf("error parsing %s:",
 				testBadCert),
 		},
 		"error parsing rsa key": {


### PR DESCRIPTION
After this change `make test` passes again.