### PR TITLE
fixup: RELEASE_DATE for release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,10 +73,16 @@ jobs:
       - name: Write cosign key to disk
         id: write_key
         run: echo "${{ secrets.COSIGN_KEY }}" > "/tmp/cosign.key"
+      - 
+        name: Get current time
+        id: time
+        uses: nanzm/get-time-action@master
+        with:
+          format: 'YYYY-MM-DD'
       - name: Get Release Date
         id: release_date
         run: |
-          RELEASE_DATE=$(date +"%y-%m-%d")
+          RELEASE_DATE=${{ steps.time.outputs.time }}
           echo "::set-output name=RELEASE_DATE::${RELEASE_DATE}"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
Fixup: get date for releases 

#### Why is this important to the project (if not answered above):
date is not parsed over next tasks.

#### Is there documentation on how to use this feature? If so, where?
https://github.com/nanzm/get-time-action#readme
#### In what environments or workflows is this feature supported?
release.yml
