### PR TITLE
Add `--password-file` to `crypto jwe encrypt`

### DIFF
--- a/command/crypto/jwe/decrypt.go
+++ b/command/crypto/jwe/decrypt.go
@@ -50,7 +50,7 @@ one of the JWKs in the JWK Set.`,
 			},
 			cli.StringFlag{
 				Name:  "password-file",
-				Usage: `The path to the <file> containing the password to encrypt the keys.`,
+				Usage: `The path to the <file> containing the password to decrypt the keys.`,
 			},
 		},
 	}


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
Add `--password-file` to `crypto jwe encrypt`
#### Pain or issue this feature alleviates:
Makes it possible to run the command without prompts for input if e.g. running it from a script to modify the password of a user as described in https://smallstep.com/docs/step-ca/provisioners/#changing-a-jwk-provisioner-password. The flag also matches the already available flag for the `decrypt` command. Also the usage string for the `decrypt` command has been updated to mention decryption. This fix basically mirrors how things are done in decrypt.go.
#### Why is this important to the project (if not answered above):
Helpful for scripting with the step client.
#### Is there documentation on how to use this feature? If so, where?
The flag includes a usage string.
#### In what environments or workflows is this feature supported?
Any using step cli.
#### In what environments or workflows is this feature explicitly NOT supported (if any)?
N/A
#### Supporting links/other PRs/issues:

💔Thank you!
