### PR TITLE
crypto/jwt: remove redundant `len` check in verify

### DIFF
--- a/command/crypto/jwt/verify.go
+++ b/command/crypto/jwt/verify.go
@@ -271,12 +271,10 @@ func validateClaimsWithLeeway(ctx *cli.Context, c jose.Claims, e jose.Expected, 
 		ers = append(ers, "invalid ID claim (jti)")
 	}
 
-	if len(e.Audience) != 0 {
-		for _, v := range e.Audience {
-			if !c.Audience.Contains(v) {
-				ers = append(ers, "invalid audience claim (aud)")
-				break
-			}
+	for _, v := range e.Audience {
+		if !c.Audience.Contains(v) {
+			ers = append(ers, "invalid audience claim (aud)")
+			break
 		}
 	}
 


### PR DESCRIPTION
`len` returns 0 if the slice is nil. From the Go specification [^1]:

> "1. For a nil slice, the number of iterations is 0."

Therefore, an additional `len(e.Audience) != 0` check for before the loop is unnecessary.

[^1]: https://go.dev/ref/spec#For_range
