### PR TITLE
Check input password value to not be empty on keypair creation

### DIFF
--- a/command/crypto/keypair.go
+++ b/command/crypto/keypair.go
@@ -182,7 +182,7 @@ func createAction(ctx *cli.Context) (err error) {
 		}
 	} else {
 		var pass []byte
-		pass, err = ui.PromptPassword("Please enter the password to encrypt the private key", ui.WithValue(password))
+		pass, err = ui.PromptPassword("Please enter the password to encrypt the private key", ui.WithValue(password), ui.WithValidateNotEmpty())
 		if err != nil {
 			return errors.Wrap(err, "error reading password")
 		}


### PR DESCRIPTION
An empty password doesn't make sense, certainly not given there's the `--no-password` option. This commit adds the empty validation check to the password prompt, always requiring a password to be provided by the user. 

An alternative would be to generate a password if the value is empty. Both methods are currently used in the CLI. The ones that generate a password are mostly used for `ca` commands. That's why I chose to validate the value to not be empty instead of generating one, as `crypto keypair` has nothing to do with the CA directly.

