### PR TITLE
Update go.step.sm/crypto with fix for PKCS#8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- Fix encrypted PKCS#8 keys used on `step crypto key format`
+  (smallstep/crypto#216).
+
+## [v0.24.1] - 2022-04-12
+
+### Added
+
+- Cross-compile Debian docker builds to improve release performance
+  (smallstep/cli#911).
+
+### Fixed
+
+- Upgrade certificates version (smallstep/cli#910).
+
 ## [v0.24.0] - 2022-04-12
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/urfave/cli v1.22.12
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
 	go.step.sm/cli-utils v0.7.5
-	go.step.sm/crypto v0.29.2
+	go.step.sm/crypto v0.29.3
 	go.step.sm/linkedca v0.19.0
 	golang.org/x/crypto v0.8.0
 	golang.org/x/sys v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1029,8 +1029,8 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.step.sm/cli-utils v0.7.5 h1:jyp6X8k8mN1B0uWJydTid0C++8tQhm2kaaAdXKQQzdk=
 go.step.sm/cli-utils v0.7.5/go.mod h1:taSsY8haLmXoXM3ZkywIyRmVij/4Aj0fQbNTlJvv71I=
 go.step.sm/crypto v0.9.0/go.mod h1:+CYG05Mek1YDqi5WK0ERc6cOpKly2i/a5aZmU1sfGj0=
-go.step.sm/crypto v0.29.2 h1:ERUUkmz1/yKGLjD6XoFEy8gtmZ1IEtf4TSOfT2sUxII=
-go.step.sm/crypto v0.29.2/go.mod h1:0lYeIyQMJbFJ27L4BOGaq2gnuTgOShf+Ju/cTsMULq4=
+go.step.sm/crypto v0.29.3 h1:lFCsFQQGic1VZIa0B/87iMCDy67+LW8eEl119GTyeWI=
+go.step.sm/crypto v0.29.3/go.mod h1:0lYeIyQMJbFJ27L4BOGaq2gnuTgOShf+Ju/cTsMULq4=
 go.step.sm/linkedca v0.19.0 h1:xuagkR35wrJI2gnu6FAM+q3VmjwsHScvGcJsfZ0GdsI=
 go.step.sm/linkedca v0.19.0/go.mod h1:b7vWPrHfYLEOTSUZitFEcztVCpTc+ileIN85CwEAluM=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=


### PR DESCRIPTION
### Description

This commit upgrades the version of go.step.sm/crypto with a fix for encrypting keys using PKCS#8.
