### PR TITLE
Update OIDC add error for duplicate ID

### DIFF
--- a/command/ca/provisioner/add.go
+++ b/command/ca/provisioner/add.go
@@ -503,7 +503,7 @@ func addOIDCProvisioner(ctx *cli.Context, name string, provMap map[string]bool) 
 	if _, ok := provMap[p.GetID()]; !ok {
 		provMap[p.GetID()] = true
 	} else {
-		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with name=%s and client-id=%s", p.GetName(), p.GetID())
+		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with client-id=%s", p.GetID())
 	}
 	list = append(list, p)
 	return

--- a/command/ca/provisioner/add.go
+++ b/command/ca/provisioner/add.go
@@ -332,7 +332,7 @@ func addAction(ctx *cli.Context) (err error) {
 
 	provMap := make(map[string]bool)
 	for _, p := range c.AuthorityConfig.Provisioners {
-		provMap[p.GetID()] = true
+		provMap[p.GetIDForToken()] = true
 	}
 
 	var list provisioner.List
@@ -408,8 +408,8 @@ func addJWKProvisioner(ctx *cli.Context, name string, provMap map[string]bool) (
 			Claims:       getClaims(ctx),
 		}
 		// Check for duplicates
-		if _, ok := provMap[p.GetID()]; !ok {
-			provMap[p.GetID()] = true
+		if _, ok := provMap[p.GetIDForToken()]; !ok {
+			provMap[p.GetIDForToken()] = true
 		} else {
 			return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with name=%s and kid=%s", name, jwk.KeyID)
 		}
@@ -448,8 +448,8 @@ func addJWKProvisioner(ctx *cli.Context, name string, provMap map[string]bool) (
 			Key:    &key,
 			Claims: getClaims(ctx),
 		}
-		if _, ok := provMap[p.GetID()]; !ok {
-			provMap[p.GetID()] = true
+		if _, ok := provMap[p.GetIDForToken()]; !ok {
+			provMap[p.GetIDForToken()] = true
 		} else {
 			return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with name=%s and kid=%s", name, jwk.KeyID)
 		}
@@ -500,8 +500,8 @@ func addOIDCProvisioner(ctx *cli.Context, name string, provMap map[string]bool) 
 		ListenAddress:         ctx.String("listen-address"),
 	}
 	// Check for duplicates
-	if _, ok := provMap[p.GetID()]; !ok {
-		provMap[p.GetID()] = true
+	if _, ok := provMap[p.GetIDForToken()]; !ok {
+		provMap[p.GetIDForToken()] = true
 	} else {
 		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with client-id=%s", p.GetID())
 	}
@@ -527,8 +527,8 @@ func addAWSProvisioner(ctx *cli.Context, name string, provMap map[string]bool) (
 	}
 
 	// Check for duplicates
-	if _, ok := provMap[p.GetID()]; !ok {
-		provMap[p.GetID()] = true
+	if _, ok := provMap[p.GetIDForToken()]; !ok {
+		provMap[p.GetIDForToken()] = true
 	} else {
 		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with type=AWS and name=%s", p.GetName())
 	}
@@ -554,8 +554,8 @@ func addAzureProvisioner(ctx *cli.Context, name string, provMap map[string]bool)
 	}
 
 	// Check for duplicates
-	if _, ok := provMap[p.GetID()]; !ok {
-		provMap[p.GetID()] = true
+	if _, ok := provMap[p.GetIDForToken()]; !ok {
+		provMap[p.GetIDForToken()] = true
 	} else {
 		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with type=Azure and name=%s", p.GetName())
 	}
@@ -582,8 +582,8 @@ func addGCPProvisioner(ctx *cli.Context, name string, provMap map[string]bool) (
 	}
 
 	// Check for duplicates
-	if _, ok := provMap[p.GetID()]; !ok {
-		provMap[p.GetID()] = true
+	if _, ok := provMap[p.GetIDForToken()]; !ok {
+		provMap[p.GetIDForToken()] = true
 	} else {
 		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with type=GCP and name=%s", p.GetName())
 	}
@@ -600,10 +600,10 @@ func addACMEProvisioner(ctx *cli.Context, name string, provMap map[string]bool) 
 	}
 
 	// Check for duplicates
-	if _, ok := provMap[p.GetID()]; !ok {
-		provMap[p.GetID()] = true
+	if _, ok := provMap[p.GetIDForToken()]; !ok {
+		provMap[p.GetIDForToken()] = true
 	} else {
-		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with ID==%s", p.GetID())
+		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with ID==%s", p.GetIDForToken())
 	}
 
 	list = append(list, p)
@@ -641,10 +641,10 @@ func addX5CProvisioner(ctx *cli.Context, name string, provMap map[string]bool) (
 	}
 
 	// Check for duplicates
-	if _, ok := provMap[p.GetID()]; !ok {
-		provMap[p.GetID()] = true
+	if _, ok := provMap[p.GetIDForToken()]; !ok {
+		provMap[p.GetIDForToken()] = true
 	} else {
-		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with ID=%s", p.GetID())
+		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with ID=%s", p.GetIDForToken())
 	}
 
 	list = append(list, p)
@@ -706,10 +706,10 @@ func addK8sSAProvisioner(ctx *cli.Context, name string, provMap map[string]bool)
 	}
 
 	// Check for duplicates
-	if _, ok := provMap[p.GetID()]; !ok {
-		provMap[p.GetID()] = true
+	if _, ok := provMap[p.GetIDForToken()]; !ok {
+		provMap[p.GetIDForToken()] = true
 	} else {
-		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with ID=%s", p.GetID())
+		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with ID=%s", p.GetIDForToken())
 	}
 
 	list = append(list, p)
@@ -726,10 +726,10 @@ func addSSHPOPProvisioner(ctx *cli.Context, name string, provMap map[string]bool
 	}
 
 	// Check for duplicates
-	if _, ok := provMap[p.GetID()]; !ok {
-		provMap[p.GetID()] = true
+	if _, ok := provMap[p.GetIDForToken()]; !ok {
+		provMap[p.GetIDForToken()] = true
 	} else {
-		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with ID=%s", p.GetID())
+		return nil, errors.Errorf("duplicated provisioner: CA config already contains a provisioner with ID=%s", p.GetIDForToken())
 	}
 
 	list = append(list, p)


### PR DESCRIPTION
- oidc uses only the clientID as the unique identifier.
