### PR TITLE
Update create.go

### DIFF
--- a/command/certificate/create.go
+++ b/command/certificate/create.go
@@ -385,7 +385,7 @@ $ step certificate create \
 			flags.TemplateSetFile,
 			cli.StringFlag{
 				Name: "password-file",
-				Usage: `The <file> to the file containing the password to
+				Usage: `The path to the <file> containing the password to
 encrypt the new private key or decrypt the user submitted private key.`,
 			},
 			cli.StringFlag{
@@ -398,7 +398,7 @@ encrypt the new private key or decrypt the user submitted private key.`,
 			},
 			cli.StringFlag{
 				Name: "ca-password-file",
-				Usage: `The <file> to the file containing the password to
+				Usage: `The path to the <file> containing the password to
 decrypt the CA private key.`,
 			},
 			cli.StringFlag{


### PR DESCRIPTION
Corrected wording in help texts for "password-file" and "ca-password-file" command line parameters.

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature: Corrected wording

#### Pain or issue this feature alleviates: Incorrect wording

#### Why is this important to the project (if not answered above): Spelling is important

#### Is there documentation on how to use this feature? If so, where? N/A

#### In what environments or workflows is this feature supported? N/A

#### In what environments or workflows is this feature explicitly NOT supported (if any)? N/A

#### Supporting links/other PRs/issues: N/A

💔Thank you!
