### PR TITLE
Skip printing user code when verification URI already includes it

### DIFF
--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -891,10 +891,12 @@ func (o *oauth) DoDeviceAuthorization() (*token, error) {
 		return nil, errors.Wrap(err, "failure decoding device authz response to JSON")
 	}
 
+	shouldPrintCode := true
 	switch {
 	case idr.VerificationURIComplete != "":
 		// Prefer VerificationURIComplete if present for user convenience
 		idr.VerificationURI = idr.VerificationURIComplete
+		shouldPrintCode = false
 	case idr.VerificationURI != "":
 		// do nothing
 	case idr.VerificationURL != "":
@@ -909,8 +911,12 @@ func (o *oauth) DoDeviceAuthorization() (*token, error) {
 		idr.Interval = defaultDeviceAuthzInterval
 	}
 
-	fmt.Fprintf(os.Stderr, "Visit %s and enter the code:\n", idr.VerificationURI)
-	fmt.Fprintln(os.Stderr, idr.UserCode)
+	if shouldPrintCode {
+		fmt.Fprintf(os.Stderr, "Visit %s and enter the code:\n", idr.VerificationURI)
+		fmt.Fprintln(os.Stderr, idr.UserCode)
+	} else {
+		fmt.Fprintf(os.Stderr, "Visit %s:\n", idr.VerificationURI)
+	}
 
 	// Poll the Token endpoint until the user completes the flow.
 	data = url.Values{}


### PR DESCRIPTION
When VerificationURIComplete is present in the device authorization response, the user code is already embedded in the URI. Printing the code separately is redundant and potentially confusing.

This suppresses the code prompt in that case and shows only the complete URI.

This is related to https://github.com/smallstep/cli/pull/1430, and the behavior is in line with `kubelogin`

Also see https://github.com/smallstep/cli/pull/1430#issuecomment-4039005316.

Change-Type: behavior
Release-Note: yes
Audience: user
Impact: low
Breaking: false
