### PR TITLE
Add linux_s390x target to goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,6 +45,7 @@ builds:
       - linux_arm_7
       - linux_mips
       - linux_mips64
+      - linux_s390x
       - linux_ppc64le
       - windows_amd64
       - windows_arm64


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Add binaries for Linux S390x 

#### Pain or issue this feature alleviates:

#### Why is this important to the project (if not answered above):
I'm unable to use step cli when running Ubuntu on s390x hardware

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
