### PR TITLE
Use parseCaURLIfExists for renew and rekey in case of offline

### DIFF
--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -234,7 +234,7 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 		rootFile = pki.GetRootCAPath()
 	}
 
-	caURL, err := flags.ParseCaURL(ctx)
+	caURL, err := flags.ParseCaURLIfExists(ctx)
 	if err != nil {
 		return err
 	}

--- a/command/ca/renew.go
+++ b/command/ca/renew.go
@@ -214,7 +214,7 @@ func renewCertificateAction(ctx *cli.Context) error {
 		rootFile = pki.GetRootCAPath()
 	}
 
-	caURL, err := flags.ParseCaURL(ctx)
+	caURL, err := flags.ParseCaURLIfExists(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #627 

@henschkowski we've already got a method that will parse the CAURL iff it is not empty. My thought is we just use that, but getting a second opinion from @maraino.
