### PR TITLE
Add category to command reference Markdown front matter

### DIFF
--- a/usage/printer.go
+++ b/usage/printer.go
@@ -58,6 +58,7 @@ func markdownHelpPrinter(w io.Writer, templ, parent string, data interface{}) {
 
 	var frontMatterTemplate = `---
 layout: auto-doc
+category: reference
 title: {{.Data.HelpName}}
 menu:
   docs:


### PR DESCRIPTION
I want to distinguish the reference docs from the rest of the documentation, and adding a `category` is a better way to do that than using the `layout` as a proxy. See smallstep/docs#131 for where this will be applied.
