### PR TITLE
Add IPs as SANs when performing ACME flow with existing CSR

### DIFF
--- a/utils/cautils/acmeutils.go
+++ b/utils/cautils/acmeutils.go
@@ -297,6 +297,9 @@ func withCSR(csr *x509.CertificateRequest) acmeFlowOp {
 		af.csr = csr
 		af.subject = csr.Subject.CommonName
 		af.sans = csr.DNSNames
+		for _, ip := range csr.IPAddresses {
+			af.sans = append(af.sans, ip.String())
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
When performing an ACME flow with an existing CSR, not all SANs would be in the ACME order. This PR fixes that.

It's related to https://github.com/smallstep/certificates/discussions/819.