### PR TITLE
Fix leaf certificate `*rsa.PublicKey` example

### DIFF
--- a/command/certificate/create.go
+++ b/command/certificate/create.go
@@ -84,7 +84,7 @@ Here's the default template used for generating a leaf certificate:
 {
 	"subject": {{ toJson .Subject }},
 	"sans": {{ toJson .SANs }},
-{{- if typeIs "*rsa.PublicKey" .Insecure.CR.PublicKey }}
+{{- if typeIs "*_rsa.PublicKey" .Insecure.CR.PublicKey }}
 	"keyUsage": ["keyEncipherment", "digitalSignature"],
 {{- else }}
 	"keyUsage": ["digitalSignature"],

--- a/command/certificate/sign.go
+++ b/command/certificate/sign.go
@@ -125,7 +125,7 @@ $ cat rocket.tpl
 		"commonName": {{toJson .Subject.CommonName }}
 	},
 	"sans": {{ toJson .SANs }},
-{{- if typeIs "*rsa.PublicKey" .Insecure.CR.PublicKey }}
+{{- if typeIs "*_rsa.PublicKey" .Insecure.CR.PublicKey }}
 	"keyUsage": ["keyEncipherment", "digitalSignature"],
 {{- else }}
 	"keyUsage": ["digitalSignature"],


### PR DESCRIPTION
As reported in https://github.com/smallstep/cli/issues/1051, the example template printed in the help has `*sa.PublicKey` instead of `*rsa.PublicKey`. This is likely due to the help text preprocessor.

This commit adds an underscore to `*_rsa.PublicKey`, which tricks the help text preprocessor into simply printing `*rsa.PublicKey`, ignoring it to be processed as Markdown.

A better fix might be to change the help text processor, but there are no tests, and it's used widely, so it's a riskier method for not too much gain.

Note that the output in the help text in the CLI is the same as on the website: https://smallstep.com/docs/step-cli/reference/certificate/create/#templates, so this PR fixes that issue too.
