### PR TITLE
Use `envOrDefault` for `GPG_PRIVATE_KEY_FILE` environment variable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -133,10 +133,10 @@ nfpms:
       postremove: scripts/postremove.sh
     rpm:
       signature:
-          key_file: "{{ .Env.GPG_PRIVATE_KEY_FILE }}"
+          key_file: '{{ envOrDefault "GPG_PRIVATE_KEY_FILE" "ENV_VAR_GPG_PRIVATE_KEY_FILE_NOT_SET" }}'
     deb:
       signature:
-          key_file: "{{ .Env.GPG_PRIVATE_KEY_FILE }}"
+          key_file: '{{ envOrDefault "GPG_PRIVATE_KEY_FILE" "ENV_VAR_GPG_PRIVATE_KEY_FILE_NOT_SET" }}'
           type: origin
   -
     << : *NFPM


### PR DESCRIPTION
By using `envOrDefault` an issue is prevented in evaluating the template before a release is created. By setting the default value to `ENV_VAR_GPG_PRIVATE_KEY_FILE_NOT_SET`, this value is then shown in the error message at signing time.

The reason for changing this is so that it becomes possible to create local, unsigned (Linux package) releases when creating a release as follows:

 `goreleaser release --snapshot --clean --skip sign,after`

Before the change (see #1404):
```console
...
• linux packages
  ⨯ release failed after 6m39s               error=template: failed to apply "{{ .Env.GPG_PRIVATE_KEY_FILE }}": map has no entry for key "GPG_PRIVATE_KEY_FILE"
```

After (skipping `sign`):
```console
...
  • linux packages
    • creating                                       package=step-cli format=deb arch=arm64v8.0 file=dist/step-cli_0.28.6~next-1_arm64.deb
    • creating                                       package=step-cli format=rpm arch=arm64v8.0 file=dist/step-cli-0.28.6~next-1.aarch64.rpm
    • creating                                       package=step-cli format=rpm arch=amd64v1 file=dist/step-cli-0.28.6~next-1.x86_64.rpm
    • creating                                       package=step-cli format=deb arch=amd64v1 file=dist/step-cli_0.28.6~next-1_amd64.deb
    • creating                                       package=step-cli format=rpm arch=amd64v1 file=dist/step-cli_amd64.rpm
    • creating                                       package=step-cli format=deb arch=arm64v8.0 file=dist/step-cli_arm64.deb
    • creating                                       package=step-cli format=rpm arch=arm64v8.0 file=dist/step-cli_arm64.rpm
    • creating                                       package=step-cli format=deb arch=amd64v1 file=dist/step-cli_amd64.deb
...
  • storing artifacts metadata
  • release succeeded after 27s
  • thanks for using GoReleaser Pro!
```

After (not skipping `sign`):
```console
...
  • linux packages
    • creating                                       package=step-cli format=deb arch=arm64v8.0 file=dist/step-cli_0.28.6~next-1_arm64.deb
    • creating                                       package=step-cli format=deb arch=amd64v1 file=dist/step-cli_0.28.6~next-1_amd64.deb
    • creating                                       package=step-cli format=rpm arch=amd64v1 file=dist/step-cli-0.28.6~next-1.x86_64.rpm
    • creating                                       package=step-cli format=rpm arch=arm64v8.0 file=dist/step-cli-0.28.6~next-1.aarch64.rpm
  ⨯ release failed after 25s                 error=nfpm failed for step-cli-0.28.6~next-1.x86_64.rpm: failed to create signatures: call to signer failed: signing error: reading PGP key file: open ENV_VAR_GPG_PRIVATE_KEY_FILE_NOT_SET: no such file or directory
```

Note that it's still necessary to skip `after`, because that runs a script to upload artifacts to GCP. 

Currently GoReleaser Pro is required when performing `goreleaser release` (as opposed to `goreleaser build`), because it's (currently) not possible to skip `after` in OSS when using a Pro config (and not skipping it results in a failure to push to GCP when `gcloud` is not available, or not authenticated):

```console
  • your configuration specifies  pro: true
    explanation=
    │ Your configuration is for GoReleaser Pro.
    │ You are currently using GoReleaser OSS, so all the Pro-only features will be ignored.
    │ Use GoReleaser Pro to enable all the features.
  ⨯ release failed after 0s                  error=--skip=after is not allowed. Valid options for skip are [announce, archive, aur, aur-source, before, chocolatey, docker, homebrew, ko, nfpm, nix, notarize, publish, sbom, scoop, sign, snapcraft, validate, winget]
```