### PR TITLE
Bump certinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Support for inspecting certificates with post-quantum algorithms ML-DSA and
+  SLH-DSA (smallstep/certinfo#69).
+
 ### Changed
 
 ### Deprecated

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/slackhq/nebula v1.10.3
 	github.com/smallstep/assert v0.0.0-20200723003110-82e2b9b3b262
 	github.com/smallstep/certificates v0.30.2
-	github.com/smallstep/certinfo v1.15.0
+	github.com/smallstep/certinfo v1.16.0
 	github.com/smallstep/cli-utils v0.12.2
 	github.com/smallstep/go-attestation v0.4.4-0.20241119153605-2306d5b464ca
 	github.com/smallstep/linkedca v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,8 @@ github.com/smallstep/assert v0.0.0-20200723003110-82e2b9b3b262 h1:unQFBIznI+VYD1
 github.com/smallstep/assert v0.0.0-20200723003110-82e2b9b3b262/go.mod h1:MyOHs9Po2fbM1LHej6sBUT8ozbxmMOFG+E+rx/GSGuc=
 github.com/smallstep/certificates v0.30.2 h1:1G3xBi8sJ740iA1mMPW2Svv7EIZKJ4Zf/iQtA5QlN0Y=
 github.com/smallstep/certificates v0.30.2/go.mod h1:oyaE/aEYUGDr+YiCZLAxxP22bOQqcSHTeDgp8Vv2rlY=
-github.com/smallstep/certinfo v1.15.0 h1:oxvuOr6KvwuXjgyg+gJEUJW6Gz9pm4uAGQ5tirpmTHg=
-github.com/smallstep/certinfo v1.15.0/go.mod h1:t5s4J23P3B/j68l2efuJFSZqCj0kBU8sa2FYbHRaffw=
+github.com/smallstep/certinfo v1.16.0 h1:ZxDI9EDmCh4B/j9YtlTk/6ut+H/Gi0N3d0TwHv7F2YY=
+github.com/smallstep/certinfo v1.16.0/go.mod h1:OPwtFVAOx29OjOYsVtj9cDliDFywkVYPt+ExDg43kPs=
 github.com/smallstep/cli-utils v0.12.2 h1:lGzM9PJrH/qawbzMC/s2SvgLdJPKDWKwKzx9doCVO+k=
 github.com/smallstep/cli-utils v0.12.2/go.mod h1:uCPqefO29goHLGqFnwk0i8W7XJu18X3WHQFRtOm/00Y=
 github.com/smallstep/go-attestation v0.4.4-0.20241119153605-2306d5b464ca h1:VX8L0r8vybH0bPeaIxh4NQzafKQiqvlOn8pmOXbFLO4=


### PR DESCRIPTION
This commit bumps certinfo, the new version adds support for post-quantum algorithms.
