### PR TITLE
Add SSH_AUTH_SOCK support to Windows environments.

### DIFF
--- a/internal/sshutil/agent_windows.go
+++ b/internal/sshutil/agent_windows.go
@@ -13,17 +13,28 @@ import (
 // dialAgent returns an ssh.Agent client. It uses the SSH_AUTH_SOCK to connect
 // to the agent.
 func dialAgent() (*Agent, error) {
-	// Attempt unix sockets for environments like cygwin.
+	// Override the default windows openssh-ssh-agent pipe
 	if socket := os.Getenv("SSH_AUTH_SOCK"); socket != "" {
+		// Attempt unix sockets for environments like cygwin.
 		if conn, err := net.Dial("unix", socket); err == nil {
 			return &Agent{
 				ExtendedAgent: agent.NewClient(conn),
 				Conn:          conn,
 			}, nil
 		}
+
+		// Connect to Windows pipe at the supplied address
+		conn, err := winio.DialPipeContext(context.Background(), socket)
+		if err != nil {
+			return nil, errors.Wrap(err, "error connecting with ssh-agent at pipe specified by environment variable SSH_AUTH_SOCK")
+		}
+		return &Agent{
+			ExtendedAgent: agent.NewClient(conn),
+			Conn:          conn,
+		}, nil
 	}
 
-	// Windows OpenSSH agent
+	// DEFAULT: Windows OpenSSH agent
 	conn, err := winio.DialPipeContext(context.Background(), `\\.\\pipe\\openssh-ssh-agent`)
 	if err != nil {
 		return nil, errors.Wrap(err, "error connecting with ssh-agent")


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature: 

Add environment variable `SSH_AUTH_SOCK` support to Windows environments.

#### Pain or issue this feature alleviates:

This feature will allow Windows ssh agents which run entirely within the Windows environment (like PuTTY) to work with step cli. It will allow the agents to use Named Pipes other than the default OpenSSH Agent specific pipe (`\\.\\pipe\\openssh-ssh-agent`).

#### Why is this important to the project:

`SSH_AUTH_SOCK` is an environment variable specifying how clients can connect and interact with an SSH agent (https://datatracker.ietf.org/doc/html/draft-ietf-sshm-ssh-agent). If it exists, clients like step cli should load ssh keys into the agent it points to. At present, it is not wholeheartedly respected on Windows systems.

The existing code (in `internal/sshutil/agent_windows.go`) only includes logic to handle the existence of `SSH_AUTH_SOCK` in Unix-like environments (such as cygwin). The existing code uses Unix pipes to connect to the agent specified by this variable (which are only available in a unix-like environment).

This PR adds functionality such that if the environment variable `SSH_AUTH_SOCK` is defined (i.e. not empty), step cli will attempt to connect to the agent at the path it specified with a Named Windows Pipe. If the variable is not defined, it will continue to fall back to the OpenSSH Agent specific pipe (`\\.\\pipe\\openssh-ssh-agent`).

This feature is specifically important to me because I'd like to use the Pageant SSH Agent. Some other programs (like WinSCP) only support Pageant, so having a method of loading keys directly through `step` is important.

#### Is there documentation on how to use this feature? If so, where?

I've added appropriate error messages. Not sure if other documentation may need to be updated!

#### In what environments or workflows is this feature supported?

Non Unix-like Windows environments.

#### Supporting links/other PRs/issues:

- #333 is related and can probably be seen as a precursor to this. 
- #1186 and its related issue #1185 offers an alternate solution where an ssh config file is parsed for alternate agent paths. I think its reasonable that this PR and mine can co-exist.

💔Thank you!
