### PR TITLE
Skip opening the default browser if STEP_OPEN_BROWSER=false

### DIFF
--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -786,19 +786,19 @@ func (o *oauth) DoLoopbackAuthorization() (*token, error) {
 
 	if skipBrowser := os.Getenv("STEP_OPEN_BROWSER") == "0"; skipBrowser {
 		fmt.Fprintln(os.Stderr, authURL)
-		} else {
+	} else {
 		if err := exec.OpenInBrowser(authURL, o.browser); err != nil {
-				fmt.Fprintln(os.Stderr, "Cannot open a web browser on your platform.")
-				fmt.Fprintln(os.Stderr)
-				fmt.Fprintln(os.Stderr, "Open a local web browser and visit:")
-				fmt.Fprintln(os.Stderr)
-				fmt.Fprintln(os.Stderr, authURL)
-				fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Cannot open a web browser on your platform.")
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Open a local web browser and visit:")
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, authURL)
+			fmt.Fprintln(os.Stderr)
 		} else {
-				fmt.Fprintln(os.Stderr, "Your default web browser has been opened to visit:")
-				fmt.Fprintln(os.Stderr)
-				fmt.Fprintln(os.Stderr, authURL)
-				fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Your default web browser has been opened to visit:")
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, authURL)
+			fmt.Fprintln(os.Stderr)
 		}
 	}
 

--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -784,18 +784,24 @@ func (o *oauth) DoLoopbackAuthorization() (*token, error) {
 		return nil, err
 	}
 
-	if err := exec.OpenInBrowser(authURL, o.browser); err != nil {
-		fmt.Fprintln(os.Stderr, "Cannot open a web browser on your platform.")
-		fmt.Fprintln(os.Stderr)
-		fmt.Fprintln(os.Stderr, "Open a local web browser and visit:")
-		fmt.Fprintln(os.Stderr)
-		fmt.Fprintln(os.Stderr, authURL)
-		fmt.Fprintln(os.Stderr)
+	skipBrowser := os.Getenv("STEP_OPEN_BROWSER") == "false"
+
+	if !skipBrowser {
+			if err := exec.OpenInBrowser(authURL, o.browser); err != nil {
+					fmt.Fprintln(os.Stderr, "Cannot open a web browser on your platform.")
+					fmt.Fprintln(os.Stderr)
+					fmt.Fprintln(os.Stderr, "Open a local web browser and visit:")
+					fmt.Fprintln(os.Stderr)
+					fmt.Fprintln(os.Stderr, authURL)
+					fmt.Fprintln(os.Stderr)
+			} else {
+					fmt.Fprintln(os.Stderr, "Your default web browser has been opened to visit:")
+					fmt.Fprintln(os.Stderr)
+					fmt.Fprintln(os.Stderr, authURL)
+					fmt.Fprintln(os.Stderr)
+			}
 	} else {
-		fmt.Fprintln(os.Stderr, "Your default web browser has been opened to visit:")
-		fmt.Fprintln(os.Stderr)
-		fmt.Fprintln(os.Stderr, authURL)
-		fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, authURL)
 	}
 
 	// Wait for response and return the token

--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -784,24 +784,22 @@ func (o *oauth) DoLoopbackAuthorization() (*token, error) {
 		return nil, err
 	}
 
-	skipBrowser := os.Getenv("STEP_OPEN_BROWSER") == "false"
-
-	if !skipBrowser {
-			if err := exec.OpenInBrowser(authURL, o.browser); err != nil {
-					fmt.Fprintln(os.Stderr, "Cannot open a web browser on your platform.")
-					fmt.Fprintln(os.Stderr)
-					fmt.Fprintln(os.Stderr, "Open a local web browser and visit:")
-					fmt.Fprintln(os.Stderr)
-					fmt.Fprintln(os.Stderr, authURL)
-					fmt.Fprintln(os.Stderr)
-			} else {
-					fmt.Fprintln(os.Stderr, "Your default web browser has been opened to visit:")
-					fmt.Fprintln(os.Stderr)
-					fmt.Fprintln(os.Stderr, authURL)
-					fmt.Fprintln(os.Stderr)
-			}
-	} else {
-			fmt.Fprintln(os.Stderr, authURL)
+	if skipBrowser := os.Getenv("STEP_OPEN_BROWSER") == "0"; skipBrowser {
+		fmt.Fprintln(os.Stderr, authURL)
+		} else {
+		if err := exec.OpenInBrowser(authURL, o.browser); err != nil {
+				fmt.Fprintln(os.Stderr, "Cannot open a web browser on your platform.")
+				fmt.Fprintln(os.Stderr)
+				fmt.Fprintln(os.Stderr, "Open a local web browser and visit:")
+				fmt.Fprintln(os.Stderr)
+				fmt.Fprintln(os.Stderr, authURL)
+				fmt.Fprintln(os.Stderr)
+		} else {
+				fmt.Fprintln(os.Stderr, "Your default web browser has been opened to visit:")
+				fmt.Fprintln(os.Stderr)
+				fmt.Fprintln(os.Stderr, authURL)
+				fmt.Fprintln(os.Stderr)
+		}
 	}
 
 	// Wait for response and return the token


### PR DESCRIPTION
This PR adds support for `STEP_OPEN_BROWSER` env var which if set to  `STEP_OPEN_BROWSER=false` it will skip opening the default browser and just output the authURL to stderr. 

