### PR TITLE
Go 1.18 support 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.16', '1.17' ]
+        go: [ '1.17', '1.18' ]
     steps:
       -
         name: Checkout
@@ -26,7 +26,7 @@ jobs:
         name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: 'v1.44.0'
+          version: 'v1.45.0'
           args: --timeout=30m
       -
         name: Test, Build
@@ -85,7 +85,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       -
         name: Configure Go
         id: configure_go
@@ -129,7 +129,7 @@ jobs:
         name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       -
         name: Install cosign
         uses: sigstore/cosign-installer@v1.1.0
@@ -165,7 +165,7 @@ jobs:
         name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       -
         name: Build
         id: build
@@ -205,7 +205,7 @@ jobs:
         name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       -
         name: Build
         id: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.16', '1.17' ]
+        go: [ '1.17', '1.18' ]
     steps:
       -
         name: Checkout
@@ -28,7 +28,7 @@ jobs:
         name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: 'v1.44.0'
+          version: 'v1.45.0'
           args: --timeout=30m
       -
         name: Test, Build
@@ -37,7 +37,7 @@ jobs:
       -
         name: Codecov
         uses: codecov/codecov-action@v1.2.1
-        if: matrix.go == '1.17'
+        if: matrix.go == '1.18'
         with:
           file: ./coverage.out
           name: codecov-umbrella

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add flags to include subscription and object ids in the Azure provisioner.
 ### Changed
+- Support two latest versions of Go (1.17, 1.18)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/command/certificate/remote_test.go
+++ b/command/certificate/remote_test.go
@@ -66,7 +66,7 @@ func TestGetPeerCertificateServerName(t *testing.T) {
 	tests := map[string]newTest{
 		"sni-disabled-host": {host, "", nil},
 		"sni-enabled-host":  {host, serverName, nil},
-		"sni-disabled-ip":   {addr, "", fmt.Errorf("failed to connect: x509: cannot validate certificate for %s because it doesn't contain any IP SANs", addr)},
+		"sni-disabled-ip":   {addr, "", fmt.Errorf("failed to connect")},
 		"sni-enabled-ip":    {addr, serverName, nil},
 	}
 

--- a/command/certificate/remote_test.go
+++ b/command/certificate/remote_test.go
@@ -2,7 +2,6 @@ package certificate
 
 import (
 	"errors"
-	"fmt"
 	"net"
 	"testing"
 
@@ -66,7 +65,7 @@ func TestGetPeerCertificateServerName(t *testing.T) {
 	tests := map[string]newTest{
 		"sni-disabled-host": {host, "", nil},
 		"sni-enabled-host":  {host, serverName, nil},
-		"sni-disabled-ip":   {addr, "", fmt.Errorf("failed to connect")},
+		"sni-disabled-ip":   {addr, "", errors.New("failed to connect")},
 		"sni-enabled-ip":    {addr, serverName, nil},
 	}
 


### PR DESCRIPTION
### Description

This PR changes the supported versions of Go to 1.17 and 1.18, using Go 1.18 for releases.