### PR TITLE
Fix: Ensure step ca rekey --daemon generates new keys as expected

### DIFF
--- a/command/ca/rekey.go
+++ b/command/ca/rekey.go
@@ -340,7 +340,10 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 		// Force is always enabled when daemon mode is used
 		ctx.Set("force", "true")
 		next := nextRenewDuration(leaf, expiresIn, rekeyPeriod)
-		return renewer.Daemon(outCert, next, expiresIn, rekeyPeriod, afterRekey)
+		rekeyFunc := func() error {
+			return renewer.RekeyAndWrite(ctx, outCert, outKey, givenPrivate, passFile, kmsURI)
+		}
+		return renewer.Daemon(outCert,next,expiresIn,rekeyPeriod, afterRekey, rekeyFunc)
 	}
 
 	// Do not rekey if (cert.notAfter - now) > (expiresIn + jitter)
@@ -353,27 +356,7 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 		}
 	}
 
-	var signer crypto.Signer
-	if givenPrivate == "" {
-		kty, crv, size, err := utils.GetKeyDetailsFromCLI(ctx, false, "kty", "curve", "size")
-		if err != nil {
-			return err
-		}
-		signer, err = keyutil.GenerateSigner(kty, crv, size)
-		if err != nil {
-			return err
-		}
-	} else {
-		opts := []pemutil.Options{pemutil.WithFilename(givenPrivate)}
-		if passFile != "" {
-			opts = append(opts, pemutil.WithPasswordFile(passFile))
-		}
-		signer, err = cryptoutil.CreateSigner(kmsURI, givenPrivate, opts...)
-		if err != nil {
-			return err
-		}
-	}
-	if _, err := renewer.Rekey(signer, outCert, outKey, ctx.IsSet("out-key") || givenPrivate == ""); err != nil {
+	if err := renewer.RekeyAndWrite(ctx, outCert, outKey, givenPrivate, passFile, kmsURI); err != nil {
 		return err
 	}
 
@@ -385,4 +368,30 @@ func rekeyCertificateAction(ctx *cli.Context) error {
 		ui.PrintSelected("Private Key", outKey)
 	}
 	return afterRekey()
+}
+func (r *renewer) RekeyAndWrite(ctx *cli.Context, outCert, outKey, givenPrivate, passFile, kmsURI string) error {
+	signer, err := generateSigner(ctx, givenPrivate, passFile, kmsURI)
+	if err != nil {
+		return err
+	}
+	if _, err := r.Rekey(signer, outCert, outKey, ctx.IsSet("out-key") || givenPrivate == ""); err != nil {
+		return err
+	}
+	return nil
+}
+
+func generateSigner(ctx *cli.Context, givenPrivate, passFile, kmsURI string) (crypto.Signer, error) {
+	if givenPrivate == "" {
+		kty, crv, size, err := utils.GetKeyDetailsFromCLI(ctx, false, "kty", "curve", "size")
+		if err != nil {
+			return nil, err
+		}
+		return keyutil.GenerateSigner(kty, crv, size)
+	} else {
+		opts := []pemutil.Options{pemutil.WithFilename(givenPrivate)}
+		if passFile != "" {
+			opts = append(opts, pemutil.WithPasswordFile(passFile))
+		}
+		return cryptoutil.CreateSigner(kmsURI, givenPrivate, opts...)
+	}
 }

--- a/command/ca/renew.go
+++ b/command/ca/renew.go
@@ -325,7 +325,7 @@ func renewCertificateAction(ctx *cli.Context) error {
 		// Force is always enabled when daemon mode is used
 		ctx.Set("force", "true")
 		next := nextRenewDuration(cert.Leaf, expiresIn, renewPeriod)
-		return renewer.Daemon(outFile, next, expiresIn, renewPeriod, afterRenew)
+		return renewer.Daemon(outFile, next, expiresIn, renewPeriod, afterRenew, nil)
 	}
 
 	// Do not renew if (cert.notAfter - now) > (expiresIn + jitter)
@@ -578,7 +578,7 @@ func (r *renewer) RenewAndPrepareNext(outFile string, expiresIn, renewPeriod tim
 	return next, nil
 }
 
-func (r *renewer) Daemon(outFile string, next, expiresIn, renewPeriod time.Duration, afterRenew func() error) error {
+func (r *renewer) Daemon(outFile string, next, expiresIn, renewPeriod time.Duration, afterRenew func() error, rekeyFunc func() error) error {
 	// Loggers
 	infoLog := log.New(os.Stdout, "INFO: ", log.LstdFlags)
 	errLog := log.New(os.Stderr, "ERROR: ", log.LstdFlags)
@@ -600,6 +600,11 @@ func (r *renewer) Daemon(outFile string, next, expiresIn, renewPeriod time.Durat
 				} else if err := afterRenew(); err != nil {
 					errLog.Println(err)
 				}
+				if rekeyFunc != nil {
+					if err := rekeyFunc(); err != nil {
+						errLog.Println(err)
+					}
+				}
 			case syscall.SIGINT, syscall.SIGTERM:
 				return nil
 			}
@@ -608,6 +613,11 @@ func (r *renewer) Daemon(outFile string, next, expiresIn, renewPeriod time.Durat
 				errLog.Println(err)
 			} else if err := afterRenew(); err != nil {
 				errLog.Println(err)
+			}
+			if rekeyFunc != nil {
+				if err := rekeyFunc(); err != nil {
+					errLog.Println(err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
Rekeying with new private key in daemon mode

#### Description
This PR fixes [#1343](https://github.com/smallstep/cli/issues/1343) where `step ca rekey` with the `--daemon` flag was not generating new keys on renewal — behaving like step ca renew instead.

#### Pain or issue this feature alleviates:
Previously, running `step ca rekey ... --daemon` would renew the certificate without generating a new key, defeating the purpose of rekeying. This fixes that behavior.

#### Why is this important to the project (if not answered above):
It ensures rekeying in daemon mode actually rotates the private key, aligning with user expectations and the behavior of one-shot rekeying.

#### Is there documentation on how to use this feature? If so, where?
Yes

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:
Fixes: #1343

💔Thank you!
