### PR TITLE
Pass missing template data in X509 sign offline mode

### DIFF
--- a/utils/cautils/offline.go
+++ b/utils/cautils/offline.go
@@ -190,8 +190,9 @@ func (c *OfflineCA) Sign(req *api.SignRequest) (*api.SignResponse, error) {
 		return nil, err
 	}
 	signOpts := provisioner.SignOptions{
-		NotBefore: req.NotBefore,
-		NotAfter:  req.NotAfter,
+		NotBefore:    req.NotBefore,
+		NotAfter:     req.NotAfter,
+		TemplateData: req.TemplateData,
 	}
 	certChain, err := c.authority.Sign(req.CsrPEM.CertificateRequest, signOpts, opts...)
 	if err != nil {


### PR DESCRIPTION
### Description

When templates are used in offline mode, the `TemplateData` was missing in X.509 signing requests, SSH signing was working fine.

Fixes #624