### PR TITLE
Parse crlEntryExtensions in CRLs

### DIFF
--- a/internal/crlutil/crlutil.go
+++ b/internal/crlutil/crlutil.go
@@ -249,7 +249,11 @@ type RevokedCertificate struct {
 }
 
 func newRevokedCertificate(c x509.RevocationListEntry) RevokedCertificate {
-	var extensions []Extension
+	extensions := make([]Extension, len(c.Extensions))
+
+	for i, e := range c.Extensions {
+		extensions[i] = newExtension(e)
+	}
 
 	return RevokedCertificate{
 		SerialNumber:      c.SerialNumber.String(),


### PR DESCRIPTION
Not sure if this was an oversight, or done on purpose, but extensions in RevocationListEntries were not being parsed. Now they get parsed.

Before change:
```
❯ step crl inspect --insecure 'http://crl4.digicert.com/sha2-ev-server-g1.crl' | grep "Revoked Certificates:" -A 5
        Revoked Certificates:
            Serial Number: 2799225036922445944820450433099856353 (0x021B1C73250B47C4CE8F305E639B79E1)
                Revocation Date: 2023-08-23 10:43:00 +0000 UTC
            Serial Number: 14874532436251617487517665762619838282 (0x0B30BB11F55A7DF580DDC276AF324F4A)
                Revocation Date: 2023-11-23 12:19:17 +0000 UTC
            Serial Number: 21201432819745242598424189347483327802 (0x0FF33F57C756BC0BA8A6B78606179D3A)
```

After change:
```
❯ ./bin/step crl inspect --insecure 'http://crl4.digicert.com/sha2-ev-server-g1.crl' | grep "Revoked Certificates:" -A 5
        Revoked Certificates:
            Serial Number: 2799225036922445944820450433099856353 (0x021B1C73250B47C4CE8F305E639B79E1)
                Revocation Date: 2023-08-23 10:43:00 +0000 UTC
                CRL Entry Extensions:
                    X509v3 CRL Reason Code:
                        Key Compromise
```