### PR TITLE
Docker: Update Debian build to use `debian:bookworm`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_IMAGE: smallstep/step-cli
-      DEBIAN_TAG: bullseye
+      DEBIAN_TAG: bookworm
     outputs:
       version: ${{ steps.extract-tag.outputs.VERSION }}
       vversion: ${{ steps.extract-tag.outputs.VVERSION }}

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:bullseye AS builder
+FROM --platform=$BUILDPLATFORM golang:bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum .
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS_OVERRIDE="GOOS=${GOOS} GOARCH=${GOARCH} GOARM=${GOARM}" \
     make V=1 bin/step
 
-FROM debian:bullseye
+FROM debian:bookworm
 
 ENV STEP="/home/step"
 ENV STEPPATH="/home/step"


### PR DESCRIPTION
I've tested that `step` builds and runs properly using the `debian:bookworm` base image and `golang:bookworm` builder image.
