### PR TITLE
Remove `--bundle` from `step ca certificate` usage text

### DIFF
--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -28,7 +28,7 @@ func certificateCommand() cli.Command {
 [**--not-before**=<time|duration>] [**--not-after**=<time|duration>]
 [**--san**=<SAN>] [**--set**=<key=value>] [**--set-file**=<file>]
 [**--acme**=<file>] [**--standalone**] [**--webroot**=<file>]
-[**--contact**=<email>] [**--http-listen**=<address>] [**--bundle**]
+[**--contact**=<email>] [**--http-listen**=<address>]
 [**--kty**=<type>] [**--curve**=<curve>] [**--size**=<size>] [**--console**]
 [**--x5c-cert**=<file>] [**--x5c-key**=<file>] [**--k8ssa-token-path**=<file>]
 [**--offline**] [**--password-file**] [**--ca-url**=<uri>] [**--root**=<file>]


### PR DESCRIPTION
The `step ca certificate` command doesn't have a `--bundle` switch, and yet the usage text suggests it is available.
This PR fixes that. I think this got reintroduced accidentally, see #521 .
