### PR TITLE
Add least-privilege permissions to triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -10,6 +10,10 @@ on:
       - opened
       - reopened
 
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   triage:
     uses: smallstep/workflows/.github/workflows/triage.yml@main


### PR DESCRIPTION
## Summary

- Add explicit `permissions:` block (`pull-requests: write`, `issues: write`) to the triage workflow that triggers on `pull_request_target`, constraining the `GITHUB_TOKEN` to only the scopes actually needed

Ref: [StepSecurity hackerbot-claw analysis](https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation)

## Test plan

- [ ] Verify triage workflow still labels PRs and adds to project board on next external PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)