### PR TITLE
Restore pull-requests: write permission in triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   triage:


### PR DESCRIPTION
Commit 527b8bd removed this permission, but the reusable
smallstep/workflows triage.yml still requires it for the
label-pr job — causing a startup_failure on every PR open event.

Change-Type: ci
Release-Note: no
Audience: internal
Impact: none
Breaking: false
Co-Authored-By: Claude <noreply@anthropic.com>
