### PR TITLE
cli reference: next.js doesn't like {}'d values in Markdown

### DIFF
--- a/command/ca/provisioner/provisioner.go
+++ b/command/ca/provisioner/provisioner.go
@@ -578,7 +578,7 @@ Use the '--group' flag multiple times to configure multiple groups.`,
 	}
 	oidcTenantIDFlag = cli.StringFlag{
 		Name:  "tenant-id",
-		Usage: `The <tenant-id> used to replace the templatized {tenantid} in the OpenID Configuration.`,
+		Usage: `The <tenant-id> used to replace the templatized tenantid value in the OpenID Configuration.`,
 	}
 
 	// X5C provisioner flags


### PR DESCRIPTION
We only had one instance of this, so instead of making a general fix for this, I just changed the text.
