### PR TITLE
Add --token-file flag to step ca certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add `--token-file` flag to `step ca certificate` to read the token from a file.
 - Support for inspecting certificates with post-quantum algorithms ML-DSA and
   SLH-DSA (smallstep/certinfo#69).
 

--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/smallstep/cli/flags"
 	"github.com/smallstep/cli/token"
+	"github.com/smallstep/cli/utils"
 	"github.com/smallstep/cli/utils/cautils"
 )
 
@@ -182,6 +183,10 @@ multiple SANs. The '--san' flag and the '--token' flag are mutually exclusive.`,
 				Usage: "The directory where TPM keys and certificates will be stored",
 				Value: filepath.Join(step.Path(), "tpm"),
 			},
+			cli.StringFlag{
+				Name:  "token-file",
+				Usage: "The path to a <file> containing the one time token.",
+			},
 			flags.TemplateSet,
 			flags.TemplateSetFile,
 			flags.CaConfig,
@@ -232,19 +237,30 @@ func certificateAction(ctx *cli.Context) error {
 	crtFile, keyFile := args.Get(1), args.Get(2)
 
 	tok := ctx.String("token")
+	tokenFile := ctx.String("token-file")
 	offline := ctx.Bool("offline")
 	sans := ctx.StringSlice("san")
 
 	switch {
+	case tok != "" && tokenFile != "":
+		return errs.IncompatibleFlagWithFlag(ctx, "token", "token-file")
 	case offline && tok != "":
-		// offline and token are incompatible because the token is generated before
-		// the start of the offline CA.
 		return errs.IncompatibleFlagWithFlag(ctx, "offline", "token")
+	case offline && tokenFile != "":
+		return errs.IncompatibleFlagWithFlag(ctx, "offline", "token-file")
 	case ctx.String("attestation-uri") != "" && ctx.String("kms") != "":
 		// attestation-uri and kms are incompatible because the ACME-DA flow
 		// expects all necessary parameters in the attestation-uri, and having
 		// both can be confusing.
 		return errs.IncompatibleFlagWithFlag(ctx, "attestation-uri", "kms")
+	}
+
+	if tokenFile != "" {
+		b, err := utils.ReadFile(tokenFile)
+		if err != nil {
+			return err
+		}
+		tok = strings.TrimSpace(string(b))
 	}
 
 	// certificate flow unifies online and offline flows on a single api

--- a/command/ca/certificate.go
+++ b/command/ca/certificate.go
@@ -185,7 +185,7 @@ multiple SANs. The '--san' flag and the '--token' flag are mutually exclusive.`,
 			},
 			cli.StringFlag{
 				Name:  "token-file",
-				Usage: "The path to a <file> containing the one time token.",
+				Usage: "The path to a <file> containing the one time token. Mutually exclusive with '--token' and '--offline'; for JWK tokens it is effectively incompatible with '--san' because SANs are taken from the token.",
 			},
 			flags.TemplateSet,
 			flags.TemplateSetFile,


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:
Add `--token-file` flag to the `step ca certificate` command.

#### Pain or issue this feature alleviates:
It alleviates the need to manage tokens via STDOUT/STDIN or cumbersome shell variables when automating certificate issuance. `step ca token` already supports writing to disk via `--output-file`, but `step ca certificate` lacked a matching parameter to read that token back from disk.

#### Why is this important to the project (if not answered above):
It brings consistency between the `token` and `certificate` commands, providing a much cleaner UX for programmatic scripted workflows that rely on creating a token in one step and using it in another.

#### Is there documentation on how to use this feature? If so, where?
Addition is noted in CHANGELOG.md and documented in CLI Usage/help 

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?
Logically incompatible with the '--token' and '--offline' flag. Command will return Error
#### Supporting links/other PRs/issues:
https://github.com/smallstep/cli/issues/1435
Fixes #1435 
💔Thank you!
