### PR TITLE
Improve local GoReleaser build process and development docs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,9 @@
 version: 2
 project_name: step
 
+# Enable GoReleaser OSS to read Pro configs: https://goreleaser.com/errors/version/#using-a-pro-configuration-file-with-goreleaser-oss
+pro: true 
+
 variables:
   packageName: step-cli
   packageRelease: 1 # Manually update release: in the nfpm section to match this value if you change this

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,7 +97,7 @@ nfpms:
   #
   - &NFPM
     id: packages
-    builds:
+    ids:
       - nfpm
     package_name: "{{ .Var.packageName }}"
     release: "1"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,7 +71,7 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-    builds:
+    ids:
       - default
     wrap_in_directory: "{{ .ProjectName }}_{{ .Version }}"
     files:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ builds:
     id: default
     env:
       - CGO_ENABLED=0
-    main: ./cmd/step/main.go
+    main: ./cmd/step
     flags:
       - -trimpath
     ldflags:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,7 +70,7 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Version }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ['zip']
     ids:
       - default
     wrap_in_directory: "{{ .ProjectName }}_{{ .Version }}"

--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,10 @@ GORELEASER_PRO_URL=https://github.com/goreleaser/goreleaser-pro/releases/latest/
 
 # Determine the hooks to skip. When using GoReleaser OSS with a Pro config, specifying "after"
 # to be skipped results in an error. When using GoReleaser Pro running the "goreleaser-local"
-# target both "post-hooks" and "after" are necessary required to skip the upload to GCP. The 
-# logic below checks the GoReleaser binary to be Pro or not, and then sets the steps to skip 
-# accordingly. It's possible this is a GoReleaser bug for the case where a Pro config is used 
-# with GoReleaser OSS.
+# target both "post-hooks" and "after" are required to skip the upload to GCP. The logic below 
+# checks the GoReleaser binary to be Pro or not, and then sets the steps to skip accordingly. 
+# It's possible this is a GoReleaser bug for the case where a Pro config is used with GoReleaser 
+# OSS.
 GORELEASER_OSS_SKIP=post-hooks
 GORELEASER_PRO_SKIP=post-hooks,after
 GORELEASER_SKIP=$(if $(filter true,$(shell goreleaser --version | grep -q goreleaser-pro && echo true || echo false)),$(GORELEASER_PRO_SKIP),$(GORELEASER_OSS_SKIP))

--- a/Makefile
+++ b/Makefile
@@ -139,20 +139,10 @@ goreleaser:
 	   	--snapshot \
 		--single-target \
 	   	--clean \
-		--output $(PREFIX)/$(BINNAME)
-
-goreleaser-local:
-	$Q mkdir -p $(PREFIX)
-	$Q $(GOOS_OVERRIDE) $(CGO_OVERRIDE) DEBUG=$(DEBUG) goreleaser build \
-		--id $(GORELEASER_BUILD_ID) \
-	   	--snapshot \
-		--single-target \
-	   	--clean \
 		--skip=$(GORELEASER_SKIP) \
 		--output $(PREFIX)/$(BINNAME)
 
-
-.PHONY: build goreleaser goreleaser-local
+.PHONY: build goreleaser
 
 
 #########################################

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,11 @@ ifeq ($(OS),Windows_NT)
 else
 	HOSTOS=$(shell uname)
 endif
+
 HOSTARCH=$(shell go env GOHOSTARCH)
+ifeq ($(HOSTARCH),amd64)
+       HOSTARCH=x86_64
+endif
 
 GORELEASER_PRO_URL=https://github.com/goreleaser/goreleaser-pro/releases/latest/download/goreleaser-pro_$(HOSTOS)_$(HOSTARCH).tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,16 @@ HOSTARCH=$(shell go env GOHOSTARCH)
 
 GORELEASER_PRO_URL=https://github.com/goreleaser/goreleaser-pro/releases/latest/download/goreleaser-pro_$(HOSTOS)_$(HOSTARCH).tar.gz
 
+# Determine the hooks to skip. When using GoReleaser OSS with a Pro config, specifying "after"
+# to be skipped results in an error. When using GoReleaser Pro running the "goreleaser-local"
+# target both "post-hooks" and "after" are necessary required to skip the upload to GCP. The 
+# logic below checks the GoReleaser binary to be Pro or not, and then sets the steps to skip 
+# accordingly. It's possible this is a GoReleaser bug for the case where a Pro config is used 
+# with GoReleaser OSS.
+GORELEASER_OSS_SKIP=post-hooks
+GORELEASER_PRO_SKIP=post-hooks,after
+GORELEASER_SKIP=$(if $(filter true,$(shell goreleaser --version | grep -q goreleaser-pro && echo true || echo false)),$(GORELEASER_PRO_SKIP),$(GORELEASER_OSS_SKIP))
+
 .PHONY: all
 
 #########################################
@@ -127,7 +137,18 @@ goreleaser:
 	   	--clean \
 		--output $(PREFIX)/$(BINNAME)
 
-.PHONY: build goreleaser
+goreleaser-local:
+	$Q mkdir -p $(PREFIX)
+	$Q $(GOOS_OVERRIDE) $(CGO_OVERRIDE) DEBUG=$(DEBUG) goreleaser build \
+		--id $(GORELEASER_BUILD_ID) \
+	   	--snapshot \
+		--single-target \
+	   	--clean \
+		--skip=$(GORELEASER_SKIP) \
+		--output $(PREFIX)/$(BINNAME)
+
+
+.PHONY: build goreleaser goreleaser-local
 
 
 #########################################

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Here's a quick example, combining `step oauth` and `step crypto` to get and veri
 
 * Connect with `step` users on [GitHub Discussions](https://github.com/smallstep/certificates/discussions) or [Discord](https://bit.ly/step-discord)
 * [Open an issue](https://github.com/smallstep/cli/issues/new/choose) and tell us what features you'd like to see
+* [Contribute](./docs/CONTRIBUTING.md) to the `step` codebase
 * [Follow Smallstep on Twitter](https://twitter.com/smallsteplabs)
 
 ## Further Reading

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,9 +7,11 @@ to manage issues, etc.
 
 ## Table of Contents
 
-* [Asking Support Questions](#asking-support-questions)
 * [Reporting Issues](#reporting-issues)
-* [Submitting Patches](#submitting-patches)
+* [Asking Support Questions](#asking-support-questions)
+* [Code Contribution](#code-contribution)
+  * [Local Development](#local-development)
+  * [Submitting Patches](#submitting-patches)
   * [Code Contribution Guidelines](#code-contribution-guidelines)
   * [Git Commit Message Guidelines](#git-commit-message-guidelines)
 
@@ -18,8 +20,7 @@ to manage issues, etc.
 If you believe you have found a defect in `step cli` or its
 documentation, use the GitHub [issue
 tracker](https://github.com/smallstep/cli/issues) to report the
-problem. When reporting the issue, please provide the version of `step
-cli` in use (`step version`) and your operating system.
+problem. When reporting the issue, please provide the version of `step` CLI in use (`step version`) and your operating system.
 
 ## Asking Support Questions
 
@@ -37,7 +38,11 @@ primitives and higher order resources.
 
 **Bug fixes are, of course, always welcome.**
 
-## Submitting Patches
+### Local Development
+
+Check out the [local development](./local-development.md) guide for instructions for working on the `step` CLI code.
+
+### Submitting Patches
 
 `step cli` welcomes all contributors and contributions. If you are
 interested in helping with the project, please reach out to us or, better yet,

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -15,6 +15,8 @@ To get started with local development, you will need three things:
 
 - Golang installed locally (instructions available
 [here](https://golang.org/doc/install)).
+  - We follow the general Go support timeline, meaning the latest two versions 
+  of Go are supported. See `go.mod` for the current minimum version.
 - A version of `make` available for usage of the `Makefile`.
 - The repository checked out in the appropriate location of your `$GOPATH`.
 
@@ -40,7 +42,7 @@ binary in the `bin` folder.
 ### Running Tests and Linting
 
 Now that you've installed any dependencies, you can run the tests and lint the
-code base simply by running `make`.
+codebase simply by running `make`.
 
 #### Unit Tests
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -62,15 +62,7 @@ make integration
 
 #### And coding style tests
 
-These tests apply the following `Go` linters to verify code style and formatting:
-
-* [deadcode](https://github.com/tsenart/deadcode)
-* [gofmt](https://golang.org/cmd/gofmt/)
-* [golint](https://github.com/golang/lint/golint)
-* [ineffassign](https://github.com/gordonklaus/ineffassign)
-* [metalinter](https://github.com/alecthomas/gometalinter)
-* [misspell](https://github.com/client9/misspell/cmd/misspell)
-* [vet](https://golang.org/cmd/vet/)
+The currently enabled linters are defined in our shared [golangci-lint config](https://raw.githubusercontent.com/smallstep/workflows/master/.golangci.yml)
 
 ```
 make lint

--- a/utils/cautils/token_flow_test.go
+++ b/utils/cautils/token_flow_test.go
@@ -91,8 +91,7 @@ func TestProvisionerPromptPrompts(t *testing.T) {
 		p2 := &provisioner.SCEP{Name: "scep"}
 
 		got, err := provisionerPrompt(clictx, []provisioner.Interface{p1, p2})
-		require.Nil(t, got)
-		require.ErrorContains(t, err, "error allocating terminal") // TODO(hs): would be nice to refactor to configurable output
+		require.Error(t, err) // TODO(hs): would be nice to refactor to configurable output, and catch specific error cases (again)
 		require.Nil(t, got)
 	})
 
@@ -158,7 +157,7 @@ func TestProvisionerPromptPrompts(t *testing.T) {
 		p2 := &provisioner.OIDC{Name: "oidc-2", ClientID: "client-id-1"}
 
 		got, err := provisionerPrompt(clictx, []provisioner.Interface{p1, p2})
-		require.ErrorContains(t, err, "error allocating terminal") // TODO(hs): would be nice to refactor to configurable output
+		require.Error(t, err) // TODO(hs): would be nice to refactor to configurable output, and catch specific error cases (again)
 		require.Nil(t, got)
 	})
 }


### PR DESCRIPTION
The `goreleaser` target has been adapted to allow for building CLI 
releases that are very similar to the ones that we release as part of 
our GitHub Actions release process. The target skips the hooks that 
trigger binaries to be pushed to GCP, allowing the release process to 
happen locally.

This PR also allows the GoReleaser process to be performed with
either its Pro or OSS version using a single config file.

Other changes in this PR:
- Updated documentation for contributing to the `step` codebase
- Replaced list of enabled linters with the current `golangci-lint` config
- Enabled git data to be embedded into binary
- Fixed some GoReleaser config deprecations
- Fixed the GoReleaser Pro download URL for AMD64 
- Fixed some test cases that failed when ran using `make test`

Example build using Pro:

```console
make goreleaser
  • by using this software you agree with its EULA, available at https://goreleaser.com/eula
  • running goreleaser v2.8.2
  • skipping after, post-hooks, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=ece761143dd381180c19ce41096e5f300c432601 branch=herman/goreleaser-improvements current_tag=v0.28.6 previous_tag=v0.28.5 dirty=false
    • pipe skipped or partially skipped              reason=validation is disabled
  • parsing tag
  • setting defaults
  • partial
    • adjusting environment                          by=target target=darwin_arm64 dist=dist/darwin_arm64
  • snapshotting
    • building snapshot...                           version=v0.28.6-next
  • running before hooks
    • running hook                                   hook=go mod download
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • partial build                                  filter=target=darwin_arm64_v8.0 matches=darwin_arm64_v8.0
    • building                                       binary=dist/darwin_arm64/default_darwin_arm64_v8.0/bin/step
  • setting up metadata
  • storing artifacts metadata
  • copying binary to "bin/step"
  • build succeeded after 3s
  • thanks for using GoReleaser Pro!
```

Example build using OSS:

```console
make goreleaser
  • your configuration specifies  pro: true
    explanation=
    │ Your configuration is for GoReleaser Pro.
    │ You are currently using GoReleaser OSS, so all the Pro-only features will be ignored.
    │ Use GoReleaser Pro to enable all the features.
  • skipping post-hooks and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=ece761143dd381180c19ce41096e5f300c432601 branch=herman/goreleaser-improvements current_tag=v0.28.6 previous_tag=v0.28.5 dirty=false
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • partial
  • snapshotting
    • building snapshot...                           version=v0.28.6-next
  • running before hooks
    • running                                        hook=go mod download
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • partial build                                  match=target=darwin_arm64_v8.0
    • building                                       binary=dist/default_darwin_arm64_v8.0/bin/step
  • writing artifacts metadata
  • copying binary to "bin/step"
  • build succeeded after 3s
  • thanks for using GoReleaser!
```