### PR TITLE
Add support in for signing and publishing RPM and Deb packages to GCP Artifact Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,8 @@ jobs:
       contents: write
       packages: write
     uses: smallstep/workflows/.github/workflows/goreleaser.yml@jdoss/Package_Repos
+    with:
+      enable-packages-upload: true
     secrets: inherit
 
   build_upload_docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      packages: write
     uses: smallstep/workflows/.github/workflows/goreleaser.yml@jdoss/Package_Repos
     secrets: inherit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: smallstep/workflows/.github/workflows/goreleaser.yml@main
+    uses: smallstep/workflows/.github/workflows/goreleaser.yml@jdoss/Package_Repos
     secrets: inherit
 
   build_upload_docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       id-token: write
       contents: write
       packages: write
-    uses: smallstep/workflows/.github/workflows/goreleaser.yml@jdoss/Package_Repos
+    uses: smallstep/workflows/.github/workflows/goreleaser.yml@main
     with:
       enable-packages-upload: true
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ vendor
 step
 .idea
 .envrc
+
+# Packages files
+0x889B19391F774443-Certify.key
+gha-creds-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ go.work.sum
 coverage.txt
 output
 vendor
+dist/
 step
 .idea
 .envrc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,11 @@ before:
   hooks:
     - go mod download
 
+after:
+  hooks:
+    - cmd: bash scripts/package-repo-import.sh {{ .Var.packageName }} {{ .Version }}
+      output: true
+
 builds:
   - &BUILD
     id: default
@@ -87,7 +92,7 @@ nfpms:
     builds:
       - nfpm
     package_name: step-cli
-    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+    file_name_template: "{{.ConventionalFileName}}"
     vendor: Smallstep Labs
     homepage: https://github.com/smallstep/cli
     maintainer: Smallstep <techadmin@smallstep.com>
@@ -113,6 +118,13 @@ nfpms:
     scripts:
       postinstall: scripts/postinstall.sh
       postremove: scripts/postremove.sh
+    rpm:
+      signature:
+          key_file: "{{ .Env.GPG_PRIVATE_KEY_FILE }}"
+    deb:
+      signature:
+          key_file: "{{ .Env.GPG_PRIVATE_KEY_FILE }}"
+          type: origin
   -
     << : *NFPM
     id: unversioned
@@ -133,6 +145,13 @@ signs:
   certificate: "${artifact}.pem"
   args: ["sign-blob", "--oidc-issuer=https://token.actions.githubusercontent.com", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}", "--yes"]
   artifacts: all
+
+publishers:
+- name: Google Cloud Artifact Registry
+  ids:
+  - packages
+  cmd: ./scripts/package-upload.sh {{ abs .ArtifactPath }} {{ .Var.packageName }} {{ .Version }} {{ .Var.packageRelease }}
+  disable: "{{ if .IsNightly }}true{{ end }}"
 
 snapshot:
   name_template: "{{ .Tag }}-next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,7 +98,11 @@ nfpms:
       - nfpm
     package_name: "{{ .Var.packageName }}"
     release: "1"
-    file_name_template: "{{.ConventionalFileName}}"
+    file_name_template: >-
+      {{- trimsuffix .ConventionalFileName .ConventionalExtension -}}
+      {{- if and (eq .Arm "6") (eq .ConventionalExtension ".deb") }}6{{ end -}}
+      {{- if not (eq .Amd64 "v1")}}{{ .Amd64 }}{{ end -}}
+      {{- .ConventionalExtension -}}
     vendor: Smallstep Labs
     homepage: https://github.com/smallstep/cli
     maintainer: Smallstep <techadmin@smallstep.com>

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,10 @@
 version: 2
 project_name: step
 
+variables:
+  packageName: step-cli
+  packageRelease: 1 # Manually update release: in the nfpm section to match this value if you change this
+
 before:
   hooks:
     - go mod download
@@ -92,7 +96,8 @@ nfpms:
   - &NFPM
     builds:
       - nfpm
-    package_name: step-cli
+    package_name: "{{ .Var.packageName }}"
+    release: "1"
     file_name_template: "{{.ConventionalFileName}}"
     vendor: Smallstep Labs
     homepage: https://github.com/smallstep/cli

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -157,7 +157,7 @@ publishers:
   ids:
   - packages
   cmd: ./scripts/package-upload.sh {{ abs .ArtifactPath }} {{ .Var.packageName }} {{ .Version }} {{ .Var.packageRelease }}
-  disable: "{{ if .IsNightly }}true{{ end }}"
+  disable: "{{ if .Prerelease }}true{{ end }}"
 
 snapshot:
   name_template: "{{ .Tag }}-next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 # Documentation: https://goreleaser.com/customization/
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 version: 2
 project_name: step
 

--- a/scripts/package-repo-import.sh
+++ b/scripts/package-repo-import.sh
@@ -20,8 +20,14 @@ check_package() {
   local REPO="${1}"
   local VER="${2}"
   if [ ! -f /tmp/version-deleted.stamp ]; then
-    gcloud artifacts versions list --repository "${REPO}" --location "${GCLOUD_LOCATION}" --package "${PACKAGE}" \
-    --filter "VERSION:${VER}" --format json  2> /dev/null |jq -re '.[].name?' >/dev/null 2>&1 || EXITCODE=$?
+    gcloud artifacts versions list \
+       --repository "${REPO}" \
+       --location "${GCLOUD_LOCATION}" \
+       --package "${PACKAGE}" \
+       --filter "VERSION:${VER}" \
+       --format json  2> /dev/null \
+       | jq -re '.[].name?' >/dev/null 2>&1 \
+       || EXITCODE=$?
     if [[ "${EXITCODE}" -eq 0 ]]; then
       echo "Package version already exists. Removing it..."
       gcloud artifacts versions delete --quiet "${VER}" --package "${PACKAGE}" --repository "${REPO}" --location "${GCLOUD_LOCATION}"

--- a/scripts/package-repo-import.sh
+++ b/scripts/package-repo-import.sh
@@ -30,7 +30,11 @@ check_package() {
        || EXITCODE=$?
     if [[ "${EXITCODE}" -eq 0 ]]; then
       echo "Package version already exists. Removing it..."
-      gcloud artifacts versions delete --quiet "${VER}" --package "${PACKAGE}" --repository "${REPO}" --location "${GCLOUD_LOCATION}"
+      gcloud artifacts versions delete \
+      --quiet "${VER}" \
+      --package "${PACKAGE}" \
+      --repository "${REPO}" \
+      --location "${GCLOUD_LOCATION}"
       touch /tmp/version-deleted.stamp
     fi
   fi

--- a/scripts/package-repo-import.sh
+++ b/scripts/package-repo-import.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+: ${GCLOUD_LOCATION:=us-central1}
+: ${GCLOUD_RPM_REPO:=rpms}
+: ${GCLOUD_DEB_REPO:=debs}
+
+PACKAGE="${1}"
+VERSION="${2}"
+RELEASE="1"
+EPOCH="0"
+GORELEASER_PHASE=${GORELEASER_PHASE:-release}
+
+echo "Package: ${PACKAGE}"
+echo "Version: ${VERSION}"
+
+check_package() {
+  local EXITCODE=0
+  local REPO="${1}"
+  local VER="${2}"
+  if [ ! -f /tmp/version-deleted.stamp ]; then
+    gcloud artifacts versions list --repository "${REPO}" --location "${GCLOUD_LOCATION}" --package "${PACKAGE}" \
+    --filter "VERSION:${VER}" --format json  2> /dev/null |jq -re '.[].name?' >/dev/null 2>&1 || EXITCODE=$?
+    if [[ "${EXITCODE}" -eq 0 ]]; then
+      echo "Package version already exists. Removing it..."
+      gcloud artifacts versions delete --quiet "${VER}" --package "${PACKAGE}" --repository "${REPO}" --location "${GCLOUD_LOCATION}"
+      touch /tmp/version-deleted.stamp
+    fi
+  fi
+}
+
+if [[ ${GORELEASER_PHASE} != "publish" ]]; then
+  echo "Skipping artifact import; GORELEASER_PHASE is not 'publish'"
+  exit 0;
+fi
+
+check_package "${GCLOUD_RPM_REPO}" "${EPOCH}:${VERSION}-${RELEASE}"
+gcloud artifacts yum import "${GCLOUD_RPM_REPO}" \
+  --location "${GCLOUD_LOCATION}" \
+  --gcs-source "gs://artifacts-outgoing/${PACKAGE}/rpm/${VERSION}/*"
+
+check_package ${GCLOUD_DEB_REPO} "${VERSION}-${RELEASE}"}
+gcloud artifacts apt import "${GCLOUD_DEB_REPO}" \
+  --location "${GCLOUD_LOCATION}" \
+  --gcs-source "gs://artifacts-outgoing/${PACKAGE}/deb/${VERSION}/*"

--- a/scripts/package-upload.sh
+++ b/scripts/package-upload.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+FILE="${1}"
+PACKAGE="${2}"
+VERSION="${3}"
+
+echo "Package File: ${FILE}"
+echo "Package: ${PACKAGE}"
+echo "Version: ${VERSION}"
+echo "Release: ${RELEASE}"
+echo "Location: ${GCLOUD_LOCATION}"
+
+if [ "${FILE: -4}" == ".deb" ]; then
+  gcloud storage cp ${FILE} gs://artifacts-outgoing/${PACKAGE}/deb/${VERSION}/
+else
+  gcloud storage cp ${FILE} gs://artifacts-outgoing/${PACKAGE}/rpm/${VERSION}/
+fi


### PR DESCRIPTION
This adds support for signing RPM and Deb packages and uploading them to GCP Artifact Registry. It also changes the RPM and Deb file name format to use the ConventionalFileName macro in GoReleaser.