### PR TITLE
Do not require client authentication if not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Do not create an identity token if it's not enabled (smallstep/cli#1495).
+
 ### Deprecated
 
 ### Removed

--- a/command/ssh/ssh.go
+++ b/command/ssh/ssh.go
@@ -187,6 +187,15 @@ func loginOnUnauthorized(ctx *cli.Context) (ca.RetryFunc, error) {
 			return false
 		}
 
+		// Check if client authentication is required.
+		version, err := client.Version()
+		if err != nil {
+			return fail(err)
+		}
+		if !version.RequireClientAuthentication {
+			return false
+		}
+
 		// Generate OIDC token
 		tok, err := flow.GenerateIdentityToken(ctx)
 		if err != nil {


### PR DESCRIPTION
This commit removes the creation of an identity certificate when we get an unauthorized response if the client authentication is not enabled.
