### PR TITLE
Hide step oauth command if it fails

### DIFF
--- a/utils/cautils/token_generator.go
+++ b/utils/cautils/token_generator.go
@@ -133,7 +133,7 @@ func generateOIDCToken(ctx *cli.Context, p *provisioner.OIDC) (string, error) {
 	}
 	out, err := exec.Step(args...)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf(`error generating OIDC token: exec "step oauth" failed`)
 	}
 	return strings.TrimSpace(string(out)), nil
 }


### PR DESCRIPTION
### Description

This commit changes the error printed by step if running `step oauth` fails. This avoids printing the client secret in the command line, even if that is "public" knowledge.
