### PR TITLE
Use bash parameter expansion.

### DIFF
--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -1,16 +1,12 @@
-#! /bin/bash
+#!/bin/bash
 
 _step_cli_bash_autocomplete() {
-	local cur opts base
-	COMPREPLY=()
-	cur="${COMP_WORDS[COMP_CWORD]}"
-	if [[ "$cur" == "-"* ]]; then
-		opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion )
-	else
-		opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
-	fi
-	COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
-	return 0
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local opts
+
+    opts=$("${COMP_WORDS[@]:0:$COMP_CWORD}" "${cur:+$cur }--generate-bash-completion")
+
+    COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 }
 
 complete -o bashdefault -o default -o nospace -F _step_cli_bash_autocomplete step


### PR DESCRIPTION
I've updated this so it cleverly uses bash parameter expansion to conditionally include the current word and a space only if it starts with a hyphen.
