### PR TITLE
Suppress messages on needs-renewal commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ---
 
+## [x.y.z] - TBD
+
+### Changed
+
+- Suppress output messages for `step certificate needs-renewal` and `step ssh
+  needs-renewal` commands when certificates don't need renewal. Use the
+  `--verbose` flag to always show messages regardless of renewal status
+  (smallstep/cli#1548).
+
 ## [0.29.0] - 2025-12-02
 
 ### Added

--- a/command/certificate/needsRenewal.go
+++ b/command/certificate/needsRenewal.go
@@ -60,7 +60,7 @@ $ step certificate needs-renewal ./certificate.crt --bundle
 '''
 
 Check if the leaf certificate provided by smallstep.com has passed 66 percent
-of its vlaidity period:
+of its validity period:
 '''
 $ step certificate needs-renewal https://smallstep.com
 '''
@@ -234,5 +234,11 @@ func isVerboseExit(needsRenewal, isVerbose bool) error {
 		}
 		return nil
 	}
-	return errs.NewExitError(errors.Errorf("certificate does not need renewal"), 1)
+
+	if isVerbose {
+		return errs.NewExitError(errors.Errorf("certificate does not need renewal"), 1)
+	}
+
+	// urfave/cli won't show any message
+	return cli.NewExitError("", 1)
 }

--- a/command/ssh/needsRenewal.go
+++ b/command/ssh/needsRenewal.go
@@ -172,5 +172,11 @@ func isVerboseExit(needsRenewal, isVerbose bool) error {
 		}
 		return nil
 	}
-	return errs.NewExitError(errors.Errorf("certificate does not need renewal"), 1)
+
+	if isVerbose {
+		return errs.NewExitError(errors.Errorf("certificate does not need renewal"), 1)
+	}
+
+	// urfave/cli won't show any message
+	return cli.NewExitError("", 1)
 }


### PR DESCRIPTION
This commit suppresses the message "certificate does not need renewal" on the `step certificate needs-renewal` and `step ssh needs-renewal` unless the `--verbose` flag is passed.

Fixes PRO-320