### PR TITLE
Only restart services which are actually running

### DIFF
--- a/systemd/cert-renewer@.service
+++ b/systemd/cert-renewer@.service
@@ -24,7 +24,7 @@ ExecStart=/usr/bin/step ca renew --force ${CERT_LOCATION} ${KEY_LOCATION}
 ; Try to reload or restart the systemd service that relies on this cert-renewer
 ; If the relying service doesn't exist, forge ahead.
 ; (In systemd <229, use `reload-or-try-restart` instead of `try-reload-or-restart`)
-ExecStartPost=/usr/bin/env sh -c "! systemctl --quiet is-enabled %i.service || systemctl try-reload-or-restart %i"
+ExecStartPost=/usr/bin/env sh -c "! systemctl --quiet is-active %i.service || systemctl try-reload-or-restart %i"
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/ssh-cert-renewer.service
+++ b/systemd/ssh-cert-renewer.service
@@ -27,7 +27,7 @@ ExecStart=/usr/bin/step ssh renew --force ${CERT_LOCATION} ${KEY_LOCATION}
 ; (In systemd <229, use `reload-or-try-restart` instead of `try-reload-or-restart`)
 ; 
 ; NOTE: Some systems use sshd.service; others use ssh.service. Change this as needed:
-ExecStartPost=/usr/bin/env sh -c "! systemctl --quiet is-enabled sshd.service || systemctl try-reload-or-restart sshd"
+ExecStartPost=/usr/bin/env sh -c "! systemctl --quiet is-active sshd.service || systemctl try-reload-or-restart sshd"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
#### Name of feature:

Only restart services which are actually running

#### Pain or issue this feature alleviates:

A service might be enabled by default but not currently running. With the old code we would restart it in this case. is-active only touches currently running services.

#### In what environments or workflows is this feature supported?

systemd
