### PR TITLE
Add completion command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -101,8 +101,6 @@ nfpms:
 
     bindir: /usr/bin
     contents:
-      - src: autocomplete/bash_autocomplete
-        dst: /usr/share/bash-completion/completions/step-cli
       - src: debian/copyright
         dst: /usr/share/doc/step-cli/copyright
         # Ghost files are used for RPM and ignored elsewhere

--- a/autocomplete/README.md
+++ b/autocomplete/README.md
@@ -1,0 +1,2 @@
+## Deprecated
+The files in this folder are deprecated and will be removed in the future. The prefered way to acces the completion scripts is through `step completion <shell>`.

--- a/cmd/step/main.go
+++ b/cmd/step/main.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/smallstep/cli/command/beta"
 	_ "github.com/smallstep/cli/command/ca"
 	_ "github.com/smallstep/cli/command/certificate"
+	_ "github.com/smallstep/cli/command/completion"
 	_ "github.com/smallstep/cli/command/context"
 	_ "github.com/smallstep/cli/command/crl"
 	_ "github.com/smallstep/cli/command/crypto"

--- a/command/completion/completion.go
+++ b/command/completion/completion.go
@@ -1,0 +1,110 @@
+package completion
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/smallstep/cli/flags"
+	"github.com/urfave/cli"
+	"go.step.sm/cli-utils/command"
+	"go.step.sm/cli-utils/errs"
+)
+
+func init() {
+	cmd := cli.Command{
+		Name:      "completion",
+		Usage:     "print the shell completion script",
+		UsageText: "**step completion** <shell>",
+		Description: `**step completion** command prints the shell completion script.
+
+## POSITIONAL ARGUMENTS
+
+<shell>
+: The shell program. Either bash or zsh.
+
+## EXAMPLES
+
+Add bash completion for the current user.
+'''
+$ step completion bash >> ~/.bash_completion
+'''
+`,
+		Flags: []cli.Flag{
+			flags.HiddenNoContext,
+		},
+		Action: Completion,
+		BashComplete: func(c *cli.Context) {
+			if c.NArg() > 0 {
+				return
+			}
+			fmt.Println("bash")
+			fmt.Println("zsh")
+		},
+	}
+
+	command.Register(cmd)
+}
+
+var bash = `# bash completion for step
+_step_cli_bash_autocomplete() {
+	local cur opts base
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	if [[ "$cur" == "-"* ]]; then
+		opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
+	else
+		opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+	fi
+	COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+	return 0
+}
+
+complete -o bashdefault -o default -F _step_cli_bash_autocomplete step
+
+`
+
+var zsh = `# zsh completion for step
+#compdef step
+
+_step() {
+
+  local -a opts
+  local cur
+  cur=${words[-1]}
+  if [[ "$cur" == "-"* ]]; then
+    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+  else
+    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+  fi
+
+  if [[ "${opts[1]}" != "" ]]; then
+    _describe 'values' opts
+  else
+    _files
+  fi
+
+  return
+}
+
+compdef _step step
+
+`
+
+func Completion(ctx *cli.Context) error {
+	if err := errs.NumberOfArguments(ctx, 1); err != nil {
+		return err
+	}
+
+	shell := ctx.Args().First()
+
+	switch shell {
+	case "bash":
+		fmt.Print(bash)
+	case "zsh":
+		fmt.Print(zsh)
+	default:
+		return errors.Errorf("unsupported shell %s", shell)
+	}
+
+	return nil
+}

--- a/debian/step-cli.bash-completion
+++ b/debian/step-cli.bash-completion
@@ -1,1 +1,0 @@
-autocomplete/bash_autocomplete step-cli

--- a/make/bundle.sh
+++ b/make/bundle.sh
@@ -57,7 +57,6 @@ mkdir -p "$newdir/bin"
 
 cp "$OUTPUT_DIR/bin/step" "$newdir/bin/${STEP_EXEC_NAME}"
 cp README.md "$newdir"
-cp -a autocomplete "$newdir"
 
 if [ ${ZIP} -eq 0 ]; then
     NEW_BUNDLE="${RELEASE_DIR}/step_${STEP_PLATFORM}_${STEP_VERSION}_${STEP_ARCH}.tar.gz"

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,17 +1,22 @@
 #!/bin/sh
 
 updateAlternatives() {
-	update-alternatives \
-		--install /usr/bin/step step /usr/bin/step-cli 50 \
-		--slave /usr/share/bash-completion/completions/step step.bash-completion /usr/share/bash-completion/completions/step-cli
+	update-alternatives --install /usr/bin/step step /usr/bin/step-cli 50
+}
+
+updateCompletion() {
+  /usr/bin/step completion bash > /usr/share/bash-completion/completions/step
+  chmod 644 /usr/share/bash-completion/completions/step
 }
 
 cleanInstall() {
 	updateAlternatives
+	updateCompletion
 }
 
 upgrade() {
 	updateAlternatives
+	updateCompletion
 }
 
 action="$1"


### PR DESCRIPTION
Fixes #622

### Description
Add shell completion command. #622

I removed the `-o nospace` from `autocomplete/bash_autocomplete`. I think it's far better.


