### PR TITLE
Flexible config and OAuth redirect_uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased - 0.17.5] - DATE
 ### Added
-- Allow override the listen address on OIDC flows when there is an existing
+- Allow override of the listen address on OIDC flows when there is an existing
   value in provisioner configuration.
 - Add a way to set the redirect_uri in an OIDC flow. Allowing to get a
   certificate from containers or environments where it is hard to send traffic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased - 0.17.5] - DATE
 ### Added
+- Allow override the listen address on OIDC flows when there is an existing
+  value in provisioner configuration.
+- Add a way to set the redirect_uri in an OIDC flow. Allowing to get a
+  certificate from containers or environments where it is hard to send traffic
+  to 127.0.0.1 and where the IDP does not support the urn:ietf:wg:oauth:2.0:oob
+  flow.
 ### Changed
 ### Deprecated
 ### Removed

--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -116,7 +116,7 @@ Redirect to a fixed port instead of random one:
 $ step oauth --listen :10000
 '''
 
-Redirect to a fixed url but listen in all the interfaces:
+Redirect to a fixed url but listen on all the interfaces:
 '''
 $ step oauth --listen 0.0.0.0:10000 --listen-url http://127.0.0.1:10000
 '''

--- a/command/ssh/config.go
+++ b/command/ssh/config.go
@@ -114,8 +114,6 @@ func configAction(ctx *cli.Context) (recoverErr error) {
 		return errs.IncompatibleFlagWithFlag(ctx, "roots", "roots")
 	case team != "" && isFederation:
 		return errs.IncompatibleFlagWithFlag(ctx, "roots", "federation")
-	case team != "" && len(sets) > 0:
-		return errs.IncompatibleFlagWithFlag(ctx, "roots", "set")
 	case isRoots && isFederation:
 		return errs.IncompatibleFlagWithFlag(ctx, "roots", "federation")
 	case isRoots && len(sets) > 0:

--- a/utils/cautils/token_generator.go
+++ b/utils/cautils/token_generator.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -121,7 +122,7 @@ func generateOIDCToken(ctx *cli.Context, p *provisioner.OIDC) (string, error) {
 	if ctx.Bool("console") {
 		args = append(args, "--console")
 	}
-	if p.ListenAddress != "" {
+	if p.ListenAddress != "" && os.Getenv("STEP_LISTEN") == "" {
 		args = append(args, "--listen", p.ListenAddress)
 	}
 	out, err := exec.Step(args...)


### PR DESCRIPTION
### Description

This PR allows to use `--set` and `--team` together in the `step ssh config`. There's no need to make them incompatible and can be useful for some templates.

This PR also allows overriding a fixed listen-address coming from the CA with the value on an environment variable. This combined with a new `--listen-url` flag allows to do the OAuth flow in restricted environments like containers if the IDP doesn't support the out of band flow.

These changes allow the following flow with an OIDC provisioner:
```
$ docker run -it -p 10000:10000 smallstep/step-cli:latest /bin/bash
bash-5.1$ step ca bootstrap --ca-url ...  --fingerprint ...
bash-5.1$ export STEP_LISTEN=0.0.0.0:10000
bash-5.1$ export STEP_LISTEN_URL=http://127.0.0.1:10000
bash-5.1$ step ca certificate mariano@smallstep.com mariano.crt mariano.key
```

If we just use `STEP_LISTEN=:10000`, the host machine won't be able to able to send the request back to the server as docker won't allow port redirections going to 127.0.0.1. And we cannot use `STEP_LISTEN=0.0.0.0:10000` because some IDPs like Google won't allow this. For example, Google shows this:

```
Authorization Error
Error 400: invalid_request
Invalid parameter value for redirect_uri: Raw IP addresses not allowed: http://0.0.0.0:10000
```

Combining both we can have the redirect_uri set to http://127.0.0.1:10000 and we can use the port mapping properly.

I've used the name `--listen-url` instead of `--redirect-uri` to avoid confusion with the current `--redirect-url` parameter and because this new flag will be generally used together with `--listen`, although this is not a requirement.