### PR TITLE
Replace deprecated GoReleaser --rm-dist flag with --clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: 'latest'
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_PAT }}
           RELEASE_DATE: ${{ steps.release_date.outputs.RELEASE_DATE }}


### PR DESCRIPTION
See https://github.com/goreleaser/goreleaser/commit/d18adfb57ee951787536b22b62f2a5ebc511c716 for details
