### PR TITLE
Add reload support for test command step fileserver

### DIFF
--- a/command/fileserver/fileserver.go
+++ b/command/fileserver/fileserver.go
@@ -1,21 +1,26 @@
 package fileserver
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
+	"strconv"
+	"sync"
+	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/smallstep/cli/utils"
-	"go.step.sm/cli-utils/errs"
-
 	"github.com/urfave/cli"
+
 	"go.step.sm/cli-utils/command"
+	"go.step.sm/cli-utils/errs"
 )
 
 func init() {
@@ -25,9 +30,11 @@ func init() {
 		Action: command.ActionFunc(fileServerAction),
 		Usage:  "start an HTTP(S) server serving the contents of a path",
 		UsageText: `step fileserver <dir>
-[**--address**=<address>] [**--cert**=<file>] [**--key**=<file>] [**--roots**=<file>]`,
-		Description: `**step fileserver** command starts an HTTP(S) server serving the contents of a file
-system.
+[**--address**=<address>] [**--cert**=<file>] [**--key**=<file>] [**--roots**=<file>]
+[**--pidfile**=<file>]`,
+		Description: `**step fileserver** command starts an HTTP(S) server that serves
+the contents of a file system. If the server is running using certificates, sending the
+HUP signal will reload the certificates.
 
 This command is experimental and only intended for test purposes.
 
@@ -74,6 +81,10 @@ $ step fileserver --cert localhost.crt --key localhost.key \
 				Name:  "roots",
 				Usage: "The <file> containing the root certificate(s) that will be used to verify the client certificates.",
 			},
+			cli.StringFlag{
+				Name:  "pidfile",
+				Usage: `The path to the <file> to write the process ID.`,
+			},
 		},
 	}
 	command.Register(cmd)
@@ -111,24 +122,31 @@ func fileServerAction(ctx *cli.Context) error {
 		return errs.RequiredWithFlag(ctx, "key", "cert")
 	}
 
+	var r *tlsRenewer
 	var tlsConfig *tls.Config
-	if roots != "" {
-		b, err := utils.ReadFile(roots)
+	if cert != "" {
+		r, err = newTLSRenewer(cert, key, roots)
 		if err != nil {
 			return err
 		}
-		pool := x509.NewCertPool()
-		pool.AppendCertsFromPEM(b)
 		tlsConfig = &tls.Config{
-			ClientCAs:  pool,
-			ClientAuth: tls.RequireAndVerifyClientCert,
-			MinVersion: tls.VersionTLS12,
+			MinVersion:         tls.VersionTLS12,
+			GetConfigForClient: r.GetConfigForClient,
 		}
+	}
+
+	if pidfile := ctx.String("pidfile"); pidfile != "" {
+		pid := []byte(strconv.Itoa(os.Getpid()) + "\n")
+		//nolint:gosec // 0644 (-rw-r--r--) are common permissions for a pid file
+		if err := os.WriteFile(pidfile, pid, 0644); err != nil {
+			return fmt.Errorf("error writing pidfile: %w", err)
+		}
+		defer os.Remove(pidfile)
 	}
 
 	l, err := net.Listen("tcp", address)
 	if err != nil {
-		return errors.Wrapf(err, "failed to listen on at %s", address)
+		return fmt.Errorf("error listening at %s: %w", address, err)
 	}
 
 	srv := &http.Server{
@@ -136,16 +154,119 @@ func fileServerAction(ctx *cli.Context) error {
 		TLSConfig:         tlsConfig,
 		ReadHeaderTimeout: 15 * time.Second,
 	}
-	if cert != "" && key != "" {
-		fmt.Printf("Serving HTTPS at %s ...\n", l.Addr().String())
-		err = srv.ServeTLS(l, cert, key)
-	} else {
-		fmt.Printf("Serving HTTP at %s...\n", l.Addr().String())
-		err = srv.Serve(l)
-	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		signalHandler(r, srv)
+		wg.Done()
+	}()
+
+	go func() {
+		if cert != "" {
+			log.Printf("serving HTTPS at %s\n", l.Addr().String())
+			err = srv.ServeTLS(l, cert, key)
+		} else {
+			log.Printf("serving HTTP at %s\n", l.Addr().String())
+			err = srv.Serve(l)
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
-		return errors.Wrap(err, "file server failed")
+		return fmt.Errorf("file server failed: %w", err)
 	}
 
 	return nil
+}
+
+func signalHandler(r *tlsRenewer, srv *http.Server) {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	defer signal.Stop(signals)
+
+	for sig := range signals {
+		switch sig {
+		case syscall.SIGHUP:
+			if err := r.Reload(); err != nil {
+				log.Printf("error reloading server: %v", err)
+			}
+		case syscall.SIGINT, syscall.SIGTERM:
+			log.Println("shutting down")
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := srv.Shutdown(ctx); err != nil {
+				log.Printf("error shutting down the server: %v", err)
+			}
+			cancel()
+			return
+		}
+	}
+}
+
+// tlsRenewer implements the tls.Config callback GetConfigForClient that returns
+// the TLS configuration. It will reload the configured files if Reload is
+// called.
+type tlsRenewer struct {
+	certFile  string
+	keyFile   string
+	rootFile  string
+	tlsConfig *tls.Config
+	rw        sync.RWMutex
+}
+
+func newTLSRenewer(certFile, keyFile, rootFile string) (*tlsRenewer, error) {
+	renewer := &tlsRenewer{
+		certFile: certFile,
+		keyFile:  keyFile,
+		rootFile: rootFile,
+	}
+	if err := renewer.Reload(); err != nil {
+		return nil, err
+	}
+	return renewer, nil
+}
+
+func (r *tlsRenewer) Reload() error {
+	if r == nil {
+		return nil
+	}
+
+	log.Printf("reloading TLS configuration")
+	var clientCAs *x509.CertPool
+	var clientAuth tls.ClientAuthType
+	if r.rootFile != "" {
+		b, err := utils.ReadFile(r.rootFile)
+		if err != nil {
+			return err
+		}
+		clientCAs = x509.NewCertPool()
+		clientCAs.AppendCertsFromPEM(b)
+		clientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	cert, err := tls.LoadX509KeyPair(r.certFile, r.keyFile)
+	if err != nil {
+		return err
+	}
+
+	r.rw.Lock()
+	r.tlsConfig = &tls.Config{
+		ClientCAs:  clientCAs,
+		ClientAuth: clientAuth,
+		MinVersion: tls.VersionTLS12,
+		GetCertificate: func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return &cert, nil
+		},
+	}
+	r.rw.Unlock()
+	return nil
+}
+
+func (r *tlsRenewer) GetConfigForClient(*tls.ClientHelloInfo) (*tls.Config, error) {
+	r.rw.RLock()
+	defer r.rw.RUnlock()
+	return r.tlsConfig, nil
 }


### PR DESCRIPTION
### Description

This commit adds the option of reloading the certificates used by the test command `step fileserver`. If the HUP signal is sent to the fileserver and is using certificates, the same file will be reloaded from the disk and used.
