### PR TITLE
Fix word-wrapping in step api token create example

### DIFF
--- a/command/api/token/create.go
+++ b/command/api/token/create.go
@@ -40,10 +40,11 @@ func createCommand() cli.Command {
 <key-file>
 :  File to read the private key (PEM format).
 
-## Examples
-
+## EXAMPLES
+Use a certificate to get a new API token:
+'''
 $ step api token create ff98be70-7cc3-4df5-a5db-37f5d3c96e23 internal.crt internal.key
-`,
+'''`,
 	}
 }
 


### PR DESCRIPTION
### Description

This PR uses the code block to avoid word-wrapping an example. It also makes the example title uppercase to match the rest of the commands:

Before this fix, the examples block looked like this:
```
Examples
      $ step api token create ff98be70-7cc3-4df5-a5db-37f5d3c96e23 internal.crt
      internal.key
```

With the fix it looks like this:
```
EXAMPLES
      Use a certificate to get a new API token:

          $ step api token create ff98be70-7cc3-4df5-a5db-37f5d3c96e23 internal.crt internal.key
```