### PR TITLE
Fix error when using `--insecure` and creating RSA keys <2048 bits

### DIFF
--- a/command/crypto/jwk/create.go
+++ b/command/crypto/jwk/create.go
@@ -15,6 +15,7 @@ import (
 	"go.step.sm/cli-utils/errs"
 	"go.step.sm/cli-utils/ui"
 	"go.step.sm/crypto/jose"
+	"go.step.sm/crypto/keyutil"
 	"go.step.sm/crypto/randutil"
 )
 
@@ -432,8 +433,9 @@ func createAction(ctx *cli.Context) (err error) {
 		}
 		// If size is not set it will use a safe default
 		if ctx.IsSet("size") {
-			if size < 2048 && !ctx.Bool("insecure") {
-				return errs.MinSizeInsecureFlag(ctx, "size", "2048")
+			minimalSize := keyutil.MinRSAKeyBytes * 8
+			if size < minimalSize && !ctx.Bool("insecure") {
+				return errs.MinSizeInsecureFlag(ctx, "size", minimalSize)
 			}
 			if size <= 0 {
 				return errs.MinSizeFlag(ctx, "size", "0")
@@ -450,7 +452,7 @@ func createAction(ctx *cli.Context) (err error) {
 		// If size is not set it will use a safe default
 		if ctx.IsSet("size") {
 			if size < 16 && !ctx.Bool("insecure") {
-				return errs.MinSizeInsecureFlag(ctx, "size", "16")
+				return errs.MinSizeInsecureFlag(ctx, "size", 16)
 			}
 			if size <= 0 {
 				return errs.MinSizeFlag(ctx, "size", "0")

--- a/command/crypto/jwk/create.go
+++ b/command/crypto/jwk/create.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/smallstep/cli/flags"
@@ -435,7 +436,7 @@ func createAction(ctx *cli.Context) (err error) {
 		if ctx.IsSet("size") {
 			minimalSize := keyutil.MinRSAKeyBytes * 8
 			if size < minimalSize && !ctx.Bool("insecure") {
-				return errs.MinSizeInsecureFlag(ctx, "size", minimalSize)
+				return errs.MinSizeInsecureFlag(ctx, "size", strconv.Itoa(minimalSize))
 			}
 			if size <= 0 {
 				return errs.MinSizeFlag(ctx, "size", "0")
@@ -452,7 +453,7 @@ func createAction(ctx *cli.Context) (err error) {
 		// If size is not set it will use a safe default
 		if ctx.IsSet("size") {
 			if size < 16 && !ctx.Bool("insecure") {
-				return errs.MinSizeInsecureFlag(ctx, "size", 16)
+				return errs.MinSizeInsecureFlag(ctx, "size", "16")
 			}
 			if size <= 0 {
 				return errs.MinSizeFlag(ctx, "size", "0")

--- a/utils/cli.go
+++ b/utils/cli.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"strconv"
+
 	"github.com/urfave/cli"
 	"go.step.sm/cli-utils/errs"
 	"go.step.sm/crypto/keyutil"
@@ -32,7 +34,7 @@ func GetKeyDetailsFromCLI(ctx *cli.Context, insecure bool, ktyKey, curveKey, siz
 			}
 			minimalSize := keyutil.MinRSAKeyBytes * 8
 			if size < minimalSize && !insecure {
-				return kty, crv, size, errs.MinSizeInsecureFlag(ctx, sizeKey, minimalSize)
+				return kty, crv, size, errs.MinSizeInsecureFlag(ctx, sizeKey, strconv.Itoa(minimalSize))
 			}
 			if size <= 0 {
 				return kty, crv, size, errs.MinSizeFlag(ctx, sizeKey, "0")

--- a/utils/cli.go
+++ b/utils/cli.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"github.com/urfave/cli"
 	"go.step.sm/cli-utils/errs"
+	"go.step.sm/crypto/keyutil"
 )
 
 // DefaultRSASize sets the default key size for RSA to 2048 bits.
@@ -29,8 +30,9 @@ func GetKeyDetailsFromCLI(ctx *cli.Context, insecure bool, ktyKey, curveKey, siz
 			if ctx.IsSet(curveKey) {
 				return kty, crv, size, errs.IncompatibleFlagValue(ctx, curveKey, ktyKey, kty)
 			}
-			if size < 2048 && !insecure {
-				return kty, crv, size, errs.MinSizeInsecureFlag(ctx, sizeKey, "2048")
+			minimalSize := keyutil.MinRSAKeyBytes * 8
+			if size < minimalSize && !insecure {
+				return kty, crv, size, errs.MinSizeInsecureFlag(ctx, sizeKey, minimalSize)
 			}
 			if size <= 0 {
 				return kty, crv, size, errs.MinSizeFlag(ctx, sizeKey, "0")


### PR DESCRIPTION
Before this commit, the CLI would allow specifying RSA key sizes smaller than 2048 when also setting `--insecure`, but creation of the key would still fail with `the size of the RSA key should be at least 2048 bits`, originating from the `keyutil.generateRSAKey` function.

This commit enables the insecure mode for the `keyutil` package when `--insecure` is provided, allowing short RSA keys to be created.

While there are existing tests for checking (in)compatible CLI flags that involve short RSA keys, the command didn't seem to be actually executed as part of the test. That's part of the reason why this bug wasn't found earlier, I think.
