### PR TITLE
Add ssh signataure to step ssh inspect

### DIFF
--- a/command/ssh/inspect.go
+++ b/command/ssh/inspect.go
@@ -110,7 +110,7 @@ func inspectAction(ctx *cli.Context) error {
 		fmt.Println(name + ":")
 		fmt.Printf("%8sType: %s %s certificate\n", space, inspect.KeyName, inspect.Type)
 		fmt.Printf("%8sPublic key: %s-CERT %s\n", space, inspect.KeyAlgo, inspect.KeyFingerprint)
-		fmt.Printf("%8sSigning CA: %s %s\n", space, inspect.SigningKeyAlgo, inspect.SigningKeyFingerprint)
+		fmt.Printf("%8sSigning CA: %s %s (using %s)\n", space, inspect.SigningKeyAlgo, inspect.SigningKeyFingerprint, inspect.Signature.Type)
 		fmt.Printf("%8sKey ID: \"%s\"\n", space, inspect.KeyID)
 		fmt.Printf("%8sSerial: %d\n", space, inspect.Serial)
 		fmt.Printf("%8sValid: %s\n", space, inspect.Validity())
@@ -141,6 +141,18 @@ func inspectAction(ctx *cli.Context) error {
 				fmt.Printf("%16s%s %v\n", space, k, v)
 			}
 		}
+		fmt.Printf("%8sSignature:", space)
+		for i, b := range cert.Signature.Blob {
+			if (i % 16) == 0 {
+				fmt.Printf("\n%16s", space)
+			}
+			fmt.Printf("%02x", b)
+			if i != len(cert.Signature.Blob)-1 {
+				fmt.Print(":")
+			}
+		}
+		fmt.Println()
+
 	case "json":
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")

--- a/crypto/sshutil/inspect.go
+++ b/crypto/sshutil/inspect.go
@@ -20,12 +20,19 @@ type CertificateInspect struct {
 	KeyFingerprint        string
 	SigningKeyAlgo        string
 	SigningKeyFingerprint string
+	Signature             Signature
 	Serial                uint64
 	ValidAfter            time.Time
 	ValidBefore           time.Time
 	Principals            []string
 	CriticalOptions       map[string]string
 	Extensions            map[string]string
+}
+
+type Signature struct {
+	Type  string
+	Value []byte
+	Rest  []byte `json:",omitempty"`
 }
 
 // InspectCertificate returns a CertificateInspect with the properties of the
@@ -65,12 +72,17 @@ func InspectCertificate(cert *ssh.Certificate) (*CertificateInspect, error) {
 		KeyFingerprint:        sum,
 		SigningKeyAlgo:        sigAlgo,
 		SigningKeyFingerprint: sigSum,
-		Serial:                cert.Serial,
-		ValidAfter:            validAfter,
-		ValidBefore:           validBefore,
-		Principals:            cert.ValidPrincipals,
-		CriticalOptions:       cert.CriticalOptions,
-		Extensions:            cert.Extensions,
+		Signature: Signature{
+			Type:  cert.Signature.Format,
+			Value: cert.Signature.Blob,
+			Rest:  cert.Signature.Rest,
+		},
+		Serial:          cert.Serial,
+		ValidAfter:      validAfter,
+		ValidBefore:     validBefore,
+		Principals:      cert.ValidPrincipals,
+		CriticalOptions: cert.CriticalOptions,
+		Extensions:      cert.Extensions,
 	}, nil
 }
 


### PR DESCRIPTION
### Description

This PR adds the signature and signature type to the `step ssh inspect` command. Fixes #699

Now a certificate will inspect as:

```console
$ step ssh inspect mariano-cert.pub
mariano-cert.pub:
        Type: ecdsa-sha2-nistp256-cert-v01@openssh.com user certificate
        Public key: ECDSA-CERT SHA256:a8SHPBTzbkmcfAp+FWBoOj87k7wnGEG3qleXFPXz8FM
        Signing CA: ECDSA SHA256:ExpOxCvxwkeqnHuUtTR5dhsTUFgcN1QeuAYqOGE6200 (using ecdsa-sha2-nistp256)
        Key ID: "mariano@smallstep.com"
        Serial: 6770237405177342977
        Valid: from 2022-02-01T12:01:07 to 2022-02-02T04:02:07
        Principals:
                mariano@smallstep.com
        Critical Options: (none)
        Extensions:
                permit-port-forwarding
                permit-pty
                permit-user-rc
                permit-X11-forwarding
                permit-agent-forwarding
        Signature:
                00:00:00:20:62:59:41:e3:96:ab:49:95:e8:6a:1d:a5:
                9e:63:21:c5:b6:1d:66:f9:40:e8:7b:ec:c4:4c:41:c9:
                33:8e:2b:a3:00:00:00:21:00:a9:f0:ee:9c:69:5a:4f:
                a8:f3:dd:8c:88:36:92:3f:3a:70:31:fe:52:53:cf:b4:
                05:cd:a3:ba:1b:69:5b:3c:e0
```

The `(using ecdsa-sha2-nistp256)` has been added too to match the output of `ssh-keygen -L -f mariano-cert.pub`. Note that `ssh-keygen` does not display the signature.