### PR TITLE
Update goreleaser YML version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,5 @@
-# This is an example .goreleaser.yml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
+# Documentation: https://goreleaser.com/customization/
+version: 2
 project_name: step
 
 before:


### PR DESCRIPTION
This is just to fix a deprecation warning for goreleaser v2—the version which we are already running.

https://goreleaser.com/blog/goreleaser-v2/#upgrading
