### PR TITLE
Use `golangci-lint` `v2.10.1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,5 @@ jobs:
     with:
       only-latest-golang: false
       run-codeql: true
+      golangci-lint-version: "v2.10.1"
     secrets: inherit


### PR DESCRIPTION
A potential solution to CI hanging with `golangci-lint` `v2.11.x` is to use the last `v2.10.1` for now. 