### PR TITLE
Sort context list alphabetically

### DIFF
--- a/command/context/list.go
+++ b/command/context/list.go
@@ -40,7 +40,7 @@ func listAction(ctx *cli.Context) error {
 		fmt.Printf("▶ %s\n", cur.Name)
 	}
 
-	for _, v := range cs.List() {
+	for _, v := range cs.ListAlphabetical() {
 		if cur != nil && v.Name == cur.Name {
 			continue
 		}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/urfave/cli v1.22.5
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
-	go.step.sm/cli-utils v0.7.2
+	go.step.sm/cli-utils v0.7.3
 	go.step.sm/crypto v0.16.2
 	go.step.sm/linkedca v0.16.1
 	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29

--- a/go.sum
+++ b/go.sum
@@ -1136,6 +1136,8 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.step.sm/cli-utils v0.7.0/go.mod h1:Ur6bqA/yl636kCUJbp30J7Unv5JJ226eW2KqXPDwF/E=
 go.step.sm/cli-utils v0.7.2 h1:kUNNhGRWAad3bLkhvbLjVr3Dqs5DgxCZQcUspWaQCIQ=
 go.step.sm/cli-utils v0.7.2/go.mod h1:Ur6bqA/yl636kCUJbp30J7Unv5JJ226eW2KqXPDwF/E=
+go.step.sm/cli-utils v0.7.3 h1:IA12IaiXVCI18yOFVQuvMpyvjL8wuwUn1yO+KhAVAr0=
+go.step.sm/cli-utils v0.7.3/go.mod h1:RJRwbBLqzs5nrepQLAV9FuT3fVpWz66tKzLIB7Izpfk=
 go.step.sm/crypto v0.9.0/go.mod h1:+CYG05Mek1YDqi5WK0ERc6cOpKly2i/a5aZmU1sfGj0=
 go.step.sm/crypto v0.16.2 h1:Pr9aazTwWBBZNogUsOqhOrPSdwAa9pPs+lMB602lnDA=
 go.step.sm/crypto v0.16.2/go.mod h1:1WkTOTY+fOX/RY4TnZREp6trQAsBHRQ7nu6QJBiNQF8=


### PR DESCRIPTION
#### Name of feature:

Sort context list alphabetically

#### Pain or issue this feature alleviates:

Hard to find contexts when there's no order

I made it default to sorting alphabetically (case-insensitive), because I think that makes sense for most, if not all, use cases.

