### PR TITLE
git: ignore .envrc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ output
 vendor
 step
 .idea
+.envrc


### PR DESCRIPTION
This PR includes `.envrc` to `.gitignore` as a convenience to engineers who work on `cli` while at the same time use a tool like [`direnv`](https://direnv.net/).