### PR TITLE
Prerelease fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
     uses: smallstep/workflows/.github/workflows/goreleaser.yml@jdoss/PRERELEASE_env_var
     with:
       enable-packages-upload: true
-      is-prerelease: ${{ needs.create_release.outputs.is_prerelease }}
+      is-prerelease: "${{ needs.create_release.outputs.is_prerelease }}"
     secrets: inherit
 
   build_upload_docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
     uses: smallstep/workflows/.github/workflows/goreleaser.yml@jdoss/PRERELEASE_env_var
     with:
       enable-packages-upload: true
-      is-prerelease: ${{ needs.create_release.outputs.is_prerelease }}
+      is-prerelease: ${{ needs.create_release.outputs.is_prerelease == 'true' }}
     secrets: inherit
 
   build_upload_docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
     uses: smallstep/workflows/.github/workflows/goreleaser.yml@jdoss/PRERELEASE_env_var
     with:
       enable-packages-upload: true
-      is_prerelease: ${{ needs.create_release.outputs.is_prerelease }}
+      is-prerelease: ${{ needs.create_release.outputs.is_prerelease }}
     secrets: inherit
 
   build_upload_docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,10 @@ jobs:
       id-token: write
       contents: write
       packages: write
-    uses: smallstep/workflows/.github/workflows/goreleaser.yml@main
+    uses: smallstep/workflows/.github/workflows/goreleaser.yml@jdoss/PRERELEASE_env_var
     with:
       enable-packages-upload: true
+      is_prerelease: ${{ needs.create_release.outputs.is_prerelease }}
     secrets: inherit
 
   build_upload_docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
     uses: smallstep/workflows/.github/workflows/goreleaser.yml@jdoss/PRERELEASE_env_var
     with:
       enable-packages-upload: true
-      is-prerelease: "${{ needs.create_release.outputs.is_prerelease }}"
+      is-prerelease: ${{ needs.create_release.outputs.is_prerelease }}
     secrets: inherit
 
   build_upload_docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       id-token: write
       contents: write
       packages: write
-    uses: smallstep/workflows/.github/workflows/goreleaser.yml@jdoss/PRERELEASE_env_var
+    uses: smallstep/workflows/.github/workflows/goreleaser.yml@main
     with:
       enable-packages-upload: true
       is-prerelease: ${{ needs.create_release.outputs.is_prerelease == 'true' }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ before:
 
 after:
   hooks:
+    # This script depends on IS_PRERELEASE env being set. This is set by CI in the Is Pre-release step.
     - cmd: bash scripts/package-repo-import.sh {{ .Var.packageName }} {{ .Version }}
       output: true
 
@@ -161,7 +162,6 @@ publishers:
   ids:
   - packages
   cmd: ./scripts/package-upload.sh {{ abs .ArtifactPath }} {{ .Var.packageName }} {{ .Version }} {{ .Var.packageRelease }}
-  disable: "{{ if .Prerelease }}true{{ end }}"
 
 snapshot:
   name_template: "{{ .Tag }}-next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,6 +95,7 @@ nfpms:
   # Package metadata: dpkg --info dist/step_....deb
   #
   - &NFPM
+    id: packages
     builds:
       - nfpm
     package_name: "{{ .Var.packageName }}"

--- a/scripts/package-repo-import.sh
+++ b/scripts/package-repo-import.sh
@@ -45,6 +45,11 @@ if [[ ${GORELEASER_PHASE} != "publish" ]]; then
   exit 0;
 fi
 
+if [[ ${IS_PRERELEASE} == "true" ]]; then
+  echo "Skipping artifact import; IS_PRERELEASE is 'true'"
+  exit 0;
+fi
+
 check_package "${GCLOUD_RPM_REPO}" "${EPOCH}:${VERSION}-${RELEASE}"
 gcloud artifacts yum import "${GCLOUD_RPM_REPO}" \
   --location "${GCLOUD_LOCATION}" \

--- a/scripts/package-repo-import.sh
+++ b/scripts/package-repo-import.sh
@@ -40,11 +40,6 @@ check_package() {
   fi
 }
 
-if [[ ${GORELEASER_PHASE} != "publish" ]]; then
-  echo "Skipping artifact import; GORELEASER_PHASE is not 'publish'"
-  exit 0;
-fi
-
 if [[ ${IS_PRERELEASE} == "true" ]]; then
   echo "Skipping artifact import; IS_PRERELEASE is 'true'"
   exit 0;


### PR DESCRIPTION
This PR moves the package upload logic so the packages always upload to the GCS bucket but they will not import into the YUM and Apt repos if it is a prerelease.