### PR TITLE
Add optional SHA1 fingerprint output for certificates

### DIFF
--- a/command/certificate/fingerprint.go
+++ b/command/certificate/fingerprint.go
@@ -18,7 +18,8 @@ func fingerprintCommand() cli.Command {
 		Action: cli.ActionFunc(fingerprintAction),
 		Usage:  "print the fingerprint of a certificate",
 		UsageText: `**step certificate fingerprint** <crt-file>
-[**--bundle**] [**--roots**=<root-bundle>] [**--servername**=<servername>] [**--format**=<format>]`,
+[**--bundle**] [**--roots**=<root-bundle>] [**--servername**=<servername>] 
+[**--format**=<format>] [**--sha1**] [**--insecure**]`,
 		Description: `**step certificate fingerprint** reads a certificate and prints to STDOUT the
 certificate SHA256 of the raw certificate.
 
@@ -82,7 +83,7 @@ debugging invalid certificates remotely.`,
 			command.FingerprintFormatFlag("hex"),
 			cli.BoolFlag{
 				Name:  "sha1",
-				Usage: `Use the SHA-1 hash algorithm to hash the certificate. Require '--insecure' flag.`,
+				Usage: `Use the SHA-1 hash algorithm to hash the certificate. Requires **--insecure** flag.`,
 			},
 		},
 	}
@@ -101,7 +102,7 @@ func fingerprintAction(ctx *cli.Context) error {
 		insecure   = ctx.Bool("insecure")
 		crtFile    = ctx.Args().First()
 		format     = ctx.String("format")
-		sha1       = ctx.Bool("sha1")
+		useSHA1    = ctx.Bool("sha1")
 	)
 
 	encoding, err := command.GetFingerprintEncoding(format)
@@ -129,7 +130,7 @@ func fingerprintAction(ctx *cli.Context) error {
 	}
 
 	for i, crt := range certs {
-		fp, err := x509util.EncodedFingerprint(crt, x509util.FingerprintEncoding(encoding), sha1, insecure)
+		fp, err := x509util.EncodedFingerprint(crt, x509util.FingerprintEncoding(encoding), useSHA1, insecure)
 		if err != nil {
 			return err
 		}

--- a/command/certificate/fingerprint.go
+++ b/command/certificate/fingerprint.go
@@ -80,6 +80,18 @@ debugging invalid certificates remotely.`,
 			},
 			flags.ServerName,
 			command.FingerprintFormatFlag("hex"),
+			cli.StringFlag{
+				Name:  "alg",
+				Value: "SHA-256",
+				Usage: `The <alg> to hash the certificate. 
+ If unset, default is SHA-256. 
+  
+: <alg> is a case-sensitive string and must be one of: 
+  
+     **SHA-256**
+
+     **SHA-1** `,
+			},
 		},
 	}
 }
@@ -97,6 +109,7 @@ func fingerprintAction(ctx *cli.Context) error {
 		insecure   = ctx.Bool("insecure")
 		crtFile    = ctx.Args().First()
 		format     = ctx.String("format")
+		alg        = ctx.String("alg")
 	)
 
 	encoding, err := command.GetFingerprintEncoding(format)
@@ -124,7 +137,10 @@ func fingerprintAction(ctx *cli.Context) error {
 	}
 
 	for i, crt := range certs {
-		fp := x509util.EncodedFingerprint(crt, x509util.FingerprintEncoding(encoding))
+		fp, err := x509util.EncodedFingerprint(crt, x509util.FingerprintEncoding(encoding), alg)
+		if err != nil {
+			return err
+		}
 		if bundle {
 			fmt.Printf("%d: %s\n", i, fp)
 		} else {

--- a/command/certificate/fingerprint.go
+++ b/command/certificate/fingerprint.go
@@ -80,17 +80,9 @@ debugging invalid certificates remotely.`,
 			},
 			flags.ServerName,
 			command.FingerprintFormatFlag("hex"),
-			cli.StringFlag{
-				Name:  "alg",
-				Value: "SHA-256",
-				Usage: `The <alg> to hash the certificate. 
- If unset, default is SHA-256. 
-  
-: <alg> is a case-sensitive string and must be one of: 
-  
-     **SHA-256**
-
-     **SHA-1** `,
+			cli.BoolFlag{
+				Name:  "sha1",
+				Usage: `Use the SHA-1 hash algorithm to hash the certificate. Require '--insecure' flag.`,
 			},
 		},
 	}
@@ -109,7 +101,7 @@ func fingerprintAction(ctx *cli.Context) error {
 		insecure   = ctx.Bool("insecure")
 		crtFile    = ctx.Args().First()
 		format     = ctx.String("format")
-		alg        = ctx.String("alg")
+		sha1       = ctx.Bool("sha1")
 	)
 
 	encoding, err := command.GetFingerprintEncoding(format)
@@ -137,7 +129,7 @@ func fingerprintAction(ctx *cli.Context) error {
 	}
 
 	for i, crt := range certs {
-		fp, err := x509util.EncodedFingerprint(crt, x509util.FingerprintEncoding(encoding), alg)
+		fp, err := x509util.EncodedFingerprint(crt, x509util.FingerprintEncoding(encoding), sha1, insecure)
 		if err != nil {
 			return err
 		}

--- a/crypto/x509util/crt.go
+++ b/crypto/x509util/crt.go
@@ -46,7 +46,7 @@ func EncodedFingerprint(cert *x509.Certificate, encoding FingerprintEncoding,
 	sha1Mode bool, insecure bool) (string, error) {
 	if sha1Mode {
 		if !insecure {
-			return "", errors.New("sha1 require '--insecure' flag")
+			return "", errors.New("sha1 requires '--insecure' flag")
 		}
 		sum := sha1.Sum(cert.Raw)
 		return fingerprint.Fingerprint(sum[:], fingerprint.WithEncoding(fingerprint.Encoding(encoding))), nil

--- a/crypto/x509util/crt_test.go
+++ b/crypto/x509util/crt_test.go
@@ -46,7 +46,7 @@ func TestEncodedFingerprint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cert := mustParseCertificate(t, tt.fn)
-			if got, _ := EncodedFingerprint(cert, tt.encoding, "SHA-256"); got != tt.want {
+			if got, _ := EncodedFingerprint(cert, tt.encoding, false, false); got != tt.want {
 				t.Errorf("EncodedFingerprint() = %v, want %v", got, tt.want)
 			}
 		})

--- a/crypto/x509util/crt_test.go
+++ b/crypto/x509util/crt_test.go
@@ -46,7 +46,7 @@ func TestEncodedFingerprint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cert := mustParseCertificate(t, tt.fn)
-			if got := EncodedFingerprint(cert, tt.encoding); got != tt.want {
+			if got, _ := EncodedFingerprint(cert, tt.encoding, "SHA-256"); got != tt.want {
 				t.Errorf("EncodedFingerprint() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Add optional SHA1 fingerprint output for certificates has requested in https://github.com/smallstep/cli/issues/611