### PR TITLE
[action] Move goreleaser workflow into shared workflows library

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,42 +63,12 @@ jobs:
           prerelease: ${{ steps.is_prerelease.outputs.IS_PRERELEASE }}
 
   goreleaser:
-    name: Upload Assets to GitHub w/ goreleaser
-    runs-on: ubuntu-latest
     needs: create_release
     permissions:
       id-token: write
       contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-          check-latest: true
-      - name: Configure Go
-        id: configure_go
-        run: |
-          PATH=$PATH:/usr/local/go/bin:/home/admin/go/bin
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v2
-        with:
-          cosign-release: 'v1.13.1'
-      - name: Get Release Date
-        id: release_date
-        run: |
-          RELEASE_DATE=$(date +"%y-%m-%d")
-          echo "RELEASE_DATE=${RELEASE_DATE}" >> ${GITHUB_OUTPUT}
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          version: 'latest'
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_PAT }}
-          RELEASE_DATE: ${{ steps.release_date.outputs.RELEASE_DATE }}
-          COSIGN_EXPERIMENTAL: 1
+    uses: smallstep/workflows/.github/workflows/goreleaser.yml@max/goreleaser
+    secrets: inherit
 
   build_upload_docker:
     name: Build & Upload Docker Images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: smallstep/workflows/.github/workflows/goreleaser.yml@max/goreleaser
+    uses: smallstep/workflows/.github/workflows/goreleaser.yml@main
     secrets: inherit
 
   build_upload_docker:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -227,7 +227,9 @@ release:
   #  - glob: ./glob/**/to/**/file/**/*
   #  - glob: ./glob/foo/to/bar/file/foobar/override_from_previous
 
-scoop:
+scoops:
+-
+  name: cli
   # Template for the url which is determined by the given Token (github or gitlab)
   # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   # Default for gitlab is "https://gitlab.com/<repo_owner>/<repo_name>/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"


### PR DESCRIPTION
- The name `scoop` has been deprecated. Switch to `scoops`.