### PR TITLE
Fix error message on step certificate inspect

### DIFF
--- a/command/certificate/inspect.go
+++ b/command/certificate/inspect.go
@@ -202,7 +202,7 @@ func inspectAction(ctx *cli.Context) error {
 		return errs.InvalidFlagValue(ctx, "format", format, "text, json, pem")
 	}
 	if short && (format == "json" || format == "pem") {
-		return errs.IncompatibleFlagWithFlag(ctx, "short", "format json")
+		return errs.IncompatibleFlagWithFlag(ctx, "short", "format "+format)
 	}
 
 	switch addr, isURL, err := trimURL(crtFile); {


### PR DESCRIPTION
This commit fixes the error message displayed when we run `step certificate inspect --short --format pem ...`.
