### PR TITLE
Add audience flag to api token create

### DIFF
--- a/command/api/token/create.go
+++ b/command/api/token/create.go
@@ -22,10 +22,11 @@ func createCommand() cli.Command {
 		Action: cli.ActionFunc(createAction),
 		Usage:  "create a new token",
 		UsageText: `**step api token create** <team-id> <crt-file> <key-file>
-[**--api-url**=<url>]
+[**--api-url**=<url>] [**--audience**=<name>]
 `,
 		Flags: []cli.Flag{
 			apiURLFlag,
+			audienceFlag,
 		},
 		Description: `**step ca api token create** creates a new token for connecting to the Smallstep API.
 
@@ -49,8 +50,9 @@ $ step api token create ff98be70-7cc3-4df5-a5db-37f5d3c96e23 internal.crt intern
 }
 
 type createTokenReq struct {
-	TeamID string   `json:"teamID"`
-	Bundle [][]byte `json:"bundle"`
+	TeamID   string   `json:"teamID"`
+	Bundle   [][]byte `json:"bundle"`
+	Audience string   `json:"audience,omitempty"`
 }
 
 type createTokenResp struct {
@@ -86,8 +88,9 @@ func createAction(ctx *cli.Context) (err error) {
 	}
 	b := &bytes.Buffer{}
 	r := &createTokenReq{
-		TeamID: teamID,
-		Bundle: clientCert.Certificate,
+		TeamID:   teamID,
+		Bundle:   clientCert.Certificate,
+		Audience: ctx.String("audience"),
 	}
 	err = json.NewEncoder(b).Encode(r)
 	if err != nil {

--- a/command/api/token/token.go
+++ b/command/api/token/token.go
@@ -26,4 +26,8 @@ var (
 		Usage: "URL where the Smallstep API can be found",
 		Value: "https://gateway.smallstep.com",
 	}
+	audienceFlag = cli.StringFlag{
+		Name:  "audience",
+		Usage: "Request a token for an audience other than the API Gateway",
+	}
 )


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
--audience flag for step api token create

#### Pain or issue this feature alleviates:
Allows tokens to be issued for audiences besides the API gateway

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
