### PR TITLE
Add `nolint` exclusion on `authority.WithProvisioner` usage

### DIFF
--- a/command/ca/provisioner/caConfigClient.go
+++ b/command/ca/provisioner/caConfigClient.go
@@ -93,7 +93,7 @@ func newCaConfigClient(ctx context.Context, cfg *config.Config, cfgFile string) 
 		}
 	}
 	a, err := authority.New(cfg, authority.WithAdminDB(newNoDB()),
-		authority.WithSkipInit(), authority.WithProvisioners(provClxn))
+		authority.WithSkipInit(), authority.WithProvisioners(provClxn)) //nolint:staticcheck // TODO: WithProvisioners has been deprecated, temporarily do not lint this line.
 	if err != nil {
 		return nil, errors.Wrapf(err, "error loading authority")
 	}


### PR DESCRIPTION
Undoes the change in #1587. 

@dopey not sure what's going on here (yet). After merging https://github.com/smallstep/cli/pull/1430 it seems to have failed. It also did in the merge before that. It did not in https://github.com/smallstep/cli/actions/runs/22926902099/job/66539409429, which also uses `v2.10.1`. On merging #1587, the regular linting process completed, but when it was triggered after tagging it failed. I've definitely seen this type of flapping before. Some caching going on, and analysis happening on a non-current version of the code, somehow?

If anything, the `nolint` seems necessary, as I don't see any indication that `staticcheck` was removed from earlier/later versions. If it flaps again, we maybe can add `nolintlint` as an exclusion too as a workaround.