### PR TITLE
Find more plugins on Windows

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/urfave/cli"
 	"go.step.sm/cli-utils/step"
@@ -19,7 +20,22 @@ func LookPath(name string) (string, error) {
 	fileName := "step-" + name + "-plugin"
 	switch runtime.GOOS {
 	case "windows":
-		for _, ext := range []string{".com", ".exe", ".bat", ".cmd"} {
+		var exts []string
+		x := os.Getenv(`PATHEXT`)
+		if x != "" {
+			for _, e := range strings.Split(strings.ToLower(x), `;`) {
+				if e == "" {
+					continue
+				}
+				if e[0] != '.' {
+					e = "." + e
+				}
+				exts = append(exts, e)
+			}
+		} else {
+			exts = []string{".com", ".exe", ".bat", ".cmd"}
+		}
+		for _, ext := range exts {
 			path := filepath.Join(step.BasePath(), "plugins", fileName+ext)
 			if _, err := os.Stat(path); err == nil {
 				return path, nil

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -58,7 +58,7 @@ func Run(ctx *cli.Context, file string) error {
 
 	// if running on Windows and (likely) a PowerShell script, invoke powershell
 	// with the arguments instead of the plugin file directly.
-	if runtime.GOOS == "windows" && filepath.Ext(file) == ".ps1" {
+	if runtime.GOOS == "windows" && strings.ToLower(filepath.Ext(file)) == ".ps1" {
 		cmdName = "powershell"
 		args = append([]string{args[0], "-noprofile", "-nologo", file}, args[1:]...)
 	}


### PR DESCRIPTION
This PR adds support for `PATHEXT` in the `(step path)/plugins` directory, as well as support for `.ps1` execution.

Example PowerShell script in `C:\Users\herman\.step\plugins\step-script-plugin.ps1`:
```powershell
Write-Host 'Hello from PowerShell, step!'
Write-Host $args
```

```console
C:\Users\herman\Desktop>step.exe script bla foo
Hello from PowerShell, step!
bla foo
```

Currently the behavior is to fallback to some well-known executable extensions, including `.ps1`, if `PATHEXT` is not set. If `PATHEXT` is set, it is used to extract the executable extensions. By default, `PATHEXT` does not include `.ps1`, so that should be added if necessary.

Not sure if `PATHEXT` makes sense in `(step path)/plugins`. It can go both ways.