### PR TITLE
Create API tokens with team slug

### DIFF
--- a/command/api/token/create.go
+++ b/command/api/token/create.go
@@ -21,7 +21,7 @@ func createCommand() cli.Command {
 		Name:   "create",
 		Action: cli.ActionFunc(createAction),
 		Usage:  "create a new token",
-		UsageText: `**step api token create** <team-id>|<team-slug> <crt-file> <key-file>
+		UsageText: `**step api token create** <team> <crt-file> <key-file>
 [**--api-url**=<url>] [**--audience**=<name>]
 `,
 		Flags: []cli.Flag{
@@ -32,7 +32,7 @@ func createCommand() cli.Command {
 
 ## POSITIONAL ARGUMENTS
 
-<team-id>|<team-slug>
+<team>
 :  UUID or slug of the team the API token will be issued for. This is available in the Smallstep dashboard.
 
 <crt-file>


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
API auth tokens with team slug

#### Pain or issue this feature alleviates:
Previous you needed to supply the team UUID to get an auth token for the API.

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?
Getting an auth token from the Gateway API.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
