### PR TITLE
add jq to docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ ARG STEPGID=1000
 
 RUN apk update \
         && apk upgrade \
-        && apk add --no-cache bash curl tzdata \
+        && apk add --no-cache bash curl tzdata jq \
         && addgroup -g ${STEPGID} step \
         && adduser -D -u ${STEPUID} -G step step \
         && chown step:step /home/step

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -29,7 +29,7 @@ ARG STEPGID=1000
 
 RUN apt-get update \
         && apt-get upgrade -y \
-        && apt-get install -y --no-install-recommends curl \
+        && apt-get install -y --no-install-recommends curl jq \
         && addgroup --gid ${STEPGID} step \
         && adduser --disabled-password --uid ${STEPUID} --gid ${STEPGID} step \
         && chown step:step /home/step


### PR DESCRIPTION
* adds `jq` to installed packages for parsing `json` endpoints on **step-ca**

---

<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature: 

* improve dependencies

#### Pain or issue this feature alleviates: 

* adds the ability to parse `json` endpoints in step-ca (I'm building a step-cli / caddy pod so clients can always bootstrap)

#### Is there documentation on how to use this feature? If so, where?

* I'll probably add some more docs after I have it working well

#### In what environments or workflows is this feature supported? 

* containers

#### Supporting links/other PRs/issues:

so the current `fingerprint` can [always be queried](https://github.com/smallstep/certificates/discussions/449#discussioncomment-275657) from a container

💔Thank you!
