### PR TITLE
gh: aligned workflow permissions with smallstep/workflows#324

### DIFF
--- a/.github/workflows/actionci.yml
+++ b/.github/workflows/actionci.yml
@@ -16,6 +16,7 @@ jobs:
   actionci:
     permissions:
       contents: read
+      actions: read
       security-events: write
     uses: smallstep/workflows/.github/workflows/actionci.yml@main
     secrets: inherit

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,8 +2,7 @@ name: Dependabot auto-merge
 on: pull_request
 
 permissions:
-  contents: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   dependabot-auto-merge:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
     needs: create_release
     permissions:
       id-token: write
-      contents: write
+      contents: read
     uses: smallstep/workflows/.github/workflows/docker-buildx-push.yml@main
     with:
       platforms: linux/amd64,linux/386,linux/arm,linux/arm64
@@ -100,7 +100,7 @@ jobs:
     needs: create_release
     permissions:
       id-token: write
-      contents: write
+      contents: read
     uses: smallstep/workflows/.github/workflows/docker-buildx-push.yml@main
     with:
       platforms: linux/amd64,linux/386,linux/arm,linux/arm64

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -11,7 +11,6 @@ on:
       - reopened
 
 permissions:
-  pull-requests: write
   issues: write
 
 jobs:


### PR DESCRIPTION
This PR amends the workflows configuration to be more inline with smallstep/workflows#324.

It additionally addresses the following:

1. Relaxes the `dependabot-auto-merge.yml` permissions, since the called workflow no longer needs `contents: write` or `pull-requests: write`.
2. Drops `pull-requests: write` from `triage.yml`, since the called workflow only labels via the issues API.
3. Relaxes `contents: write` to `contents: read` on the `build_upload_docker` and `build_upload_docker_debian` jobs in `release.yml`.
