### PR TITLE
Fix principals not including local part of an email

### DIFF
--- a/command/ssh/login.go
+++ b/command/ssh/login.go
@@ -99,7 +99,7 @@ func loginAction(ctx *cli.Context) error {
 
 	principals := ctx.StringSlice("principal")
 	if subject != "" && len(principals) == 0 {
-		principals = []string{subject}
+		principals = createPrincipalsFromSubject(subject)
 	}
 
 	// Flags


### PR DESCRIPTION
So `step ssh login` used to automatically fill in `principals` with both `username@email.com` and `username`. However, it no longer does this. It looks like this may have changed around this commit: https://github.com/smallstep/cli/commit/3fdcde8caf85bf9539dbfb697f564579b9276316

I fixed this by adding back in `createPrincipalsFromSubject`.

Related PRs:

- https://github.com/smallstep/cli/pull/370
- https://github.com/smallstep/cli/pull/621
