### PR TITLE
Remove checks for OIDC provided certificates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Using go 1.17 to build
 - Have `--dns` behave as string slice flag in `step ca init`
+- The way CSR is created on `step ca certificate` with OIDC to better support of admins
 ### Deprecated
 ### Removed
 ### Fixed

--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -228,14 +228,7 @@ func certificateAction(ctx *cli.Context) error {
 		if !strings.EqualFold(subject, req.CsrPEM.Subject.CommonName) {
 			return errors.Errorf("token subject '%s' and argument '%s' do not match", req.CsrPEM.Subject.CommonName, subject)
 		}
-	case token.OIDC: // Validate that the subject matches an email SAN
-		if len(req.CsrPEM.EmailAddresses) == 0 {
-			return errors.New("unexpected token: payload does not contain an email claim")
-		}
-		if email := req.CsrPEM.EmailAddresses[0]; email != subject {
-			return errors.Errorf("token email '%s' and argument '%s' do not match", email, subject)
-		}
-	case token.AWS, token.GCP, token.Azure, token.K8sSA:
+	case token.OIDC, token.AWS, token.GCP, token.Azure, token.K8sSA:
 		// Common name will be validated on the server side, it depends on
 		// server configuration.
 	default:

--- a/command/ca/sign.go
+++ b/command/ca/sign.go
@@ -191,7 +191,7 @@ func signCertificateAction(ctx *cli.Context) error {
 		return errors.Wrap(err, "error parsing flag '--token'")
 	}
 	switch jwt.Payload.Type() {
-	case token.AWS, token.GCP, token.Azure, token.K8sSA:
+	case token.OIDC, token.AWS, token.GCP, token.Azure, token.K8sSA:
 		// Common name will be validated on the server side, it depends on
 		// server configuration.
 	default:

--- a/utils/cautils/certificate_flow.go
+++ b/utils/cautils/certificate_flow.go
@@ -287,7 +287,7 @@ func (f *CertificateFlow) CreateSignRequest(ctx *cli.Context, tok, subject strin
 		}
 	case token.OIDC:
 		// If no sans are given using the --san flag, and the subject argument
-		// matches the email then CN=token.sub SANs=email.
+		// matches the email then CN=token.sub SANs=email, token.iss#token.sub
 		//
 		// If no sans are given and the subject argument does not match the
 		// email then CN=subject SANs=splitSANs(subject)
@@ -297,6 +297,10 @@ func (f *CertificateFlow) CreateSignRequest(ctx *cli.Context, tok, subject strin
 			if jwt.Payload.Email != "" && strings.EqualFold(subject, jwt.Payload.Email) {
 				subject = jwt.Payload.Subject
 				emails = append(emails, jwt.Payload.Email)
+				if iss, err := url.Parse(jwt.Payload.Issuer); err == nil && iss.Scheme != "" {
+					iss.Fragment = jwt.Payload.Subject
+					uris = append(uris, iss)
+				}
 			} else {
 				dnsNames, ips, emails, uris = splitSANs([]string{subject})
 			}

--- a/utils/cautils/certificate_flow.go
+++ b/utils/cautils/certificate_flow.go
@@ -293,6 +293,10 @@ func (f *CertificateFlow) CreateSignRequest(ctx *cli.Context, tok, subject strin
 		// email then CN=subject SANs=splitSANs(subject)
 		//
 		// If sans are provided CN=subject SANs=splitSANs(sans)
+		//
+		// Note that with the way token types are identified, an OIDC token with
+		// `sans` claim will never reach this code. We will leave the condition
+		// as it is in case we want it to support it later.
 		if len(sans) == 0 && len(jwt.Payload.SANs) == 0 {
 			if jwt.Payload.Email != "" && strings.EqualFold(subject, jwt.Payload.Email) {
 				subject = jwt.Payload.Subject

--- a/utils/cautils/certificate_flow.go
+++ b/utils/cautils/certificate_flow.go
@@ -293,7 +293,7 @@ func (f *CertificateFlow) CreateSignRequest(ctx *cli.Context, tok, subject strin
 		// email then CN=subject SANs=splitSANs(subject)
 		//
 		// If sans are provided CN=subject SANs=splitSANs(sans)
-		if len(sans) == 0 {
+		if len(sans) == 0 && len(jwt.Payload.SANs) == 0 {
 			if jwt.Payload.Email != "" && strings.EqualFold(subject, jwt.Payload.Email) {
 				subject = jwt.Payload.Subject
 				emails = append(emails, jwt.Payload.Email)
@@ -347,7 +347,7 @@ func splitSANs(args ...[]string) (dnsNames []string, ipAddresses []net.IP, email
 	var unique []string
 	for _, sans := range args {
 		for _, san := range sans {
-			if ok := m[san]; !ok {
+			if ok := m[san]; !ok && san != "" {
 				m[san] = true
 				unique = append(unique, san)
 			}


### PR DESCRIPTION
### Description

This PR removes the checks in `step` when certificates are signed using OIDC provisioners.

With OIDC tokens the CSR will be built based on the `--san` flags, subject argument, token.sub, token.email and token.iss based on the following rules:

* If at least one `--san` is provided: CN=subject SANs=splitSANs(sans)
* If no sans and subject == token.email: CN=token.sub SANs=token.email, token.iss#token.sub
* if no sans and subject != token.email: CN=subject SANs=splitSANs(subject)

Fixes #340

Notes: 
* If a non-admin uses a subject that does not match his email the CSR sent to the CA will be build using the rules above, but he will get a certificate with CN=token.sub, SANs=email, token.iss#token.sub
* Extra checks that we want to add in the CA are not part of the scope of this PR, and we should add a new issue to validate this if we want to show an error.