### PR TITLE
command/ca/token: support custom "user" claim

### DIFF
--- a/token/options.go
+++ b/token/options.go
@@ -80,6 +80,25 @@ func WithStep(v interface{}) Options {
 	}
 }
 
+// WithUserData returns an Option function that merges the provided map with the
+// existing user claim in the payload.
+func WithUserData(v map[string]interface{}) Options {
+	return func(c *Claims) error {
+		if _, ok := c.ExtraClaims[UserClaim]; !ok {
+			c.Set(UserClaim, make(map[string]interface{}))
+		}
+		s := c.ExtraClaims[UserClaim]
+		sm, ok := s.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("%q claim is %T, not map[string]interface{}", UserClaim, s)
+		}
+		for k, val := range v {
+			sm[k] = val
+		}
+		return nil
+	}
+}
+
 // WithSSH returns an Options function that sets the step claim with the ssh
 // property in the value.
 func WithSSH(v interface{}) Options {

--- a/token/token.go
+++ b/token/token.go
@@ -32,6 +32,9 @@ const SANSClaim = "sans"
 // StepClaim is the property name for a JWT claim the stores the custom information in the certificate.
 const StepClaim = "step"
 
+// UserClaim is the property name for a JWT claim that stores user-provided custom information.
+const UserClaim = "user"
+
 // ConfirmationClaim is the property name for a JWT claim that stores a JSON
 // object used as Proof-Of-Possession.
 const ConfirmationClaim = "cnf"

--- a/utils/cautils/certificate_flow.go
+++ b/utils/cautils/certificate_flow.go
@@ -43,6 +43,7 @@ type flowContext struct {
 	SSHPublicKey            ssh.PublicKey
 	CertificateRequest      *x509.CertificateRequest
 	ConfirmationFingerprint string
+	CustomAttributes        map[string]interface{}
 }
 
 // sharedContext is used to share information between commands.
@@ -85,6 +86,18 @@ func WithCertificateRequest(cr *x509.CertificateRequest) Option {
 func WithConfirmationFingerprint(fp string) Option {
 	return newFuncFlowOption(func(fo *flowContext) {
 		fo.ConfirmationFingerprint = fp
+	})
+}
+
+// WithCustomAttributes adds custom attributes to be set in the "user" claim.
+func WithCustomAttributes(v map[string]interface{}) Option {
+	return newFuncFlowOption(func(fo *flowContext) {
+		if fo.CustomAttributes == nil {
+			fo.CustomAttributes = make(map[string]interface{})
+		}
+		for k, val := range v {
+			fo.CustomAttributes[k] = val
+		}
 	})
 }
 

--- a/utils/cautils/token_generator.go
+++ b/utils/cautils/token_generator.go
@@ -108,6 +108,11 @@ func (t *TokenGenerator) SignToken(sub string, sans []string, opts ...token.Opti
 		opts = append(opts, token.WithConfirmationFingerprint(sharedContext.ConfirmationFingerprint))
 	}
 
+	// Add custom user data, if set.
+	if sharedContext.CustomAttributes != nil {
+		opts = append(opts, token.WithUserData(sharedContext.CustomAttributes))
+	}
+
 	return t.Token(sub, opts...)
 }
 
@@ -125,6 +130,11 @@ func (t *TokenGenerator) SignSSHToken(sub, certType string, principals []string,
 		ValidAfter:  notBefore,
 		ValidBefore: notAfter,
 	})}, opts...)
+
+	// Add custom user data, if set.
+	if sharedContext.CustomAttributes != nil {
+		opts = append(opts, token.WithUserData(sharedContext.CustomAttributes))
+	}
 
 	return t.Token(sub, opts...)
 }


### PR DESCRIPTION
Add the `--set` and `--set-file` flags to the `step ca token` command, allowing the user to set keys in the "user" claim in the resulting JWT.

#### Name of feature:
Custom user data in tokens

#### Pain or issue this feature alleviates:
Lack of ability to pass custom _trusted_ data to a template without a pre-existing CSR.

#### Is there documentation on how to use this feature? If so, where?
Yes, in the CLI help for `step ca token`.

#### In what environments or workflows is this feature supported?
Online JWT token flow

#### In what environments or workflows is this feature explicitly NOT supported (if any)?
Offline token flow, because `cautils.OfflineTokenFlow` doesn't support `tokenOpts`. Enforced by flags validation.
