### PR TITLE
golangci-lint v1.45.2 avoids panic on Go 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: 'v1.45.0'
+          version: 'v1.45.2'
           args: --timeout=30m
       -
         name: Test, Build

--- a/make/common.mk
+++ b/make/common.mk
@@ -17,7 +17,7 @@ OUTPUT_ROOT=output/
 
 bootstra%:
 	# Using a released version of golangci-lint to take into account custom replacements in their go.mod
-	$Q curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.42.0
+	$Q curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.45.2
 
 .PHONY: bootstra%
 


### PR DESCRIPTION
### Description
Upgrade golangci-lint to v1.45.2 so it works with Go 1.18.


