### PR TITLE
Change `.Token.user.field` to not use curly braces

### DIFF
--- a/command/ca/token.go
+++ b/command/ca/token.go
@@ -178,7 +178,7 @@ $ step ca token --kms yubikey:pin-value=123456 \
 '''
 
 Generate a token with custom data in the "user" claim. The example below can be
-accessed in a template as **{{ .Token.user.field }}**, rendering to the string
+accessed in a template as **.Token.user.field**, rendering to the string
 "value".
 
 This is distinct from **.Insecure.User**: any attributes set using this option


### PR DESCRIPTION
The unescaped curly braces result in a broken docs site. Besides that, other template variables are also not demarcated using curly braces.

