### PR TITLE
Add --password-file flag for offline mode without password input

### DIFF
--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -20,13 +20,15 @@ func certificateCommand() cli.Command {
 		Action: command.ActionFunc(certificateAction),
 		Usage:  "generate a new private key and certificate signed by the root certificate",
 		UsageText: `**step ca certificate** <subject> <crt-file> <key-file>
-[**--token**=<token>]  [**--issuer**=<name>] [**--not-before**=<time|duration>]
-[**--not-after**=<time|duration>] [**--san**=<SAN>] [**--set**=<key=value>]
-[**--set-file**=<file>] [**--acme**=<file>] [**--standalone**] [**--webroot**=<file>]
+[**--token**=<token>]  [**--issuer**=<name>] [**--provisioner-password-file**=<file>]
+[**--not-before**=<time|duration>] [**--not-after**=<time|duration>]
+[**--san**=<SAN>] [**--set**=<key=value>] [**--set-file**=<file>]
+[**--acme**=<file>] [**--standalone**] [**--webroot**=<file>]
 [**--contact**=<email>] [**--http-listen**=<address>] [**--bundle**]
 [**--kty**=<type>] [**--curve**=<curve>] [**--size**=<size>] [**--console**]
 [**--x5c-cert**=<file>] [**--x5c-key**=<file>] [**--k8ssa-token-path**=<file>]
-[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`,
+[**--offline**] [**--password-file**] [**--ca-url**=<uri>] [**--root**=<file>]
+[**--context**=<name>]`,
 		Description: `**step ca certificate** command generates a new certificate pair
 
 ## POSITIONAL ARGUMENTS
@@ -157,6 +159,7 @@ multiple SANs. The '--san' flag and the '--token' flag are mutually exclusive.`,
 			flags.NotBefore,
 			flags.Force,
 			flags.Offline,
+			flags.PasswordFile,
 			consoleFlag,
 			flags.X5cCert,
 			flags.X5cKey,

--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -75,6 +75,16 @@ files, certificates, and keys created with **step ca init**:
 $ step ca certificate --offline internal.example.com internal.crt internal.key
 '''
 
+Request a new certificate using the offline mode with additional flags to avoid
+console prompts:
+'''
+$ step ca certificate --offline \
+	--password-file ./pass.txt \
+	--provisioner foo \
+	--provisioner-password-file ./provisioner-pass.txt \
+	internal.example.com internal.crt internal.key
+'''
+
 Request a new certificate using an OIDC provisioner:
 '''
 $ step ca certificate --token $(step oauth --oidc --bare) joe@example.com joe.crt joe.key

--- a/command/ca/sign.go
+++ b/command/ca/sign.go
@@ -28,7 +28,7 @@ func signCertificateCommand() cli.Command {
 [**--acme**=<uri>] [**--standalone**] [**--webroot**=<file>]
 [**--contact**=<email>] [**--http-listen**=<address>] [**--console**]
 [**--x5c-cert**=<file>] [**--x5c-key**=<file>]
-[**--k8ssa-token-path**=<file>]
+[**--k8ssa-token-path**=<file>] [**--offline**] [**--password-file**=<file>]
 [**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`,
 		Description: `**step ca sign** command signs the given csr and generates a new certificate.
 
@@ -58,6 +58,12 @@ Sign a new certificate using the offline mode, requires the configuration
 files, certificates, and keys created with **step ca init**:
 '''
 $ step ca sign --offline internal internal.csr internal.crt
+'''
+
+Sign a new certificate using the offline mode with additional flag to avoid
+console prompts:
+'''
+$ step ca sign --offline --password-file ./pass.txt internal internal.csr internal.crt
 '''
 
 Sign a new certificate using an X5C provisioner:
@@ -117,6 +123,7 @@ $ step ca sign foo.csr foo.crt \
 			flags.TemplateSetFile,
 			flags.Force,
 			flags.Offline,
+			flags.PasswordFile,
 			consoleFlag,
 			flags.X5cCert,
 			flags.X5cKey,


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

`--password-file` flag for offline mode

#### Pain or issue this feature alleviates:

Allows use of `offline` mode without any additional command line input. Useful for scripting.

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

It's fairly niche, and I don't think we need any additional documentation.

#### In what environments or workflows is this feature supported?

All

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

Fixes https://github.com/smallstep/cli/pull/673
