### PR TITLE
Ignore rand.Seed deprecation.

### DIFF
--- a/cmd/step/main.go
+++ b/cmd/step/main.go
@@ -53,6 +53,7 @@ var BuildTime = "N/A"
 func init() {
 	step.Set("Smallstep CLI", Version, BuildTime)
 	ca.UserAgent = step.Version()
+	//nolint:staticcheck // deprecated in Go 1.20 - leaving because we support latest 2 versions of golang
 	rand.Seed(time.Now().UnixNano())
 }
 


### PR DESCRIPTION
- we still compile and test with go 1.19 so we won't remove the newly deprecated code yet.

