### PR TITLE
Add unversioned release artifacts to build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -235,41 +235,42 @@ release:
   #  - glob: ./glob/**/to/**/file/**/*
   #  - glob: ./glob/foo/to/bar/file/foobar/override_from_previous
 
-scoop:
-  # Template for the url which is determined by the given Token (github or gitlab)
-  # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-  # Default for gitlab is "https://gitlab.com/<repo_owner>/<repo_name>/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"
-  # Default for gitea is "https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-  url_template: "http://github.com/smallstep/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+scoops:
+  -
+    # Template for the url which is determined by the given Token (github or gitlab)
+    # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    # Default for gitlab is "https://gitlab.com/<repo_owner>/<repo_name>/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"
+    # Default for gitea is "https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "http://github.com/smallstep/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
-  # Repository to push the app manifest to.
-  bucket:
-    owner: smallstep
-    name: scoop-bucket
+    # Repository to push the app manifest to.
+    bucket:
+      owner: smallstep
+      name: scoop-bucket
 
-  # Git author used to commit to the repository.
-  # Defaults are shown.
-  commit_author:
-    name: goreleaserbot
-    email: goreleaser@smallstep.com
+    # Git author used to commit to the repository.
+    # Defaults are shown.
+    commit_author:
+      name: goreleaserbot
+      email: goreleaser@smallstep.com
 
-  # The project name and current git tag are used in the format string.
-  commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
+    # The project name and current git tag are used in the format string.
+    commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
 
-  # Your app's homepage.
-  # Default is empty.
-  homepage: "https://smallstep.com/"
+    # Your app's homepage.
+    # Default is empty.
+    homepage: "https://smallstep.com/"
 
-  # Skip uploads for prerelease.
-  skip_upload: auto
+    # Skip uploads for prerelease.
+    skip_upload: auto
 
-  # Your app's description.
-  # Default is empty.
-  description: "Crypto toolkit for working with X.509, OAuth, JWT, OATH OTP, etc."
+    # Your app's description.
+    # Default is empty.
+    description: "Crypto toolkit for working with X.509, OAuth, JWT, OATH OTP, etc."
 
-  # Your app's license
-  # Default is empty.
-  license: "Apache-2.0"
+    # Your app's license
+    # Default is empty.
+    license: "Apache-2.0"
 
   #dockers:
   #  - dockerfile: docker/Dockerfile

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -236,7 +236,7 @@ release:
   #  - glob: ./glob/foo/to/bar/file/foobar/override_from_previous
 
 scoops:
-  -
+  - ids: [ default ]
     # Template for the url which is determined by the given Token (github or gitlab)
     # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     # Default for gitlab is "https://gitlab.com/<repo_owner>/<repo_name>/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,7 +55,7 @@ builds:
       - -w -X main.Version={{.Version}} -X main.BuildTime={{.Date}}
 
 archives:
-  -
+  - &ARCHIVE
     # Can be used to change the archive formats for specific GOOSs.
     # Most common use case is to archive as zip on Windows.
     # Default is empty.
@@ -71,6 +71,11 @@ archives:
       - README.md
       - LICENSE
       - autocomplete/*
+  -
+    << : *ARCHIVE
+    id: unversioned
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+
 
 nfpms:
   # Configure nFPM for .deb and .rpm releases
@@ -82,7 +87,7 @@ nfpms:
   # List file contents: dpkg -c dist/step_...deb
   # Package metadata: dpkg --info dist/step_....deb
   #
-  -
+  - &NFPM
     builds:
       - nfpm
     package_name: step-cli
@@ -100,7 +105,6 @@ nfpms:
       - deb
       - rpm
     priority: optional
-
     bindir: /usr/bin
     contents:
       - src: debian/copyright
@@ -113,6 +117,10 @@ nfpms:
     scripts:
       postinstall: scripts/postinstall.sh
       postremove: scripts/postremove.sh
+  -
+    << : *NFPM
+    id: unversioned
+    file_name_template: "{{ .PackageName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
 
 source:
   enabled: true


### PR DESCRIPTION
https://github.com/smallstep/cli/releases/tag/v0.24.2-rc.6

I just want to note that while the filenames of the archives are different, their contents is the same. Including the directory name, which still contains the version number even if the archive name is unversioned:

x step_0.24.2-rc.6/LICENSE
x step_0.24.2-rc.6/README.md
x step_0.24.2-rc.6/autocomplete/README.md
x step_0.24.2-rc.6/autocomplete/bash_autocomplete
x step_0.24.2-rc.6/autocomplete/zsh_autocomplete
x step_0.24.2-rc.6/bin/step

This also adds more files to the assets for each release, which makes that list a little harder to look at.

