### PR TITLE
Pass key to be signed as signer for the CSR instead of signing key

### DIFF
--- a/command/certificate/create.go
+++ b/command/certificate/create.go
@@ -635,7 +635,7 @@ func createAction(ctx *cli.Context) error {
 	}
 
 	// Create X.509 certificate used as base for the certificate
-	cr, err := x509util.CreateCertificateRequest(subject, sans, signer)
+	cr, err := x509util.CreateCertificateRequest(subject, sans, priv)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Quick bug fix for the CSR signer.

Note: this builds on top of the `--ca-kms` changes.