### PR TITLE
Add fish shell auto-completion

### DIFF
--- a/command/completion/completion.go
+++ b/command/completion/completion.go
@@ -39,6 +39,7 @@ $ step completion bash >> ~/.bash_completion
 			}
 			fmt.Println("bash")
 			fmt.Println("zsh")
+			fmt.Println("fish")
 		},
 	}
 
@@ -102,6 +103,8 @@ func Completion(ctx *cli.Context) error {
 		fmt.Print(bash)
 	case "zsh":
 		fmt.Print(zsh)
+	case "fish":
+		fmt.Print(ctx.App.ToFishCompletion())
 	default:
 		return errors.Errorf("unsupported shell %s", shell)
 	}


### PR DESCRIPTION
Hello

#### Name of feature:

Fish shell auto-completion

#### Pain or issue this feature alleviates:

The step CLI is already offering support for bash and zsh auto-completion, but fish was not provided yet.

#### Why is this important to the project (if not answered above):

To improve the user experience and improve discoverability of the tool.

#### Is there documentation on how to use this feature? If so, where?

```sh
step completion fish > ~/.config/fish/completions/step.fish
```

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

With the help of https://github.com/urfave/cli/pull/848

Thank you!
