### PR TITLE
OpenInBrowser on Android as well

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -115,6 +115,8 @@ func OpenInBrowser(url, browser string) error {
 		} else {
 			cmd = exec.Command("xdg-open", url)
 		}
+	case "android":
+		cmd = exec.Command("xdg-open", url)
 	case "windows":
 		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
 	default:


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
support for OpenInBrowser on Android

#### Pain or issue this feature alleviates:
without this patch, doing "step ssh login" with and OIDC-provider results in:

> Cannot open a web browser on your platform.
> 
> Open a local web browser and visit:
> http://....
> 

with this patch applied, the browser is opened automatically
(behind the scenes by using xdg-open)

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?
I tested this on "termux" on Android (which ships step-cli as one of its termux-packages). 
(On termux, "xdg-open" links to "termux-open", which then calls Android's "am" (Activity Manager))

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
