### PR TITLE
Add --admin-password-file flag

### DIFF
--- a/command/ca/acme/eab/add.go
+++ b/command/ca/acme/eab/add.go
@@ -20,16 +20,15 @@ func addCommand() cli.Command {
 		Action: cli.ActionFunc(addAction),
 		Usage:  "add ACME External Account Binding Key",
 		UsageText: `**step ca acme eab add** <provisioner> [<eab-key-reference>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>]
-[**--password-file**=<file>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--context**=<name>]`,
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`,
 		Flags: []cli.Flag{
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/acme/eab/list.go
+++ b/command/ca/acme/eab/list.go
@@ -21,18 +21,18 @@ func listCommand() cli.Command {
 		Action: cli.ActionFunc(listAction),
 		Usage:  "list all ACME External Account Binding Keys",
 		UsageText: `**step ca acme eab list** <provisioner> [<eab-key-reference>]
-[**--limit**=<number>] [**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>]
-[**--password-file**=<file>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--context**=<name>]`,
+[**--limit**=<number>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`,
 		Flags: []cli.Flag{
 			flags.Limit,
 			flags.NoPager,
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/acme/eab/remove.go
+++ b/command/ca/acme/eab/remove.go
@@ -18,16 +18,15 @@ func removeCommand() cli.Command {
 		Action: cli.ActionFunc(removeAction),
 		Usage:  "remove an ACME EAB Key from the CA",
 		UsageText: `**step ca acme eab remove** <provisioner> <eab-key-id>
-[**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>]
-[**--password-file**=<file>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--context**=<name>]`,
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`,
 		Flags: []cli.Flag{
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/admin/add.go
+++ b/command/ca/admin/add.go
@@ -19,9 +19,9 @@ func addCommand() cli.Command {
 		Action: cli.ActionFunc(addAction),
 		Usage:  "add an admin to the CA configuration",
 		UsageText: `**step ca admin add** <subject> <provisioner> [**--super**]
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>]`,
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
 				Name:  "super",
@@ -29,9 +29,9 @@ func addCommand() cli.Command {
 			},
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/admin/list.go
+++ b/command/ca/admin/list.go
@@ -18,9 +18,9 @@ func listCommand() cli.Command {
 		Action: cli.ActionFunc(listAction),
 		Usage:  "list all admins in the CA configuration",
 		UsageText: `**step ca admin list** [**--super**] [**--provisioner**=<name>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>]`,
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
 				Name:  "super",
@@ -29,9 +29,9 @@ func listCommand() cli.Command {
 			provisionerFilterFlag,
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/admin/remove.go
+++ b/command/ca/admin/remove.go
@@ -13,16 +13,16 @@ func removeCommand() cli.Command {
 		Action: cli.ActionFunc(removeAction),
 		Usage:  "remove an admin from the CA configuration",
 		UsageText: `**step ca admin remove** <subject> [**--provisioner**=<name>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>]`,
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`,
 		Flags: []cli.Flag{
 			provisionerFilterFlag,
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/admin/update.go
+++ b/command/ca/admin/update.go
@@ -19,9 +19,9 @@ func updateCommand() cli.Command {
 		Action: cli.ActionFunc(updateAction),
 		Usage:  "update an admin",
 		UsageText: `**step ca admin update** <subject> [**--super**] [**--provisioner**=<name>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>]`,
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
 				Name:  "super",
@@ -30,9 +30,9 @@ func updateCommand() cli.Command {
 			provisionerFilterFlag,
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/policy/actions/cn.go
+++ b/command/ca/policy/actions/cn.go
@@ -49,10 +49,7 @@ $ step ca policy authority x509 allow cn www.example.com --remove
 Deny "My Bad CA Name" as Common Name in X.509 certificates on authority level
 '''
 $ step ca policy authority x509 deny cn "My Bad CA Name"
-'''
-
-
-`, commandName),
+'''`, commandName),
 		Action: command.InjectContext(
 			ctx,
 			commonNamesAction,

--- a/command/ca/policy/actions/cn.go
+++ b/command/ca/policy/actions/cn.go
@@ -22,12 +22,10 @@ func CommonNamesCommand(ctx context.Context) cli.Command {
 		Usage: "add or remove common names",
 		UsageText: fmt.Sprintf(`**%s** <name> [**--remove**]
 [**--provisioner**=<name>] [**--eab-key-id**=<eab-key-id>] [**--eab-key-reference**=<eab-key-reference>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>]
-[**--password-file**=<file>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--context**=<name>]`, commandName),
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`, commandName),
 		Description: fmt.Sprintf(`**%s** command manages common names in policies
-
 
 ## EXAMPLES
 
@@ -69,9 +67,9 @@ $ step ca policy authority x509 deny cn "My Bad CA Name"
 			},
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/policy/actions/dns.go
+++ b/command/ca/policy/actions/dns.go
@@ -22,10 +22,9 @@ func DNSCommand(ctx context.Context) cli.Command {
 		Usage: "add or remove DNS domains",
 		UsageText: fmt.Sprintf(`**%s** <domain> [**--remove**]
 [**--provisioner**=<name>] [**--eab-key-id**=<eab-key-id>] [**--eab-key-reference**=<eab-key-reference>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>]
-[**--password-file**=<file>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--context**=<name>]`, commandName),
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`, commandName),
 		Description: fmt.Sprintf(`**%s** command manages DNS domains in policies
 
 ## EXAMPLES
@@ -85,9 +84,9 @@ $ step ca policy authority ssh host allow dns "badsshhost.local"
 			},
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/policy/actions/dns.go
+++ b/command/ca/policy/actions/dns.go
@@ -67,9 +67,7 @@ $ step ca policy authority ssh host allow dns "*.local"
 Deny badsshhost.local in SSH host certificates on authority level
 '''
 $ step ca policy authority ssh host allow dns "badsshhost.local"
-'''
-
-`, commandName),
+'''`, commandName),
 		Action: command.InjectContext(
 			ctx,
 			dnsAction,

--- a/command/ca/policy/actions/emails.go
+++ b/command/ca/policy/actions/emails.go
@@ -56,10 +56,7 @@ $ step ca policy provisioner ssh user allow email @example.com --provisioner my_
 Deny root@example.com domain in SSH user certificates on provisioner level
 '''
 $ step ca policy provisioner ssh user deny email @example.com --provisioner my_provisioner
-'''
-
-
-`, commandName),
+'''`, commandName),
 		Action: command.InjectContext(
 			ctx,
 			emailAction,

--- a/command/ca/policy/actions/emails.go
+++ b/command/ca/policy/actions/emails.go
@@ -20,11 +20,10 @@ func EmailCommand(ctx context.Context) cli.Command {
 	return cli.Command{
 		Name:  "email",
 		Usage: "add or remove email addresses",
-		UsageText: fmt.Sprintf(`**%s** <email> [**--remove**]
-[**--provisioner**=<name>] [**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>]
-[**--password-file**=<file>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--context**=<name>]`, commandName),
+		UsageText: fmt.Sprintf(`**%s** <email> [**--remove**] [**--provisioner**=<name>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`, commandName),
 		Description: fmt.Sprintf(`**%s** command manages email addresses and domains in policies
 
 ## EXAMPLES
@@ -73,9 +72,9 @@ $ step ca policy provisioner ssh user deny email @example.com --provisioner my_p
 			},
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/policy/actions/ips.go
+++ b/command/ca/policy/actions/ips.go
@@ -22,10 +22,9 @@ func IPCommand(ctx context.Context) cli.Command {
 		Usage: "add or remove ip addresses",
 		UsageText: fmt.Sprintf(`**%s** <ip address> [**--remove**]
 [**--provisioner**=<name>] [**--eab-key-id**=<eab-key-id>] [**--eab-key-reference**=<eab-key-reference>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>]
-[**--password-file**=<file>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--context**=<name>]`, commandName),
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`, commandName),
 		Description: fmt.Sprintf(`**%s** command manages IP addresses and ranges in policies
 
 ## EXAMPLES
@@ -105,9 +104,9 @@ $ step ca policy authority ssh host deny ip 192.168.0.40
 			},
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/policy/actions/ips.go
+++ b/command/ca/policy/actions/ips.go
@@ -87,9 +87,7 @@ $ step ca policy authority ssh host allow ip 192.168.0.0/24
 Deny IP address 192.168.0.40 in SSH host certificates on authority level
 '''
 $ step ca policy authority ssh host deny ip 192.168.0.40
-'''
-
-`, commandName),
+'''`, commandName),
 		Action: command.InjectContext(
 			ctx,
 			ipAction,

--- a/command/ca/policy/actions/principals.go
+++ b/command/ca/policy/actions/principals.go
@@ -51,9 +51,7 @@ $ step ca policy provisioner ssh host allow principal user --provisioner my_ssh_
 Deny principal root in SSH user certificates on provisioner level
 '''
 $ step ca policy provisioner ssh host deny principal root --provisioner my_ssh_user_provisioner
-'''
-
-`, commandName),
+'''`, commandName),
 		Action: command.InjectContext(
 			ctx,
 			principalAction,

--- a/command/ca/policy/actions/principals.go
+++ b/command/ca/policy/actions/principals.go
@@ -20,11 +20,10 @@ func PrincipalsCommand(ctx context.Context) cli.Command {
 	return cli.Command{
 		Name:  "principal",
 		Usage: "add or remove principals",
-		UsageText: fmt.Sprintf(`**%s** <principal> [**--remove**]
-[**--provisioner**=<name>] [**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>]
-[**--password-file**=<file>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--context**=<name>]`, commandName),
+		UsageText: fmt.Sprintf(`**%s** <principal> [**--remove**] [**--provisioner**=<name>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`, commandName),
 		Description: fmt.Sprintf(`**%s** command manages principals in SSH policies
 
 ## EXAMPLES
@@ -67,9 +66,9 @@ $ step ca policy provisioner ssh host deny principal root --provisioner my_ssh_u
 			},
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/policy/actions/remove.go
+++ b/command/ca/policy/actions/remove.go
@@ -47,8 +47,7 @@ $ step ca policy acme remove --provisioner my_acme_provisioner --eab-key-referen
 Remove an ACME EAB certificate issuance policy by EAB Key ID
 '''
 $ step ca policy acme remove --provisioner my_acme_provisioner --eab-key-id "lUOTGwvFQADjk8nxsVufbhyTOwrFmvO2"
-'''
-`, commandName),
+'''`, commandName),
 		Action: command.InjectContext(
 			ctx,
 			removeAction,

--- a/command/ca/policy/actions/remove.go
+++ b/command/ca/policy/actions/remove.go
@@ -22,11 +22,12 @@ func RemoveCommand(ctx context.Context) cli.Command {
 		Usage: "remove certificate issuance policy",
 		UsageText: fmt.Sprintf(`**%s** 
 [**--provisioner**=<name>] [**--eab-key-id**=<eab-ey-id>] [**--eab-key-reference**=<eab-key-reference>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>]
-[**--password-file**=<file>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--context**=<name>]`, commandName),
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`, commandName),
 		Description: fmt.Sprintf(`**%s** removes a certificate issuance policy.
+
+## EXAMPLES
 
 Remove the authority certificate issuance policy
 '''
@@ -58,9 +59,9 @@ $ step ca policy acme remove --provisioner my_acme_provisioner --eab-key-id "lUO
 			flags.EABReference,
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/policy/actions/uris.go
+++ b/command/ca/policy/actions/uris.go
@@ -20,11 +20,10 @@ func URICommand(ctx context.Context) cli.Command {
 	return cli.Command{
 		Name:  "uri",
 		Usage: "add or remove URI domains",
-		UsageText: fmt.Sprintf(`**%s** <uri domain> [**--remove**]
-[**--provisioner**=<name>] [**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>]
-[**--password-file**=<file>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--context**=<name>]`, commandName),
+		UsageText: fmt.Sprintf(`**%s** <uri domain> [**--remove**] [**--provisioner**=<name>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`, commandName),
 		Description: fmt.Sprintf(`**%s** command manages URI domains in policies
 
 ## EXAMPLES
@@ -62,9 +61,9 @@ $ step ca policy provisioner x509 allow uri "*.example.com" --provisioner my_pro
 			},
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/policy/actions/uris.go
+++ b/command/ca/policy/actions/uris.go
@@ -46,9 +46,7 @@ $ step ca policy authority x509 deny uri badhost.local --remove
 Allow all URI subdomains of "example.com" in X.509 certificates on provisioner level
 '''
 $ step ca policy provisioner x509 allow uri "*.example.com" --provisioner my_provisioner
-'''
-
-`, commandName),
+'''`, commandName),
 		Action: command.InjectContext(
 			ctx,
 			uriAction,

--- a/command/ca/policy/actions/view.go
+++ b/command/ca/policy/actions/view.go
@@ -48,9 +48,7 @@ $ step ca policy acme view --provisioner my_acme_provisioner --eab-key-reference
 View an ACME EAB certificate issuance policy by EAB Key ID
 '''
 $ step ca policy acme view --provisioner my_acme_provisioner --eab-key-id "lUOTGwvFQADjk8nxsVufbhyTOwrFmvO2"
-'''
-
-`, commandName),
+'''`, commandName),
 		Action: command.InjectContext(
 			ctx,
 			viewAction,

--- a/command/ca/policy/actions/view.go
+++ b/command/ca/policy/actions/view.go
@@ -23,10 +23,9 @@ func ViewCommand(ctx context.Context) cli.Command {
 		Usage: "view current certificate issuance policy",
 		UsageText: fmt.Sprintf(`**%s**
 [**--provisioner**=<name>] [**--eab-key-id**=<eab-key-id>] [**--eab-key-reference**=<eab-key-reference>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>]
-[**--password-file**=<file>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--context**=<name>]`, commandName),
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`, commandName),
 		Description: fmt.Sprintf(`**%s** shows the currently configured policy.
 
 ## EXAMPLES
@@ -62,9 +61,9 @@ $ step ca policy acme view --provisioner my_acme_provisioner --eab-key-id "lUOTG
 			flags.EABReference,
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/policy/x509/wildcards.go
+++ b/command/ca/policy/x509/wildcards.go
@@ -33,10 +33,9 @@ func allowWildcardsCommand(ctx context.Context) cli.Command {
 		Usage: "allow wildcard names in X.509 certificate issuance policies",
 		UsageText: `**step ca policy x509 wildcards allow**
 [**--provisioner**=<name>] [**--eab-key-id**=<eab-key-id>] [**--eab-key-reference**=<eab-key-reference>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>]
-[**--password-file**=<file>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--context**=<name>]`,
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`,
 		Description: `**step ca policy x509 wildcards allow** allow wildcard names in X.509 policy
 
 ## EXAMPLES	
@@ -65,9 +64,9 @@ $ step ca policy acme x509 wildcards allow --provisioner my_acme_provisioner --e
 			flags.EABReference,
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,
@@ -81,10 +80,9 @@ func denyWildcardsCommand(ctx context.Context) cli.Command {
 		Usage: "deny wildcard names in X.509 certificate issuance policies",
 		UsageText: `**step ca policy x509 wildcards deny**
 [**--provisioner**=<name>] [**--eab-key-id**=<eab-key-id>] [**--eab-key-reference**=<eab-key-reference>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>]
-[**--password-file**=<file>] [**--ca-url**=<uri>] [**--root**=<file>]
-[**--context**=<name>]`,
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>]`,
 		Description: `**step ca policy x509 wildcards deny** deny wildcard names in X.509 policy
 
 ## EXAMPLES	
@@ -113,9 +111,9 @@ $ step ca policy acme x509 wildcards deny --provisioner my_acme_provisioner --ea
 			flags.EABReference,
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/provisioner/add.go
+++ b/command/ca/provisioner/add.go
@@ -29,18 +29,18 @@ func addCommand() cli.Command {
 		Usage:  "add a provisioner",
 		UsageText: `**step ca provisioner add** <name> **--type**=JWK [**--public-key**=<file>]
 [**--private-key**=<file>] [**--create**] [**--password-file**=<file>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>]
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 ACME
 
 **step ca provisioner add** <name> **--type**=ACME
 [**--force-cn**] [**--require-eab**] [**--challenge**=<challenge>]
 [**--attestation-format**=<format>] [**--attestation-roots**=<file>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>]
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 OIDC
 
@@ -48,37 +48,37 @@ OIDC
 [**--client-id**=<id>] [**--client-secret**=<secret>]
 [**--configuration-endpoint**=<url>] [**--domain**=<domain>]
 [**--admin**=<email>]...
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>]
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 X5C
 
 **step ca provisioner add** <name> **--type**=X5C **--x5c-roots**=<file>
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>]
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 SSHPOP
 
 **step ca provisioner add** <name> **--type**=SSHPOP
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>]
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 Nebula
 
 **step ca provisioner add** <name> **--type**=Nebula **--nebula-root**=<file>
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>]
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 K8SSA
 
 **step ca provisioner add** <name> **--type**=K8SSA [**--public-key**=<file>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>]
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 IID
 
@@ -88,16 +88,17 @@ IID
 [**--azure-audience**=<name>] [**--azure-subscription-id**=<id>]
 [**--azure-object-id**=<id>] [**--instance-age**=<duration>] [**--iid-roots**=<file>]
 [**--disable-custom-sans**] [**--disable-trust-on-first-use**]
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>]
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 SCEP
 
 **step ca provisioner add** <name> **--type**=SCEP [**--force-cn**] [**--challenge**=<challenge>]
 [**--capabilities**=<capabilities>] [**--include-root**] [**--min-public-key-length**=<length>]
-[**--encryption-algorithm-identifier**=<id>] [**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<string>] [**--admin-subject**=<string>] [**--password-file**=<file>]
+[**--encryption-algorithm-identifier**=<id>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>]
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
 [**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]`,
 		Flags: []cli.Flag{
 			// General provisioner flags
@@ -171,8 +172,9 @@ SCEP
 
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFileNoAlias,
 			flags.PasswordFile,
 			flags.CaURL,
 			flags.Root,

--- a/command/ca/provisioner/remove.go
+++ b/command/ca/provisioner/remove.go
@@ -39,8 +39,7 @@ $ step ca provisioner remove acme
 Remove provisioner from a ca.json that is not in the default location:
 '''
 $ step ca provisioner remove acme --ca-config /path/to/ca.json
-'''
-`,
+'''`,
 	}
 }
 

--- a/command/ca/provisioner/remove.go
+++ b/command/ca/provisioner/remove.go
@@ -13,15 +13,15 @@ func removeCommand() cli.Command {
 		Action: cli.ActionFunc(removeAction),
 		Usage:  "remove a provisioner from the CA configuration",
 		UsageText: `**step ca provisioner remove** <name>
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]`,
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]`,
 		Flags: []cli.Flag{
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/provisioner/update.go
+++ b/command/ca/provisioner/update.go
@@ -39,7 +39,7 @@ ACME
 **step ca provisioner update** <name> [**--force-cn**] [**--require-eab**]
 [**--challenge**=<challenge>] [**--remove-challenge**=<challenge>]
 [**--attestation-format**=<format>] [**--remove-attestation-format**=<format>]
-[**--attestation-roots**=<file>] [**--admin-cert**=<file>] [**--admin-key**=<file>] 
+[**--attestation-roots**=<file>] [**--admin-cert**=<file>] [**--admin-key**=<file>]
 [**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
 [**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 

--- a/command/ca/provisioner/update.go
+++ b/command/ca/provisioner/update.go
@@ -30,17 +30,17 @@ func updateCommand() cli.Command {
 		Usage:  "update a provisioner",
 		UsageText: `**step ca provisioner update** <name> [**--public-key**=<file>]
 [**--private-key**=<file>] [**--create**] [**--password-file**=<file>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 ACME
 
 **step ca provisioner update** <name> [**--force-cn**] [**--require-eab**]
 [**--challenge**=<challenge>] [**--remove-challenge**=<challenge>]
 [**--attestation-format**=<format>] [**--remove-attestation-format**=<format>]
-[**--attestation-roots**=<file>] [**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<name>] [**--admin-subject**=<subject>] [**--password-file**=<file>]
+[**--attestation-roots**=<file>] [**--admin-cert**=<file>] [**--admin-key**=<file>] 
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
 [**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 OIDC
@@ -51,23 +51,23 @@ OIDC
 [**--domain**=<domain>] [**--remove-domain**=<domain>]
 [**--group**=<group>] [**--remove-group**=<group>]
 [**--admin**=<email>]... [**--remove-admin**=<email>]...
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>] 
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 X5C
 
 **step ca provisioner update** <name> **--x5c-roots**=<file>
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>] 
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 K8SSA (Kubernetes Service Account)
 
 **step ca provisioner update** <name> [**--public-key**=<file>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>] 
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 IID (AWS/GCP/Azure)
 
@@ -79,18 +79,17 @@ IID (AWS/GCP/Azure)
 [**--azure-audience**=<name>] [**--azure-subscription-id**=<id>]
 [**--azure-object-id**=<id>] [**--instance-age**=<duration>]
 [**--disable-custom-sans**] [**--disable-trust-on-first-use**]
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
+[**--admin-cert**=<file>] [**--admin-key**=<file>] 
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
 
 SCEP
 
 **step ca provisioner update** <name> [**--force-cn**] [**--challenge**=<challenge>]
 [**--capabilities**=<capabilities>] [**--include-root**] [**--minimum-public-key-length**=<length>]
-[**--encryption-algorithm-identifier**=<id>] [**--admin-cert**=<file>] [**--admin-key**=<file>]
-[**--admin-provisioner**=<name>] [**--admin-subject**=<subject>] [**--password-file**=<file>]
-[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]
-`,
+[**--encryption-algorithm-identifier**=<id>][**--admin-cert**=<file>] [**--admin-key**=<file>] 
+[**--admin-subject**=<subject>] [**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]`,
 		Flags: []cli.Flag{
 			nameFlag,
 			pubKeyFlag,
@@ -172,8 +171,9 @@ SCEP
 
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFileNoAlias,
 			flags.PasswordFile,
 			flags.CaURL,
 			flags.Root,

--- a/command/ca/provisioner/webhook/add.go
+++ b/command/ca/provisioner/webhook/add.go
@@ -78,8 +78,8 @@ step ca provisioner webhook add my_provisioner my_webhook --url https://example.
 Create a webhook that will only be called when signing x509 certificates:
 '''
 step ca provisioner webhook add my_provisioner my_webhook --url https://example.com --cert-type X509
-'''
-`}
+'''`,
+	}
 }
 
 func addAction(ctx *cli.Context) (err error) {

--- a/command/ca/provisioner/webhook/add.go
+++ b/command/ca/provisioner/webhook/add.go
@@ -19,9 +19,9 @@ func addCommand() cli.Command {
 [**--url**=<url>] [**--kind**=<kind>] [**--bearer-token-file**=<filename>]
 [**--basic-auth-username**=<username>] [**--basic-auth-password-file**=<filename>]
 [**--disable-tls-client-auth**] [**--cert-type**=<cert-type>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]`,
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]`,
 		Flags: []cli.Flag{
 			urlFlag,
 			kindFlag,
@@ -33,9 +33,9 @@ func addCommand() cli.Command {
 
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/provisioner/webhook/remove.go
+++ b/command/ca/provisioner/webhook/remove.go
@@ -12,15 +12,15 @@ func removeCommand() cli.Command {
 		Action: cli.ActionFunc(removeAction),
 		Usage:  "remove a webhook from a provisioner",
 		UsageText: `**step ca provisioner webhook remove** <provisioner_name> <webhook_name>
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]`,
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]`,
 		Flags: []cli.Flag{
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/provisioner/webhook/update.go
+++ b/command/ca/provisioner/webhook/update.go
@@ -21,9 +21,9 @@ func updateCommand() cli.Command {
 [**--url**=<url>] [**--kind**=<kind>] [**--bearer-token-file**=<filename>]
 [**--basic-auth-username**=<username>] [**--basic-auth-password-file**=<filename>]
 [**--disable-tls-client-auth**] [**--cert-type**=<cert-type>]
-[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-provisioner**=<name>]
-[**--admin-subject**=<subject>] [**--password-file**=<file>] [**--ca-url**=<uri>]
-[**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]`,
+[**--admin-cert**=<file>] [**--admin-key**=<file>] [**--admin-subject**=<subject>]
+[**--admin-provisioner**=<name>] [**--admin-password-file**=<file>]
+[**--ca-url**=<uri>] [**--root**=<file>] [**--context**=<name>] [**--ca-config**=<file>]`,
 		Flags: []cli.Flag{
 			// General webhook flags
 			urlFlag,
@@ -36,9 +36,9 @@ func updateCommand() cli.Command {
 
 			flags.AdminCert,
 			flags.AdminKey,
-			flags.AdminProvisioner,
 			flags.AdminSubject,
-			flags.PasswordFile,
+			flags.AdminProvisioner,
+			flags.AdminPasswordFile,
 			flags.CaURL,
 			flags.Root,
 			flags.Context,

--- a/command/ca/provisioner/webhook/update.go
+++ b/command/ca/provisioner/webhook/update.go
@@ -74,8 +74,7 @@ step ca provisioner webhook update my_provisioner my_webhook --basic-auth-passwo
 Configure the webhook to be called only when signing x509 certificates, not SSH certificates:
 '''
 step ca provisioner webhook update my_provisioner my_webhook --cert-type X509
-'''
-`,
+'''`,
 	}
 }
 

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -172,6 +172,22 @@ as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms"
 		Usage: "The admin <subject> to use for generating admin credentials.",
 	}
 
+	// AdminPasswordFileWithAlias is a cli.Flag used to pass the password to use
+	// when generating admin credentials.
+	AdminPasswordFile = cli.StringFlag{
+		Name: "admin-password-file,password-file",
+		Usage: `The path to the <file> containing the password to decrypt the one-time token
+generating key.`,
+	}
+
+	// AdminPasswordFileNoAlias is a cli.Flag used to pass the password to use
+	// when generating admin credentials.
+	AdminPasswordFileNoAlias = cli.StringFlag{
+		Name: "admin-password-file",
+		Usage: `The path to the <file> containing the password to decrypt the one-time token
+generating key.`,
+	}
+
 	// ProvisionerPasswordFile is a cli.Flag used to pass the password file to
 	// decrypt the generating key.
 	ProvisionerPasswordFile = cli.StringFlag{

--- a/utils/cautils/token_generator.go
+++ b/utils/cautils/token_generator.go
@@ -320,6 +320,8 @@ func getProvisionerPasswordOption(ctx *cli.Context) jose.Option {
 	switch {
 	case ctx.String("provisioner-password-file") != "":
 		return jose.WithPasswordFile(ctx.String("provisioner-password-file"))
+	case ctx.String("admin-password-file") != "":
+		return jose.WithPasswordFile(ctx.String("admin-password-file"))
 	case ctx.String("password-file") != "":
 		return jose.WithPasswordFile(ctx.String("password-file"))
 	default:
@@ -331,6 +333,8 @@ func getProvisionerPasswordPEMOption(ctx *cli.Context) pemutil.Options {
 	switch {
 	case ctx.String("provisioner-password-file") != "":
 		return pemutil.WithPasswordFile(ctx.String("provisioner-password-file"))
+	case ctx.String("admin-password-file") != "":
+		return pemutil.WithPasswordFile(ctx.String("admin-password-file"))
 	case ctx.String("password-file") != "":
 		return pemutil.WithPasswordFile(ctx.String("password-file"))
 	default:


### PR DESCRIPTION
### Description

On commands like "step ca provisioner add", the "--password-file" flag was used with two different purposes, to encrypt a new JWK key and to decrypt the admin JWK key. This change adds an extra flag --admin-password-file to make this different.

Fixes #744