### PR TITLE
Set proper JOSE algorithm for Ed25519 keys

### DIFF
--- a/internal/cryptoutil/cryptoutil.go
+++ b/internal/cryptoutil/cryptoutil.go
@@ -135,7 +135,7 @@ func LoadJSONWebKey(kms, name string, opts ...jose.Option) (*jose.JSONWebKey, er
 	case *rsa.PublicKey:
 		jwk.Algorithm = jose.RS256
 	case ed25519.PublicKey:
-		jwk.Algorithm = jose.XEdDSA
+		jwk.Algorithm = jose.EdDSA
 	default:
 		return nil, fmt.Errorf("unsupported key type %T", pub)
 	}


### PR DESCRIPTION
This commit fixes a typo in the JOSE algorithm specified for Ed25519 keys when a kms is used.

Fixes #1207
