### PR TITLE
Sync commands of alpine & debian Dockerfile

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -32,7 +32,7 @@ RUN apt-get update \
         && apt-get install -y --no-install-recommends curl \
         && addgroup --gid ${STEPGID} step \
         && adduser --disabled-password --uid ${STEPUID} --gid ${STEPGID} step
-
+        && chown step:step /home/step
 
 COPY --from=builder /src/bin/step "/usr/local/bin/step"
 


### PR DESCRIPTION
#### Name of feature:
Bugfix, chown command missin in debian Dockerfile variant.

#### Pain or issue this feature alleviates:
Debian image of step-ca:hsm, which depends on step-cli:bookworm has permission issues. Cannot be changed as user later because step-ca Dockerfiles use VOLUME command on /home/step.
