### PR TITLE
Fix release workflow to work with immutable releases setting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
-          draft: false
+          draft: true
           prerelease: ${{ steps.is_prerelease.outputs.IS_PRERELEASE }}
 
   goreleaser:


### PR DESCRIPTION
A repo setting change enabled immutable releases, which prevents uploading assets to a release once it's published. Creating the release as a draft lets goreleaser upload all assets first, then publish as its final step.

## Root cause

The "Restrict version tags" ruleset added in April 2026 protects `v*` tags. GitHub treats the associated release as immutable once published — asset uploads return `422 Cannot upload assets to an immutable release`. This broke the release workflow starting with v0.30.3.

## Fix

Change the `create_release` step to create the GitHub release as a draft (`draft: true`). Goreleaser finds the draft, uploads all assets, then publishes the release as its final step. Goreleaser already always uploads to a draft internally before publishing, so no goreleaser config changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)