### PR TITLE
Fix `goimports` error in GitHub actions

### DIFF
--- a/command/ca/init.go
+++ b/command/ca/init.go
@@ -566,7 +566,7 @@ func initAction(ctx *cli.Context) (err error) {
 		if helm {
 			ui.Println("What IP and port will your new CA bind to (it should match service.targetPort)?", ui.WithValue(ctx.String("address")))
 		} else {
-            ui.Println("What IP and port will your new CA bind to? (:443 will bind to 0.0.0.0:443)", ui.WithValue(ctx.String("address")))
+			ui.Println("What IP and port will your new CA bind to? (:443 will bind to 0.0.0.0:443)", ui.WithValue(ctx.String("address")))
 		}
 		address, err = ui.Prompt("(e.g. :443 or 127.0.0.1:443)",
 			ui.WithValidateFunc(ui.Address()), ui.WithValue(ctx.String("address")))


### PR DESCRIPTION
Noticed some issues running actions for https://github.com/smallstep/cli/pull/837. Some file wasn't formatted properly and resulted in the [following output](https://github.com/smallstep/cli/actions/runs/4055757550/jobs/6979640264) on GitHub Actions:

```
 Running [/home/runner/golangci-lint-1.50.1-linux-amd64/golangci-lint run --out-format=github-actions --timeout=30m] in [] ...
  Error: File is not `goimports`-ed (goimports)
```

But no further info on what file it was about.

File might've been in the Actions cache, as I hadn't pulled latest `master` yet. 