### PR TITLE
Add a docker image using debian

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_IMAGE: smallstep/step-cli
+      DEBIAN_VERSION: bullseye
     outputs:
       version: ${{ steps.extract-tag.outputs.VERSION }}
       vversion: ${{ steps.extract-tag.outputs.VVERSION }}
       is_prerelease: ${{ steps.is_prerelease.outputs.IS_PRERELEASE }}
       docker_tags: ${{ env.DOCKER_TAGS }}
+      docker_debian_tags: ${{ env.DOCKER_DEBIAN_TAGS }}
     steps:
       - name: Is Pre-release
         id: is_prerelease
@@ -43,10 +45,12 @@ jobs:
           echo "VVERSION=${VVERSION}" >> ${GITHUB_OUTPUT}
           echo "VERSION=${VERSION}" >> ${GITHUB_OUTPUT}
           echo "DOCKER_TAGS=${{ env.DOCKER_IMAGE }}:${VERSION}" >> ${GITHUB_ENV}
+          echo "DOCKER_DEBIAN_TAGS=${{ env.DOCKER_IMAGE }}:${VERSION}-${DEBIAN_VERSION}" >> ${GITHUB_ENV}
       - name: Add Latest Tag
         if: steps.is_prerelease.outputs.IS_PRERELEASE == 'false'
         run: |
           echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},${{ env.DOCKER_IMAGE }}:latest" >> ${GITHUB_ENV}
+          echo "DOCKER_DEBIAN_TAGS=${{ env.DOCKER_DEBIAN_TAGS }},${{ env.DOCKER_IMAGE }}:${DEBIAN_VERSION}" >> ${GITHUB_ENV}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -108,6 +112,20 @@ jobs:
       tags: ${{ needs.create_release.outputs.docker_tags }}
       docker_image: smallstep/step-cli
       docker_file: docker/Dockerfile
+    secrets: inherit
+
+  build_upload_docker_debian:
+    name: Build & Upload Docker Images using Debian
+    needs: create_release
+    permissions:
+      id-token: write
+      contents: write
+    uses: smallstep/workflows/.github/workflows/docker-buildx-push.yml@main
+    with:
+      platforms: linux/amd64,linux/386,linux/arm,linux/arm64
+      tags: ${{ needs.create_release.outputs.docker_debian_tags }}
+      docker_image: smallstep/step-cli
+      docker_file: docker/Dockerfile.debian
     secrets: inherit
 
 # All jobs below this are for full releases (non release candidates e.g. *-rc.*)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_IMAGE: smallstep/step-cli
-      DEBIAN_VERSION: bullseye
+      DEBIAN_TAG: bullseye
     outputs:
       version: ${{ steps.extract-tag.outputs.VERSION }}
       vversion: ${{ steps.extract-tag.outputs.VVERSION }}
       is_prerelease: ${{ steps.is_prerelease.outputs.IS_PRERELEASE }}
       docker_tags: ${{ env.DOCKER_TAGS }}
-      docker_debian_tags: ${{ env.DOCKER_DEBIAN_TAGS }}
+      docker_tags_debian: ${{ env.DOCKER_TAGS_DEBIAN }}
     steps:
       - name: Is Pre-release
         id: is_prerelease
@@ -45,12 +45,12 @@ jobs:
           echo "VVERSION=${VVERSION}" >> ${GITHUB_OUTPUT}
           echo "VERSION=${VERSION}" >> ${GITHUB_OUTPUT}
           echo "DOCKER_TAGS=${{ env.DOCKER_IMAGE }}:${VERSION}" >> ${GITHUB_ENV}
-          echo "DOCKER_DEBIAN_TAGS=${{ env.DOCKER_IMAGE }}:${VERSION}-${DEBIAN_VERSION}" >> ${GITHUB_ENV}
+          echo "DOCKER_TAGS_DEBIAN=${{ env.DOCKER_IMAGE }}:${VERSION}-${DEBIAN_TAG}" >> ${GITHUB_ENV}
       - name: Add Latest Tag
         if: steps.is_prerelease.outputs.IS_PRERELEASE == 'false'
         run: |
           echo "DOCKER_TAGS=${{ env.DOCKER_TAGS }},${{ env.DOCKER_IMAGE }}:latest" >> ${GITHUB_ENV}
-          echo "DOCKER_DEBIAN_TAGS=${{ env.DOCKER_DEBIAN_TAGS }},${{ env.DOCKER_IMAGE }}:${DEBIAN_VERSION}" >> ${GITHUB_ENV}
+          echo "DOCKER_TAGS_DEBIAN=${{ env.DOCKER_TAGS_DEBIAN }},${{ env.DOCKER_IMAGE }}:${DEBIAN_TAG}" >> ${GITHUB_ENV}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -123,7 +123,7 @@ jobs:
     uses: smallstep/workflows/.github/workflows/docker-buildx-push.yml@main
     with:
       platforms: linux/amd64,linux/386,linux/arm,linux/arm64
-      tags: ${{ needs.create_release.outputs.docker_debian_tags }}
+      tags: ${{ needs.create_release.outputs.docker_tags_debian }}
       docker_image: smallstep/step-cli
       docker_file: docker/Dockerfile.debian
     secrets: inherit


### PR DESCRIPTION
### Description

This commit adds a workflow to build a docker image using Debian bullseye. The image format will be like this:
 - smallstep/step-cli:bullseye
 - smallstep/step-cli:0.24.0-bullseye
