### PR TITLE
Fix fish completion

### DIFF
--- a/command/completion/completion.go
+++ b/command/completion/completion.go
@@ -108,7 +108,11 @@ func Completion(ctx *cli.Context) error {
 	case "zsh":
 		fmt.Print(zsh)
 	case "fish":
-		fmt.Print(ctx.App.ToFishCompletion())
+		fish, err := ctx.App.ToFishCompletion()
+		if err != nil {
+			return fmt.Errorf("error creating fish completion: %w", err)
+		}
+		fmt.Print(fish)
 	default:
 		return errors.Errorf("unsupported shell %s", shell)
 	}


### PR DESCRIPTION
Fish completion doesn't work, since a nil error is printed after the completion:

```
❯ ./bin/step completion fish | tail -n 2
complete -c step -n '__fish_seen_subcommand_from revoke' -f -l context -r -d 'The context <name> to apply for the given command.'
<nil>⏎      

❯ ./bin/step completion fish | source
- (line 3899): Expected a string, but found a redirection
<nil>
^
from sourcing file -
source: Error while reading file '<stdin>'                                                                                                                                                                                                                                         
```

So handle the error instead of printing it.