### PR TITLE
Fix `make bootstrap` failing to install `golangci-lint` using GOPATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix `make bootstrap` failing to get GOPATH and install `golangci-lint`.
 ### Security
 - Use cosign to sign and upload signatures for multi-arch Docker container.
 

--- a/make/common.mk
+++ b/make/common.mk
@@ -17,7 +17,7 @@ OUTPUT_ROOT=output/
 
 bootstra%:
 	# Using a released version of golangci-lint to take into account custom replacements in their go.mod
-	$Q curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0
+	$Q curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.42.0
 
 .PHONY: bootstra%
 


### PR DESCRIPTION
Fixes #535

### Description
To get the Go path, make/common.mk used `$(go env GOPATH)` which was thus evaluated by Make (wrongly, to an empty string). To get it evaluated (properly) by the shell, the expression must be `$$(go env GOPATH)`.

This PR adds the missing `$`.