### PR TITLE
Add the --provisioner-password-file to proxycommand.

### DIFF
--- a/command/ssh/proxycommand.go
+++ b/command/ssh/proxycommand.go
@@ -53,6 +53,7 @@ This command will add the user to the ssh-agent if necessary.
 :  The port to connect to.`,
 		Flags: []cli.Flag{
 			flags.Provisioner,
+			flags.ProvisionerPasswordFileWithAlias,
 			flags.TemplateSet,
 			flags.TemplateSetFile,
 			flags.Offline,


### PR DESCRIPTION
### Description
This PR adds the --provisioner-password-file flag to `step ssh proxycommand`

Machines doing ssh client connections might want to use a JWK provisioner to create the SSH certificate, this change allows to automatically create the token if `--provisioner` and `--provisioner-password-file` are passed.
