### PR TITLE
Update autocomplete scripts from urfave/cli

### DIFF
--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -1,21 +1,16 @@
 #! /bin/bash
 
-: ${PROG:=$(basename ${BASH_SOURCE})}
-
-_cli_bash_autocomplete() {
+_step_cli_bash_autocomplete() {
 	local cur opts base
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
-	opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
-	if [ -n "${opts}" ];
-	then
-		COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+	if [[ "$cur" == "-"* ]]; then
+		opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
 	else
-		_filedir
+		opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
 	fi
+	COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
 	return 0
 }
 
-complete -F _cli_bash_autocomplete $PROG
-
-unset PROG
+complete -o bashdefault -o default -o nospace -F _step_cli_bash_autocomplete step

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -1,13 +1,23 @@
 #compdef step
 
-function _step {
+_step() {
+
   local -a opts
-  opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
-  if [[ "${opts}" != "" ]]; then
-    _describe -t step-commands 'values' opts
+  local cur
+  cur=${words[-1]}
+  if [[ "$cur" == "-"* ]]; then
+    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
   else
-    _path_files
+    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
   fi
+
+  if [[ "${opts[1]}" != "" ]]; then
+    _describe 'values' opts
+  else
+    _files
+  fi
+
+  return
 }
 
-_step "$@"
+compdef _step step


### PR DESCRIPTION
The [bash] and [zsh] autocomplete scripts from upstream [urfave/cli] now handle autocompletion of files and also correctly handle command flags.

[bash]: https://github.com/urfave/cli/blob/master/autocomplete/bash_autocomplete
[zsh]: https://github.com/urfave/cli/blob/master/autocomplete/zsh_autocomplete
[urfave/cli]: https://github.com/urfave/cli