### PR TITLE
add es256k (secp256k1 curve) support 

### DIFF
--- a/command/crypto/key/sign_test.go
+++ b/command/crypto/key/sign_test.go
@@ -1,0 +1,127 @@
+package key
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"flag"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
+)
+
+func TestReadKey_PrivateKey(t *testing.T) {
+	arbitraryPrivateKey := "0x157c3200d896c0595a205109c5b5656e82621e8214a12a9561727870f5867962"
+	f, err := prepareFile(arbitraryPrivateKey)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+	flags := &flag.FlagSet{}
+	flags.String("alg", "secp256k1", "")
+	ctx := cli.NewContext(nil, flags, nil)
+
+	pk, err := readKey(f.Name(), false, ctx)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	assert.IsType(t, &ecdsa.PrivateKey{}, pk)
+}
+
+func TestReadKey_PublicKey(t *testing.T) {
+	arbitraryPubKey := "02d1e996bf09686ca22e5303e7d3abda4ccbbcdee94f5eb3adf6cad7238f27f840"
+	f, err := prepareFile(arbitraryPubKey)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+	flags := &flag.FlagSet{}
+	flags.String("alg", "secp256k1", "")
+	ctx := cli.NewContext(nil, flags, nil)
+
+	pk, err := readKey(f.Name(), true, ctx)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	assert.IsType(t, &ecdsa.PublicKey{}, pk)
+}
+
+func TestSign(t *testing.T) {
+	var capturedOutput bytes.Buffer
+	output = &capturedOutput
+	defer func() {
+		output = os.Stdout
+	}()
+	arbitraryKeyPair := struct {
+		priv string
+		pub  string
+	}{
+		priv: "0xb2cf8112327c38acc3b16b2cea56c684aa94580caae76e29dcb244f19bec88e2",
+		pub:  "0224e7f25110dabeb26e1f94760dc9abe15fd35d5cd2f60ce99d5fe3f35b552fcc",
+	}
+	arbitraryData := "test data"
+	pkFile, err := prepareFile(arbitraryKeyPair.priv)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer func() {
+		_ = os.Remove(pkFile.Name())
+	}()
+	dataFile, err := prepareFile(arbitraryData)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer func() {
+		_ = os.Remove(dataFile.Name())
+	}()
+	flags := &flag.FlagSet{}
+	flags.String("alg", "secp256k1", "")
+	flags.String("key", pkFile.Name(), "")
+	flags.String("format", "hex", "")
+	_ = flags.Parse([]string{dataFile.Name()})
+	ctx := cli.NewContext(nil, flags, nil)
+
+	assert.NoError(t, signAction(ctx))
+
+	actual := strings.TrimSpace(capturedOutput.String())
+	sig, err := hex.DecodeString(actual)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	// now verify it
+	pubKey, err := hex.DecodeString(arbitraryKeyPair.pub)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	secpPubKey, err := secp256k1.ParsePubKey(pubKey)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	assert.True(t, ecdsa.VerifyASN1(secpPubKey.ToECDSA(), hash(crypto.SHA256, []byte(arbitraryData)), sig))
+}
+
+// remember to delete file after use
+func prepareFile(s string) (*os.File, error) {
+	f, err := os.CreateTemp("", "test-")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := f.WriteString(s); err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	return f, nil
+}

--- a/command/crypto/key/verify.go
+++ b/command/crypto/key/verify.go
@@ -9,12 +9,12 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/pkg/errors"
 	"github.com/smallstep/cli/command"
 	"github.com/smallstep/cli/utils"
 	"github.com/urfave/cli"
 	"go.step.sm/cli-utils/errs"
-	"go.step.sm/crypto/pemutil"
 )
 
 func verifyCommand() cli.Command {
@@ -108,9 +108,9 @@ func verifyAction(ctx *cli.Context) error {
 		return errors.Wrap(err, "error decoding base64 signature")
 	}
 
-	key, err := pemutil.Read(keyFile)
+	key, err := readKey(keyFile, true, ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "unable to read key file")
 	}
 
 	printAndReturn := func(b bool) error {
@@ -127,7 +127,7 @@ func verifyAction(ctx *cli.Context) error {
 		switch k.Curve {
 		case elliptic.P224():
 			digest = hash(crypto.SHA224, b)
-		case elliptic.P256():
+		case elliptic.P256(), secp256k1.S256():
 			digest = hash(crypto.SHA256, b)
 		case elliptic.P384():
 			digest = hash(crypto.SHA384, b)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ThomasRooney/gexpect v0.0.0-20161231170123-5482f0350944
 	github.com/boombuler/barcode v1.0.1 // indirect
 	github.com/corpix/uarand v0.1.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,9 @@ github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
 github.com/dgraph-io/badger v1.6.2 h1:mNw0qs90GVgGGWylh0umH5iag1j6n/PeJtNvL6KY/x8=
 github.com/dgraph-io/badger v1.6.2/go.mod h1:JW2yswe3V058sS0kZ2h/AXeDSqFjxnZcRrVH//y2UQE=


### PR DESCRIPTION
Fix #222 

I'm using `github.com/decred/dcrd/dcrec/secp256k1/v4` which is go-native implementation for secp256k1 curve.

My first attempt to add the support into current code. Not super clean so looking for feedbacks to fit better into the current design.

Feel free to contribute into this PR as needed. I will try to find time to update as feedbacks coming in and complete the TODO.

TODO:

- [x] `step crypto key sign` and `step crypto key verify`
- [ ] `step crypto keypair`

Example:

```
echo "my data" | step crypto key sign -key /tmp/priv.key -alg es256k -format b64

echo "my data" | step crypto key verify -key /tmp/pub.key -alg es256k -signature xxxx
```
