### PR TITLE
Ignore lint errors.

### DIFF
--- a/command/ca/provisioner/caConfigClient.go
+++ b/command/ca/provisioner/caConfigClient.go
@@ -91,6 +91,7 @@ func newCaConfigClient(ctx context.Context, cfg *config.Config, cfgFile string) 
 			return nil, err
 		}
 	}
+	//nolint:contextcheck // no context for backward compatibility
 	a, err := authority.New(cfg, authority.WithAdminDB(newNoDB()),
 		//nolint:staticcheck // TODO: WithProvisioners has been deprecated, temporarily do not lint this line.
 		authority.WithSkipInit(), authority.WithProvisioners(provClxn))

--- a/internal/command/inject.go
+++ b/internal/command/inject.go
@@ -18,6 +18,7 @@ func InjectContext(injectedCtx context.Context, fn func(context.Context) error, 
 		},
 	}
 	injectedMiddleware = append(injectedMiddleware, middleware...)
+	//nolint:contextcheck // context is injected in fn
 	return wrap(fn, injectedMiddleware...)
 }
 

--- a/usage/html.go
+++ b/usage/html.go
@@ -18,6 +18,7 @@ func httpHelpAction(ctx *cli.Context) error {
 	}
 
 	fmt.Printf("Serving HTTP on %s ...\n", addr)
+	//nolint:gosec // this is a local help server
 	return http.ListenAndServe(addr, &htmlHelpHandler{
 		cliApp: ctx.App,
 	})


### PR DESCRIPTION
### Description

This PR ignores three new errors that appear with golangci-ling 1.49