### PR TITLE
jwe encrypt: add --password-file flag for PBES2

### DIFF
--- a/command/crypto/jwe/encrypt.go
+++ b/command/crypto/jwe/encrypt.go
@@ -22,7 +22,8 @@ func encryptCommand() cli.Command {
 		Usage:  "encrypt a payload using JSON Web Encryption (JWE)",
 		UsageText: `**step crypto jwe encrypt**
 [**--alg**=<key-enc-algorithm>] [**--enc**=<content-enc-algorithm>]
-[**--key**=<file>] [**--jwks**=<jwks>] [**--kid**=<kid>]`,
+[**--key**=<file>] [**--jwks**=<jwks>] [**--kid**=<kid>]
+[**--password-file**=<file>]`,
 		Description: `**step crypto jwe encrypt** encrypts a payload using JSON Web Encryption
 (JWE). By default, the payload to encrypt is read from STDIN and the JWE data
 structure will be written to STDOUT.
@@ -150,6 +151,10 @@ applications where more than one JWE payload type may be present. This
 parameter is ignored by JWE implementations, but may be processed by
 applications that use JWE.`,
 			},
+			cli.StringFlag{
+				Name:  "password-file",
+				Usage: `The path to the <file> containing the password to encrypt the keys.`,
+			},
 			flags.SubtleHidden,
 		},
 	}
@@ -187,6 +192,7 @@ func encryptAction(ctx *cli.Context) error {
 	kid := ctx.String("kid")
 	typ := ctx.String("typ")
 	cty := ctx.String("cty")
+	passwordFile := ctx.String("password-file")
 	isSubtle := ctx.Bool("subtle")
 
 	switch {
@@ -224,7 +230,17 @@ func encryptAction(ctx *cli.Context) error {
 	case jwks != "":
 		jwk, err = jose.ReadKeySet(jwks, options...)
 	case isPBES2:
-		pbes2Key, err = ui.PromptPassword("Please enter the password to encrypt the content encryption key")
+		var password string
+		if passwordFile != "" {
+			password, err = utils.ReadStringPasswordFromFile(passwordFile)
+			if err != nil {
+				return err
+			}
+		}
+		pbes2Key, err =
+			ui.PromptPassword(
+				"Please enter the password to encrypt the content encryption key",
+				ui.WithValue(password))
 	default:
 		return errs.RequiredOrFlag(ctx, "key", "jwks")
 	}


### PR DESCRIPTION
## Problem

`step crypto jwe decrypt` accepts `--password-file`, but `step crypto jwe encrypt` does not. Both commands support the PBES2 password-based key algorithms (`PBES2-HS256+A128KW`, `PBES2-HS384+A192KW`, `PBES2-HS512+A256KW`), where the password *is* the key material. Because encrypt could only read the password interactively from the TTY, encrypting with a shared password was impossible to automate — even though decrypting already was.

## Fix

Mirror the existing decrypt implementation:

- Add a `--password-file` flag to `jwe encrypt`.
- In the PBES2 branch, read the password from the file via `utils.ReadStringPasswordFromFile` and seed the prompt with `ui.WithValue(...)`. When the flag is omitted, behavior is unchanged (interactive prompt).
- Advertise the flag in the command `UsageText`.

This parallels `command/crypto/jwe/decrypt.go` exactly. No tests were added because the `jwe` command package has no existing unit or integration tests to parallel.

## Testing

Manual round-trip, fully non-interactive:

```
$ printf 'hunter2' > pw.txt
$ echo "The message" | step crypto jwe encrypt --alg PBES2-HS256+A128KW --password-file pw.txt > msg.json
$ step crypto jwe decrypt --password-file pw.txt < msg.json
The message
```

`go build ./...` and `go vet ./command/crypto/jwe/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)