### PR TITLE
Fix OIDC login flow when using proxycommand

### DIFF
--- a/command/ssh/proxycommand.go
+++ b/command/ssh/proxycommand.go
@@ -151,6 +151,8 @@ func doLoginIfNeeded(ctx *cli.Context, subject string) error {
 	// the application of an Identity function.
 	if email, ok := tokenEmail(token); ok {
 		subject = email
+		// NOTE: In case of OIDC replace principals to not trigger an error on CA side.
+		principals = []string{subject}
 	}
 
 	caClient, err := flow.GetClient(ctx, token)


### PR DESCRIPTION
#### Pain or issue this feature alleviates:
Allows to run `ssh host` when using OIDC SSO with a different ssh username from the one in OIDC token subject.

This is an issue because Step CA checks if the principal, which in this case is the username, is in the list of principals from SSO token. But CA at that point in time looks only at the subject (not the groups which are added only later from the template) which is the e-mail address and it's variants `(user.name@email.com, user.name, username)`


It is an issue because of this check on CA side: https://github.com/smallstep/certificates/blame/65090daac3d74dd9963206cbfcaf2643f57a8957/authority/provisioner/sign_ssh_options.go#L116

And even if CA did look for the username in principals list, the principals list is not supposed to contain usernames. Principals should contain whatever groups have been set up for that user and they are checked against principals list/command on the ssh server.

This allows to pass the CA check. This allows to use any usernames. SSH server is supposed to check the principals list, not CA.

#### Why is this important to the project (if not answered above):
Without a working OIDC login flow for ssh commands using **any usernames** Smallstep becomes inconvenient to use.

#### Supporting links/other PRs/issues:
After fixing this issue, there is also https://github.com/smallstep/certificates/issues/1194 to fix, which is not related to this issue, but it essentially blocks the same login flow.
