### PR TITLE
Fixes #1543

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,14 +51,10 @@ builds:
     binary: bin/step
   -
     # This build is specifically for nFPM targets (.deb and .rpm files).
-    # It's exactly the same as the default build above, except:
-    # - it only builds the archs we want to produce .deb and .rpm files for
-    # - the name of the output binary is step-cli
+    # It's exactly the same as the default build above, except the binary is
+    # named step-cli. It inherits all Linux targets from the default build.
     << : *BUILD
     id: nfpm
-    targets:
-      - linux_amd64
-      - linux_arm64
     binary: step-cli
 
 archives:


### PR DESCRIPTION
Fixes #1543

By removing `targets:` from the `nfpm` build section entirely, it will inherit the top-level build `targets` in `.goreleaser.yml`.

This will mean creating rpms and debs for 386, amd64, arm64, arm_5, arm_6, arm_7, mips, mips64, and ppc64le.
