### PR TITLE
Prefer VerificationURIComplete if present

### DIFF
--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -892,6 +892,9 @@ func (o *oauth) DoDeviceAuthorization() (*token, error) {
 	}
 
 	switch {
+	case idr.VerificationURIComplete != "":
+		// Prefer VerificationURIComplete if present for user convenience
+		idr.VerificationURI = idr.VerificationURIComplete
 	case idr.VerificationURI != "":
 		// do nothing
 	case idr.VerificationURL != "":


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Prefer VerificationURIComplete if present

#### Pain or issue this feature alleviates:

In the OIDC Device Authorization Flow in command/oauth, present the user with VerificationURIComplete rather than VerificationURI if present, so that the user doesn't have to manually type the code when using an IdP that provides this feature.

#### Is there documentation on how to use this feature? If so, where?

No, the feature is automatically used if supported by the IdP

#### In what environments or workflows is this feature supported?

The OIDC Device Authorization Flow with an IdP that provides the `verification_uri_complete` parameter (e.g. Keycloak)

#### Supporting links/other PRs/issues:

Fixes #1424

💔Thank you!
