### PR TITLE
Fix proxycommand hang when server closes before stdin closes

### DIFF
--- a/command/ssh/proxycommand.go
+++ b/command/ssh/proxycommand.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -228,6 +227,10 @@ func getBastion(ctx *cli.Context, user, host string) (*api.SSHBastionResponse, e
 }
 
 func proxyDirect(host, port string) error {
+	return proxyDirectWithIO(host, port, os.Stdin, os.Stdout)
+}
+
+func proxyDirectWithIO(host, port string, stdin io.Reader, stdout io.Writer) error {
 	address := net.JoinHostPort(host, port)
 	addr, err := net.ResolveTCPAddr("tcp", address)
 	if err != nil {
@@ -238,22 +241,25 @@ func proxyDirect(host, port string) error {
 	if err != nil {
 		return errors.Wrapf(err, "error connecting to %s", address)
 	}
+	defer conn.Close()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	// Return as soon as either direction finishes. Waiting for both can
+	// deadlock when the server closes the connection while stdin stays open.
+	// See smallstep/cli#1641. Buffered so the slower goroutine never blocks
+	// sending after we've stopped receiving.
+	done := make(chan struct{}, 2)
 	go func() {
-		io.Copy(conn, os.Stdin)
+		io.Copy(conn, stdin)
 		conn.CloseWrite()
-		wg.Done()
+		done <- struct{}{}
 	}()
-	wg.Add(1)
 	go func() {
-		io.Copy(os.Stdout, conn)
+		io.Copy(stdout, conn)
 		conn.CloseRead()
-		wg.Done()
+		done <- struct{}{}
 	}()
 
-	wg.Wait()
+	<-done
 	return nil
 }
 

--- a/command/ssh/proxycommand_test.go
+++ b/command/ssh/proxycommand_test.go
@@ -1,0 +1,55 @@
+package ssh
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test_proxyDirectWithIO_serverClosesBeforeStdin reproduces smallstep/cli#1641:
+// when the server closes the connection before the client has closed stdin, the
+// proxycommand must still return promptly. Previously it would block in
+// wg.Wait() forever because the stdin->conn goroutine stayed blocked reading a
+// stdin that never reaches EOF (the ssh client keeps it open until the
+// proxycommand exits).
+func Test_proxyDirectWithIO_serverClosesBeforeStdin(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	// Server sends some data and immediately closes the connection.
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		conn.Write([]byte("hello"))
+		conn.Close()
+	}()
+
+	host, port, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+
+	// stdin that never reaches EOF, simulating the ssh client keeping the
+	// proxycommand's stdin open for the lifetime of the session.
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close() // write end intentionally left open during the call
+
+	var stdout bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- proxyDirectWithIO(host, port, stdinR, &stdout)
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+		require.Equal(t, "hello", stdout.String())
+	case <-time.After(5 * time.Second):
+		t.Fatal("proxyDirectWithIO did not return after the server closed the connection")
+	}
+}


### PR DESCRIPTION
Fixes #1641 · Linear: PRE-124

## Problem

`step ssh proxycommand` hangs ~60s when the SSH server closes the connection before the client has closed stdin — e.g. when the server rejects the session mid-stream (PAM account check fails after cert auth succeeds).

The deadlock is in `proxyDirect`: it spawns two copy goroutines and `wg.Wait()`s for **both**. When the server closes, the `conn→stdout` goroutine returns, but the `stdin→conn` goroutine stays blocked reading `os.Stdin` — which never reaches EOF because the SSH client holds the proxycommand's stdin open until the proxycommand exits. Neither side gives, so `wg.Wait()` blocks until an OS-level timeout reaps the process.

## Fix

Return as soon as **either** direction finishes instead of waiting for both. For a proxycommand there's nothing left to do once one half of the SSH transport closes — returning lets the process exit and the OS reclaim the still-blocked goroutine. Replaced the `sync.WaitGroup` with a buffered `done` channel + `<-done`, and added `defer conn.Close()` so the surviving copy goroutine is also unblocked on the way out.

## Testing

Extracted a testable `proxyDirectWithIO(host, port, stdin, stdout)` and added `Test_proxyDirectWithIO_serverClosesBeforeStdin`: a TCP server that sends data then closes, with a stdin that never EOFs. Verified it hangs the full timeout against the old logic (RED) and returns promptly after the fix (GREEN, race-clean). `go build ./...`, `go vet`, and the full `command/ssh` package pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
