### PR TITLE
Add a debian:bullseye base image

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -18,8 +18,7 @@ RUN apt-get update \
         && apt-get upgrade \
         && apt-get install -y --no-install-recommends curl \
         && addgroup --gid ${STEPGID} step \
-        && adduser --disabled-password --uid ${STEPUID} --gid ${STEPGID} step \
-        && chown step:step /home/step
+        && adduser --disabled-password --uid ${STEPUID} --gid ${STEPGID} step
 
 
 COPY --from=builder /src/bin/step "/usr/local/bin/step"

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,0 +1,32 @@
+FROM golang AS builder
+
+RUN mkdir /src
+ADD . /src
+
+RUN cd /src && \
+	mkdir -p output/bin && \
+	make V=1 bin/step
+
+FROM debian:bullseye
+
+ENV STEP="/home/step"
+ENV STEPPATH="/home/step"
+ARG STEPUID=1000
+ARG STEPGID=1000
+
+RUN apt-get update \
+        && apt-get upgrade \
+        && apt-get install -y --no-install-recommends bash curl tzdata \
+        && addgroup --gid ${STEPGID} step \
+        && adduser --disabled-password --uid ${STEPUID} --gid ${STEPGID} step \
+        && chown step:step /home/step
+
+
+COPY --from=builder /src/bin/step "/usr/local/bin/step"
+
+USER step
+WORKDIR /home/step
+
+STOPSIGNAL SIGTERM
+
+CMD /bin/bash

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -16,7 +16,7 @@ ARG STEPGID=1000
 
 RUN apt-get update \
         && apt-get upgrade \
-        && apt-get install -y --no-install-recommends bash curl tzdata \
+        && apt-get install -y --no-install-recommends curl \
         && addgroup --gid ${STEPGID} step \
         && adduser --disabled-password --uid ${STEPUID} --gid ${STEPGID} step \
         && chown step:step /home/step


### PR DESCRIPTION
Related to smallstep/certificates#1286

- [ ] build this image as part of the release process
- [ ] tag it with `:bullseye` in Docker Hub