### PR TITLE
Fix unused linter warnings

### DIFF
--- a/cmd/step/main.go
+++ b/cmd/step/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -15,7 +16,6 @@ import (
 	"github.com/smallstep/cli/usage"
 	"github.com/urfave/cli"
 	"go.step.sm/cli-utils/command"
-	"go.step.sm/cli-utils/errs"
 	"go.step.sm/cli-utils/step"
 	"go.step.sm/cli-utils/ui"
 	"go.step.sm/crypto/jose"
@@ -114,12 +114,14 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		//nolint:errorlint // not a specific error
-		if fe, ok := err.(errs.FriendlyError); ok {
+		var messenger interface {
+			Message() string
+		}
+		if errors.As(err, &messenger) {
 			if os.Getenv("STEPDEBUG") == "1" {
-				fmt.Fprintf(os.Stderr, "%+v\n\n%s", err, fe.Message())
+				fmt.Fprintf(os.Stderr, "%+v\n\n%s", err, messenger.Message())
 			} else {
-				fmt.Fprintln(os.Stderr, fe.Message())
+				fmt.Fprintln(os.Stderr, messenger.Message())
 				fmt.Fprintln(os.Stderr, "Re-run with STEPDEBUG=1 for more info.")
 			}
 		} else {

--- a/command/ssh/config.go
+++ b/command/ssh/config.go
@@ -106,10 +106,6 @@ times to set multiple variables.`,
 	}
 }
 
-type statusCoder interface {
-	StatusCode() int
-}
-
 func configAction(ctx *cli.Context) (recoverErr error) {
 	team := ctx.String("team")
 	isHost := ctx.Bool("host")
@@ -171,8 +167,10 @@ func configAction(ctx *cli.Context) (recoverErr error) {
 			roots, err = client.SSHFederation()
 		}
 		if err != nil {
-			//nolint:errorlint // not a specific error
-			if e, ok := err.(statusCoder); ok && e.StatusCode() == http.StatusNotFound {
+			var statusCoder interface {
+				StatusCode() int
+			}
+			if errors.As(err, &statusCoder) && statusCoder.StatusCode() == http.StatusNotFound {
 				return errors.New("step certificates is not configured with SSH support")
 			}
 			return errors.Wrap(err, "error getting ssh public keys")

--- a/make/common.mk
+++ b/make/common.mk
@@ -71,7 +71,7 @@ race:
 integrate: integration
 
 integration: bin/$(BINNAME)
-	$Q $(CGO_OVERRIDE) go test -tags=integration ./integration/...
+	$Q $(CGO_OVERRIDE) gotestsum -- -tags=integration ./integration/...
 
 .PHONY: integrate integration
 


### PR DESCRIPTION
* use errors.As with interface{} correctly
