### PR TITLE
Update init.go adding dnsValue Validation at interactive prompt

### DIFF
--- a/command/ca/init.go
+++ b/command/ca/init.go
@@ -525,6 +525,7 @@ func initAction(ctx *cli.Context) (err error) {
 		ui.Println("What DNS names or IP addresses would you like to add to your new CA?",
 			ui.WithSliceValue(ctx.StringSlice("dns")))
 		dnsValue, err := ui.Prompt("(e.g. ca.smallstep.com[,1.1.1.1,etc.])",
+			ui.WithValidateFunc(ui.DNS()),
 			ui.WithSliceValue(ctx.StringSlice("dns")))
 		if err != nil {
 			return err

--- a/command/ca/init_test.go
+++ b/command/ca/init_test.go
@@ -7,6 +7,78 @@ import (
 	_ "go.step.sm/crypto/kms/azurekms"
 )
 
+func TestDNSListValidate(t *testing.T) {
+	tests := []struct {
+		name     string
+		dnsValue string
+		wantErr  bool
+	}{
+		{
+			name:     "dns can't start with -",
+			dnsValue: "-ca.smallstep.com",
+			wantErr:  true,
+		},
+		{
+			name:     "dns can't contain spaces",
+			dnsValue: "ca.small step.com",
+			wantErr:  true,
+		},
+		{
+			name:     "dns label can't be over 63 octects long",
+			dnsValue: "ca.s0000000m0000000000a0000000000000000000000000000000000000l000000000l0000000000.com",
+			wantErr:  true,
+		},
+
+		{
+			name:     "dns can't be over 255 octets long",
+			dnsValue: "1123456789012345678901233456789012345678901234567834567890123456789012345678345678901234567890123456783456789012345678901234567845678901234567890123456789012345678901234567890123456789012345678901234567890234567890.smalls345678901234567890123456783456789012345678901234567834567890123456789012345678tep.com",
+			wantErr:  true,
+		},
+
+		{
+			name:     "dns can't end with -",
+			dnsValue: "ca.smallstep-.com",
+			wantErr:  true,
+		},
+		{
+			name:     "dns can't contain _",
+			dnsValue: "c_a.smallstep.com",
+			wantErr:  true,
+		},
+
+		{
+			name:     "an element is empty at the end",
+			dnsValue: "elem,",
+			wantErr:  true,
+		},
+		{
+			name:     "an element is empty at the begining",
+			dnsValue: "elem,",
+			wantErr:  true,
+		},
+		{
+			name:     "an element is empty in the middle",
+			dnsValue: "elem,,elem",
+			wantErr:  true,
+		},
+		{
+			name:     "dns OK",
+			dnsValue: "ca.smallstep.com",
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := DNSListValidate()(tt.dnsValue)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DNSListValidate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+
+}
+
 func Test_processDNSValue(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
dnsValue validation to prevent panic when it is empty

#### Pain or issue this feature alleviates:
currently when calling _step ca init_   it accept empty string for dnsValue causing panic later

```
Ô×£  certificates git:(master) STEPDEBUG=1 step ca init
Ô£ö Deployment Type: Standalone
What would you like to name your new PKI?
Ô£ö (e.g. Smallstep): SmallStep
What DNS names or IP addresses would you like to add to your new CA?     
Ô£ö (e.g. ca.smallstep.com[,1.1.1.1,etc.]):    <- leave it empty
What IP and port will your new CA bind to?
Ô£ö (e.g. :443 or 127.0.0.1:443): :8443
What would you like to name the CA's first provisioner?
Ô£ö (e.g. you@smallstep.com): you@smallstep.com
Choose a password for your CA keys and first provisioner.
Smallstep CLI/0.21.0 (linux/amd64)
Release Date: 2022-07-06T22:23:54Z

panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
main.panicHandler()
        ./main.go:139 +0x245
panic({0x12dec00, 0xc00003e1c8})
        runtime/panic.go:838 +0x207
github.com/smallstep/certificates/pki.New({{0x137b07c, 0x7}, {0x0, 0x0}, {0x0, 0x0}, 0x0, {0x0, 0x0}, {0x0, ...}, ...}, ...)
        github.com/smallstep/certificates@v0.21.0/pki/pki.go:382 +0xfe5
github.com/smallstep/cli/command/ca.initAction(0xc00055c2c0)
        github.com/smallstep/cli/command/ca/init.go:563 +0x3419
github.com/urfave/cli.HandleAction({0x11bec80?, 0x1467900?}, 0x4?)
        github.com/urfave/cli@v1.22.5/app.go:522 +0x7f
github.com/urfave/cli.Command.Run({{0x1372454, 0x4}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x13a51fc, 0x15}, {0x14122b5, ...}, ...}, ...)
        github.com/urfave/cli@v1.22.5/command.go:173 +0x652
github.com/urfave/cli.(*App).RunAsSubcommand(0xc0006ed880, 0xc00055c000)
        github.com/urfave/cli@v1.22.5/app.go:405 +0x91b
github.com/urfave/cli.Command.startApp({{0x137001e, 0x2}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x13d6304, 0x2d}, {0x13eff37, ...}, ...}, ...)
        github.com/urfave/cli@v1.22.5/command.go:372 +0x6e7
github.com/urfave/cli.Command.Run({{0x137001e, 0x2}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x13d6304, 0x2d}, {0x13eff37, ...}, ...}, ...)
        github.com/urfave/cli@v1.22.5/command.go:102 +0x808
github.com/urfave/cli.(*App).Run(0xc0006ed6c0, {0xc00003a180, 0x3, 0x3})
        github.com/urfave/cli@v1.22.5/app.go:277 +0x8a7
main.main()
        ./main.go:113 +0x611

```

#### Why is this important to the project (if not answered above):
I believe it will prevent code panics on that particular scenario.

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
