### PR TITLE
--x5c-root → --x5c-roots

### DIFF
--- a/command/ca/provisioner/add.go
+++ b/command/ca/provisioner/add.go
@@ -53,7 +53,7 @@ OIDC
 
 X5C
 
-**step ca provisioner add** <name> **--type**=X5C **--x5c-root**=<file>
+**step ca provisioner add** <name> **--type**=X5C **--x5c-roots**=<file>
 [**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
 [**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
 [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
@@ -118,7 +118,7 @@ SCEP
 			oidcTenantIDFlag,
 
 			// X5C provisioner flags
-			x5cRootFlag,
+			x5cRootsFlag,
 
 			// Nebula provisioner flags
 			nebulaRootFlag,
@@ -216,7 +216,7 @@ step ca provisioner add Google --type OIDC --ssh \
 
 Create an X5C provisioner:
 '''
-step ca provisioner add x5c --type X5C --x5c-root x5c_ca.crt
+step ca provisioner add x5c --type X5C --x5c-roots x5c_ca.crt
 '''
 
 Create an ACME provisioner:
@@ -573,9 +573,9 @@ func createSSHPOPDetails(ctx *cli.Context) (*linkedca.ProvisionerDetails, error)
 }
 
 func createX5CDetails(ctx *cli.Context) (*linkedca.ProvisionerDetails, error) {
-	x5cRootFile := ctx.String("x5c-root")
+	x5cRootFile := ctx.String("x5c-roots")
 	if x5cRootFile == "" {
-		return nil, errs.RequiredWithFlagValue(ctx, "type", "x5c", "x5c-root")
+		return nil, errs.RequiredWithFlagValue(ctx, "type", "x5c", "x5c-roots")
 	}
 
 	roots, err := pemutil.ReadCertificateBundle(x5cRootFile)

--- a/command/ca/provisioner/provisioner.go
+++ b/command/ca/provisioner/provisioner.go
@@ -582,7 +582,7 @@ Use the '--group' flag multiple times to configure multiple groups.`,
 
 	// X5C provisioner flags
 	x5cRootsFlag = cli.StringFlag{
-		Name: "x5c-roots",
+		Name: "x5c-roots, x5c-root",
 		Usage: `PEM-formatted root certificate(s) <file> used to validate the signature on X5C
 provisioning tokens.`,
 	}

--- a/command/ca/provisioner/provisioner.go
+++ b/command/ca/provisioner/provisioner.go
@@ -581,9 +581,9 @@ Use the '--group' flag multiple times to configure multiple groups.`,
 	}
 
 	// X5C provisioner flags
-	x5cRootFlag = cli.StringFlag{
-		Name: "x5c-root",
-		Usage: `Root certificate (chain) <file> used to validate the signature on X5C
+	x5cRootsFlag = cli.StringFlag{
+		Name: "x5c-roots",
+		Usage: `PEM-formatted root certificate(s) <file> used to validate the signature on X5C
 provisioning tokens.`,
 	}
 )

--- a/command/ca/provisioner/update.go
+++ b/command/ca/provisioner/update.go
@@ -57,7 +57,7 @@ OIDC
 
 X5C
 
-**step ca provisioner update** <name> **--x5c-root**=<file>
+**step ca provisioner update** <name> **--x5c-roots**=<file>
 [**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
 [**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
 [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
@@ -112,7 +112,7 @@ SCEP
 			oidcTenantIDFlag,
 
 			// X5C Root Flag
-			x5cRootFlag,
+			x5cRootsFlag,
 
 			// Nebula provisioner flags
 			nebulaRootFlag,
@@ -231,7 +231,7 @@ step ca provisioner update Google \
 
 Update an X5C provisioner:
 '''
-step ca provisioner update x5c --x5c-root x5c_ca.crt
+step ca provisioner update x5c --x5c-roots x5c_ca.crt
 '''
 
 Update an ACME provisioner:
@@ -641,8 +641,8 @@ func updateX5CDetails(ctx *cli.Context, p *linkedca.Provisioner) error {
 		return errors.New("error casting details to X5C type")
 	}
 	details := data.X5C
-	if ctx.IsSet("x5c-root") {
-		x5cRootFile := ctx.String("x5c-root")
+	if ctx.IsSet("x5c-roots") {
+		x5cRootFile := ctx.String("x5c-roots")
 		roots, err := pemutil.ReadCertificateBundle(x5cRootFile)
 		if err != nil {
 			return errors.Wrapf(err, "error loading X5C Root certificates from %s", x5cRootFile)

--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,8 @@ require (
 	go.step.sm/crypto v0.19.0
 	go.step.sm/linkedca v0.19.0-rc.1
 	golang.org/x/crypto v0.0.0-20220826181053-bd7e27e6170d
-	golang.org/x/net v0.0.0-20220607020251-c690dde0001d
-	golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d
+	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
+	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/square/go-jose.v2 v2.6.0

--- a/go.sum
+++ b/go.sum
@@ -1225,8 +1225,9 @@ golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220607020251-c690dde0001d h1:4SFsTMi4UahlKoloni7L4eYzhFRifURQLw+yv0QDCx8=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220909164309-bea034e7d591 h1:D0B/7al0LLrVC8aWF4+oxpv/m8bc7ViFfVS8/gXGdqI=
+golang.org/x/net v0.0.0-20220909164309-bea034e7d591/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1357,8 +1358,9 @@ golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d h1:Zu/JngovGLVi6t2J3nmAf3AoTDwuzw85YZ3b9o4yU7s=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=


### PR DESCRIPTION
The flag `--x5c-root` in `provisioner add` and `provisioner update` should be plural, because you can configure multiple root CAs to be trusted.

- [x] This would benefit from backward compatibility. I could add `Aliases` to the `StringFlag`, but I think the singular version should be hidden from help text and I wasn't sure how to do that.
