### PR TITLE
Add scope token response param

### DIFF
--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -70,6 +70,7 @@ type token struct {
 	TokenType    string `json:"token_type"`
 	Err          string `json:"error,omitempty"`
 	ErrDesc      string `json:"error_description,omitempty"`
+	Scope        string `json:"scope,omitempty"`
 }
 
 func init() {
@@ -1075,7 +1076,7 @@ func (o *oauth) DoJWTAuthorization(issuer, aud string) (*token, error) {
 		return nil, errors.Wrapf(err, "error serializing JWT")
 	}
 
-	tok := &token{raw, "", "", 3600, "Bearer", "", ""}
+	tok := &token{raw, "", "", 3600, "Bearer", "", "", ""}
 	return tok, nil
 }
 


### PR DESCRIPTION
The OAuth2.0 spec (https://www.rfc-editor.org/rfc/rfc6749#section-5.1) dictates that there should/could be a `scope` parameter in responses from calls to the `/token` endpoint. Including this in the cli output is useful for debugging access tokens etc.

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature: 
Include `scope` response param in output

#### Pain or issue this feature alleviates: 
Helps when debugging/validating access tokens from various OAuth providers

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
