### PR TITLE
Fix Makefile for `darwin/amd64` -targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ binary-darwin-amd64:
 	$(call BUNDLE_MAKE,darwin,amd64,,$(BINARY_OUTPUT)darwin-amd64)
 
 binary-darwin-arm64:
-	$(call BUNDLE_MAKE,darwin,amd64,,$(BINARY_OUTPUT)darwin-arm64)
+	$(call BUNDLE_MAKE,darwin,arm64,,$(BINARY_OUTPUT)darwin-arm64)
 
 binary-windows-amd64:
 	$(call BUNDLE_MAKE,windows,amd64,,$(BINARY_OUTPUT)windows-amd64)


### PR DESCRIPTION
Closes #1461

Makefile contained a an apparent typo.


### Tested on

* go version go1.24.5 darwin/arm64
* GNU Make 3.81
* macOS 15.5
