### PR TITLE
Fix testscript `RunMain` deprecation

### DIFF
--- a/cmd/step/main.go
+++ b/cmd/step/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-
 	"github.com/smallstep/certificates/ca"
 	"github.com/smallstep/cli-utils/step"
 
@@ -27,5 +25,5 @@ func init() {
 }
 
 func main() {
-	os.Exit(cmd.Run())
+	cmd.Run()
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
-	github.com/rogpeppe/go-internal v1.13.1
+	github.com/rogpeppe/go-internal v1.14.1
 	github.com/slackhq/nebula v1.9.5
 	github.com/smallstep/assert v0.0.0-20200723003110-82e2b9b3b262
 	github.com/smallstep/certificates v0.28.3

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/redis/go-redis/v9 v9.8.0 h1:q3nRvjrlge/6UD7eTu/DSg2uYiU2mCL0G/uzBWqhicI=
 github.com/redis/go-redis/v9 v9.8.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
-github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
-github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=

--- a/integration/shared_test.go
+++ b/integration/shared_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"os"
 	"testing"
 
 	"github.com/rogpeppe/go-internal/testscript"
@@ -10,7 +9,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	os.Exit(testscript.RunMain(m, map[string]func() int{
+	testscript.Main(m, map[string]func(){
 		"step": cmd.Run, // main entrypoint name
-	}))
+	})
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -43,14 +43,18 @@ import (
 	_ "github.com/smallstep/cli/command/ssh"
 )
 
-func Run() int {
+func Run() {
+	os.Exit(run())
+}
+
+func run() int {
+	defer panicHandler()
+
 	// initialize step environment.
 	if err := step.Init(); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		return 1
 	}
-
-	defer panicHandler()
 
 	// create new instance of app
 	app := newApp(os.Stdout, os.Stderr)


### PR DESCRIPTION
See https://github.com/rogpeppe/go-internal/pull/281.

Replaces https://github.com/smallstep/cli/pull/1444.