### PR TITLE
Add support for alternate issuers for Azure tokens

### DIFF
--- a/token/parse.go
+++ b/token/parse.go
@@ -171,7 +171,10 @@ func parseResponse(jwt *jose.JSONWebToken, p Payload) (*JSONWebToken, error) {
 		if err := json.Unmarshal(p.Amazon.Document, &p.Amazon.InstanceIdentityDocument); err != nil {
 			return nil, errors.Wrap(err, "error unmarshaling instance identity document")
 		}
-	case strings.HasPrefix(p.Issuer, "https://sts.windows.net/"):
+	case strings.HasPrefix(p.Issuer, "https://sts.windows.net/"),
+		strings.HasPrefix(p.Issuer, "https://sts.chinacloudapi.cn/"),
+		strings.HasPrefix(p.Issuer, "https://sts.microsoftazure.de/"),
+		strings.HasPrefix(p.Issuer, "https://sts.usgovcloudapi.net/"):
 		if re := azureXMSMirIDRegExp.FindStringSubmatch(p.XMSMirID); len(re) > 0 {
 			p.Azure = &AzurePayload{
 				SubscriptionID: re[1],

--- a/token/parse.go
+++ b/token/parse.go
@@ -171,10 +171,7 @@ func parseResponse(jwt *jose.JSONWebToken, p Payload) (*JSONWebToken, error) {
 		if err := json.Unmarshal(p.Amazon.Document, &p.Amazon.InstanceIdentityDocument); err != nil {
 			return nil, errors.Wrap(err, "error unmarshaling instance identity document")
 		}
-	case strings.HasPrefix(p.Issuer, "https://sts.windows.net/"),
-		strings.HasPrefix(p.Issuer, "https://sts.chinacloudapi.cn/"),
-		strings.HasPrefix(p.Issuer, "https://sts.microsoftazure.de/"),
-		strings.HasPrefix(p.Issuer, "https://sts.usgovcloudapi.net/"):
+	case isAzurePayload(p):
 		if re := azureXMSMirIDRegExp.FindStringSubmatch(p.XMSMirID); len(re) > 0 {
 			p.Azure = &AzurePayload{
 				SubscriptionID: re[1],
@@ -189,4 +186,21 @@ func parseResponse(jwt *jose.JSONWebToken, p Payload) (*JSONWebToken, error) {
 		JSONWebToken: jwt,
 		Payload:      p,
 	}, nil
+}
+
+func isAzurePayload(p Payload) bool {
+	azureTokenIssuerPrefixes := []string{
+		"https://sts.windows.net",
+		"https://login.microsoftonline.com",
+		"https://login.microsoftonline.us",
+		"https://sts.chinacloudapi.cn",
+		"https://login.partner.microsoftonline.cn",
+	}
+
+	for _, prefix := range azureTokenIssuerPrefixes {
+		if strings.HasPrefix(p.Issuer, prefix) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
To be complete, this feature would require a go.mod bump for github.com/smallstep/certificates once the linked PR is merged and released.

#### Name of feature: 
Add all knowns Azure issuers for IMDS token

#### Pain or issue this feature alleviates:
When step is running on an Azure virtual machine in an Azure cloud different from "Public", the issuer is set to a different URL. This PR adds support for Public, China, Germany and US Gov clouds (waiting on a confirmation from Azure for US Gov and Germany URL)

#### Why is this important to the project (if not answered above):
Provides greater support for more environment.

#### Is there documentation on how to use this feature? If so, where?
No as there is no external configuration change needed for this feature

#### In what environments or workflows is this feature supported?
No as there is no external configuration change needed for this feature

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:
https://github.com/smallstep/certificates/pull/1309

