### PR TITLE
Build Docker images using goreleaser-pro instead of make

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,11 @@
-FROM --platform=$BUILDPLATFORM golang:alpine AS builder
+FROM --platform=$BUILDPLATFORM goreleaser/goreleaser-pro:latest AS builder
+# Note: goreleaser-pro:lates uses golang:alpine as base image
 
 WORKDIR /src
 COPY go.mod go.sum .
 RUN go mod download
 COPY . .
-RUN apk add --no-cache make git curl
+# RUN apk add --no-cache git curl
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -16,8 +17,13 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     if [ "${TARGETARCH}" = "arm" ] && [ "${TARGETVARIANT}" ]; then \
     GOARM="${TARGETVARIANT#v}"; \
     fi; \
-    CGO_ENABLED=0 GOOS_OVERRIDE="GOOS=${GOOS} GOARCH=${GOARCH} GOARM=${GOARM}" \
-    make V=1 bin/step
+    CGO_ENABLED=0 \
+    goreleaser build \
+      --id default \
+      --single-target \
+      --auto-snapshot \
+      --clean \
+      --output bin/step
 
 FROM alpine
 
@@ -40,4 +46,4 @@ WORKDIR /home/step
 
 STOPSIGNAL SIGTERM
 
-CMD /bin/bash
+CMD [ "/bin/bash" ]

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -4,8 +4,9 @@ WORKDIR /src
 COPY go.mod go.sum .
 RUN go mod download
 COPY . .
+RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends make git curl
+    && apt-get install -y --no-install-recommends curl goreleaser-pro
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -17,8 +18,13 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     if [ "${TARGETARCH}" = "arm" ] && [ "${TARGETVARIANT}" ]; then \
     GOARM="${TARGETVARIANT#v}"; \
     fi; \
-    CGO_ENABLED=0 GOOS_OVERRIDE="GOOS=${GOOS} GOARCH=${GOARCH} GOARM=${GOARM}" \
-    make V=1 bin/step
+    CGO_ENABLED=0 \
+    goreleaser build \
+      --id default \
+      --single-target \
+      --auto-snapshot \
+      --clean \
+      --output bin/step
 
 FROM debian:bookworm
 
@@ -41,4 +47,4 @@ WORKDIR /home/step
 
 STOPSIGNAL SIGTERM
 
-CMD /bin/bash
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
Note: We need to wait for a release of GoReleaser Pro before we can merge this.

This PR builds `bin/step` using the same GoReleaser Pro workflow as in other parts of the CI system:

```
goreleaser build \
      --id default \
      --single-target \
      --auto-snapshot \
      --clean \
      --output bin/step
```

It should use the version number from the most recent tag.
The `--auto-snapshot` flag appends `-next` to the version number if the git repo is dirty.

The `--single-target` flag builds for the current `GOOS`, `GOARCH`, and `GOARM` only.
