### PR TITLE
Fix `cast` package tests for `linux/arm32`

### DIFF
--- a/internal/cast/cast_test.go
+++ b/internal/cast/cast_test.go
@@ -36,7 +36,7 @@ func TestInt64ConvertsValues(t *testing.T) {
 }
 
 func TestInt64PanicsOnLargeValue(t *testing.T) {
-	require.Panics(t, func() { cast.Int64(uint64(math.MaxInt + 1)) })
+	require.Panics(t, func() { cast.Int64(uint64(math.MaxInt64 + 1)) })
 }
 
 func TestUint64ConvertsValues(t *testing.T) {
@@ -56,16 +56,16 @@ func TestInt32ConvertsValues(t *testing.T) {
 }
 
 func TestInt32PanicsOnTooSmallValue(t *testing.T) {
-	require.Panics(t, func() { cast.Int32(math.MinInt32 - 1) })
+	require.Panics(t, func() { cast.Int32(int64(math.MinInt32 - 1)) })
 }
 
 func TestInt32PanicsOnLargeValue(t *testing.T) {
-	require.Panics(t, func() { cast.Int32(math.MaxInt32 + 1) })
+	require.Panics(t, func() { cast.Int32(int64(math.MaxInt32 + 1)) })
 }
 
 func TestUint32ConvertsValues(t *testing.T) {
 	require.Equal(t, uint32(0), cast.Uint32(0))
-	require.Equal(t, uint32(math.MaxUint32), cast.Uint32(math.MaxUint32))
+	require.Equal(t, uint32(math.MaxUint32), cast.Uint32(int64(math.MaxUint32)))
 	require.Equal(t, uint32(42), cast.Uint32(42))
 }
 
@@ -74,8 +74,9 @@ func TestUint32PanicsOnNegativeValue(t *testing.T) {
 }
 
 func TestUint32PanicsOnLargeValue(t *testing.T) {
-	require.Panics(t, func() { cast.Uint32(math.MaxUint32 + 1) })
+	require.Panics(t, func() { cast.Uint32(int64(math.MaxUint32 + 1)) })
 }
+
 func TestUint8ConvertsValues(t *testing.T) {
 	require.Equal(t, uint8(0), cast.Uint8(0))
 	require.Equal(t, uint8(math.MaxUint8), cast.Uint8(math.MaxUint8))
@@ -87,5 +88,5 @@ func TestUint8PanicsOnNegativeValue(t *testing.T) {
 }
 
 func TestUint8PanicsOnLargeValue(t *testing.T) {
-	require.Panics(t, func() { cast.Uint8(math.MaxUint32 + 1) })
+	require.Panics(t, func() { cast.Uint8(math.MaxUint8 + 1) })
 }


### PR DESCRIPTION
Fixes #1367.

In the absence of `arm32` runners in our CI, I've tested this locally with a Dockerfile roughly equivalent to this (based on the `cli` Dockerfile):

```dockerfile
FROM --platform=linux/arm golang:alpine AS builder

WORKDIR /src
COPY go.mod go.sum .
RUN go mod download
COPY . .
RUN apk add --no-cache make git curl

ARG TARGETOS
ARG TARGETARCH
ARG TARGETVARIANT

RUN --mount=type=cache,target=/root/.cache/go-build \
    --mount=type=cache,target=/go/pkg \
    GOOS="${TARGETOS}"; \
    GOARCH="${TARGETARCH}"; \
    if [ "${TARGETARCH}" = "arm" ] && [ "${TARGETVARIANT}" ]; then \
    GOARM="${TARGETVARIANT#v}"; \
    fi; \
    CGO_ENABLED=0 GOOS_OVERRIDE="GOOS=${GOOS} GOARCH=${GOARCH} GOARM=${GOARM}" \
    go test -timeout 30s github.com/smallstep/cli/internal/cast 

RUN --mount=type=cache,target=/root/.cache/go-build \
    --mount=type=cache,target=/go/pkg \
    GOOS="${TARGETOS}"; \
    GOARCH="${TARGETARCH}"; \
    if [ "${TARGETARCH}" = "arm" ] && [ "${TARGETVARIANT}" ]; then \
    GOARM="${TARGETVARIANT#v}"; \
    fi; \
    CGO_ENABLED=0 GOOS_OVERRIDE="GOOS=${GOOS} GOARCH=${GOARCH} GOARM=${GOARM}" \
    make V=1 bin/step

FROM alpine

ENV STEP="/home/step"
ENV STEPPATH="/home/step"
ARG STEPUID=1000
ARG STEPGID=1000

RUN apk update \
        && apk upgrade \
        && apk add --no-cache bash curl tzdata \
        && addgroup -g ${STEPGID} step \
        && adduser -D -u ${STEPUID} -G step step \
        && chown step:step /home/step

COPY --from=builder /src/bin/step "/usr/local/bin/step"

USER step
WORKDIR /home/step

STOPSIGNAL SIGTERM

CMD /bin/bash
```