### PR TITLE
Fix PowerShell 5.1 CLI crashes in Windows 11

### DIFF
--- a/utils/sysutils/sysutils_windows.go
+++ b/utils/sysutils/sysutils_windows.go
@@ -10,16 +10,21 @@ import (
 
 func init() {
 	var inMode, outMode uint32
-	if err := windows.GetConsoleMode(windows.Stdin, &inMode); err == nil {
-		inMode |= windows.ENABLE_VIRTUAL_TERMINAL_INPUT
-		if err := windows.SetConsoleMode(windows.Stdin, inMode); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to set console mode: %v", err)
+	maj, _, build := windows.RtlGetNtVersionNumbers()
+	if maj < 10 || (maj == 10 && build <= 14393) {
+		// the Windows 10 Anniversary Edition added VT100 support
+		// enable vterm support in older versions of the Windows terminal
+		if err := windows.GetConsoleMode(windows.Stdin, &inMode); err == nil {
+			inMode |= windows.ENABLE_VIRTUAL_TERMINAL_INPUT
+			if err := windows.SetConsoleMode(windows.Stdin, inMode); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to set console mode: %v", err)
+			}
 		}
-	}
-	if err := windows.GetConsoleMode(windows.Stdout, &outMode); err == nil {
-		outMode |= windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING
-		if err := windows.SetConsoleMode(windows.Stdout, outMode); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to set console mode: %v", err)
+		if err := windows.GetConsoleMode(windows.Stdout, &outMode); err == nil {
+			outMode |= windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING
+			if err := windows.SetConsoleMode(windows.Stdout, outMode); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to set console mode: %v", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
I have tested this build with PowerShell 5.1 and PowerShell 7.4 in Windows 11
I have not tested in Windows 10 pre- and post- anniversary edition
