### PR TITLE
Fix command completion for zsh

### DIFF
--- a/command/completion/completion.go
+++ b/command/completion/completion.go
@@ -69,8 +69,7 @@ complete -o bashdefault -o default -F _step_cli_bash_autocomplete step
 
 `
 
-var zsh = `# zsh completion for step
-#compdef step
+var zsh = `#compdef step
 
 _step() {
 


### PR DESCRIPTION
zsh only reads the first line of a file when searching for `#compdef` lines. The completion script added a comment above this line and caused zsh autocomplete to fail.

https://zsh.sourceforge.io/Doc/Release/Completion-System.html

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature

bugfix for zsh completion

#### Pain or issue this feature alleviates:

zsh autocompletion didn't work before

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

yes, already exists

#### In what environments or workflows is this feature supported?

anyone using zsh

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

n/a

#### Supporting links/other PRs/issues:

https://zsh.sourceforge.io/Doc/Release/Completion-System.html

> When compinit is run, it searches all such files accessible via fpath/FPATH and reads the first line of each of them. This line should contain one of the tags described below. Files whose first line does not start with one of these tags are not considered to be part of the completion system and will not be treated specially. 

💔Thank you!
