### PR TITLE
Add --service for running as a windows service for renewal and rekeying

### DIFF
--- a/command/ca/renew.go
+++ b/command/ca/renew.go
@@ -200,6 +200,13 @@ periodically. By default the daemon will renew a certificate before 2/3 of the
 time to expiration has elapsed. The period can be configured using the
 **--renew-period** or **--expires-in** flags.`,
 			},
+			cli.BoolFlag{
+				Name: "service",
+				Usage: `Run the renew command as a windows service, renewing and overwriting the certificate
+periodically. By default the service will renew a certificate before 2/3 of the
+time to expiration has elapsed. The period can be configured using the
+**--renew-period** or **--expires-in** flags. You must install this as a service first using **sc.exe create step-renew binPath= "path_to_step_cli.exe ca renew --service --ca-url=your_ca_url --root=path_to_root_ca.crt other_arguments"** `,
+			},
 			cli.StringFlag{
 				Name: "renew-period",
 				Usage: `The period with which to schedule renewals of the certificate in daemon mode.
@@ -225,6 +232,7 @@ func renewCertificateAction(ctx *cli.Context) error {
 	keyFile := args.Get(1)
 	passFile := ctx.String("password-file")
 	isDaemon := ctx.Bool("daemon")
+	isService := ctx.Bool("service")
 	execCmd := ctx.String("exec")
 
 	outFile := ctx.String("out")
@@ -256,7 +264,7 @@ func renewCertificateAction(ctx *cli.Context) error {
 	if expiresIn > 0 && renewPeriod > 0 {
 		return errs.IncompatibleFlagWithFlag(ctx, "expires-in", "renew-period")
 	}
-	if renewPeriod > 0 && !isDaemon {
+	if renewPeriod > 0 && !isDaemon && !isService {
 		return errs.RequiredWithFlag(ctx, "renew-period", "daemon")
 	}
 
@@ -314,6 +322,13 @@ func renewCertificateAction(ctx *cli.Context) error {
 		ctx.Set("force", "true")
 		next := nextRenewDuration(cert.Leaf, expiresIn, renewPeriod)
 		return renewer.Daemon(outFile, next, expiresIn, renewPeriod, afterRenew)
+	}
+
+	if isService {
+		// Force is always enabled when daemon mode is used
+		ctx.Set("force", "true")
+		next := nextRenewDuration(cert.Leaf, expiresIn, renewPeriod)
+		return renewer.Service(outFile, next, expiresIn, renewPeriod, afterRenew)
 	}
 
 	// Do not renew if (cert.notAfter - now) > (expiresIn + jitter)

--- a/command/ca/service.go
+++ b/command/ca/service.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package ca
+
+func (r *renewer) Service(outFile string, next, expiresIn, renewPeriod time.Duration, afterRenew func() error) error {
+	errLog := log.New(os.Stderr, "ERROR: ", log.LstdFlags)
+	errLog.Fatalf("running as a service is only supported on windows, use --daemon instead.")
+}

--- a/command/ca/service_windows.go
+++ b/command/ca/service_windows.go
@@ -1,0 +1,85 @@
+//go:build windows
+
+package ca
+
+import (
+	"fmt"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/eventlog"
+	"log"
+	"os"
+	"time"
+)
+
+type windowsRenewer struct {
+	eLog                         *eventlog.Log
+	next, expiresIn, renewPeriod time.Duration
+	afterRenew                   func() error
+	renewer                      *renewer
+	outFile                      string
+}
+
+func (r *renewer) Service(outFile string, next, expiresIn, renewPeriod time.Duration, afterRenew func() error) error {
+	errLog := log.New(os.Stderr, "ERROR: ", log.LstdFlags)
+	inService, err := svc.IsWindowsService()
+	if err != nil {
+		errLog.Fatalf("failed to determine if we are running in service: %v", err)
+	}
+
+	if !inService {
+		errLog.Fatalf("--service requires running as a service, see step ca renew --help for an example of how to install the service")
+	}
+
+	eventlog.InstallAsEventCreate("step-renew", eventlog.Info|eventlog.Warning|eventlog.Error)
+
+	// Loggers
+	eLog, err := eventlog.Open("step-renew")
+	if err != nil {
+		return err
+	}
+	defer eLog.Close()
+
+	wr := windowsRenewer{
+		eLog:        eLog,
+		next:        next,
+		expiresIn:   expiresIn,
+		renewPeriod: renewPeriod,
+		afterRenew:  afterRenew,
+		renewer:     r,
+		outFile:     outFile,
+	}
+
+	eLog.Info(100, fmt.Sprintf("starting step certificate renewal service. First renewal in %s", next.Round(time.Second)))
+
+	return svc.Run("step-renew", &wr)
+}
+
+func (wr *windowsRenewer) Execute(args []string, cr <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
+	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
+	var err error
+	changes <- svc.Status{State: svc.StartPending}
+
+	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
+loop:
+	for {
+		select {
+		case <-time.After(wr.next):
+			if wr.next, err = wr.renewer.RenewAndPrepareNext(wr.outFile, wr.expiresIn, wr.renewPeriod); err != nil {
+				wr.eLog.Warning(1, err.Error())
+			} else if err := wr.afterRenew(); err != nil {
+				wr.eLog.Warning(1, err.Error())
+			}
+		case c := <-cr:
+			switch c.Cmd {
+			case svc.Interrogate:
+				changes <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				break loop
+			default:
+				wr.eLog.Error(1, fmt.Sprintf("unexpected control request #%d", c))
+			}
+		}
+	}
+	changes <- svc.Status{State: svc.StopPending}
+	return
+}


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Adds a new command line flag `--service` which will run as a Windows Service. Users can install the service by running `sc.exe create step-renew binPath= "path_to_step_cli.exe ca renew --service --ca-url=the_ca_url --root=path_to_root_ca.crt certfile.crt keyfile.key` as an Administrator.

#### Pain or issue this feature alleviates:

Allows renewal via windows service as an alternative to --daemon on windows hosts

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

CLI usage examples have been added

#### In what environments or workflows is this feature supported?

Windows hosts

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

Non-windows hosts (use `--daemon` instead)

#### Supporting links/other PRs/issues:

💔Thank you!
