### PR TITLE
Fix broken link in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,7 +40,7 @@ primitives and higher order resources.
 
 ### Local Development
 
-Check out the [local development](./local-development.md) guide for instructions for working on the `step` CLI code.
+Check out the [local development](./docs/local-development.md) guide for instructions for working on the `step` CLI code.
 
 ### Submitting Patches
 


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
Fix the link to the local development page in CONTRIBUTING.md
#### Pain or issue this feature alleviates:

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
