### PR TITLE
Redact KMS URI secrets from plugin error output

### DIFF
--- a/internal/cryptoutil/cryptoutil.go
+++ b/internal/cryptoutil/cryptoutil.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -216,14 +217,30 @@ type kmsPublicKey struct {
 	kms, key string
 }
 
+// sensitiveURIParams matches the KMS URI attributes whose values are
+// credentials: pin-value (yubikey, pkcs11, capi), management-key (yubikey),
+// and client-secret (azurekms). The value runs until the next URI delimiter
+// (";", "&", "?"), whitespace (an argv or word boundary), or a double quote (a
+// Go-quoted prose boundary), so redaction leaves the surrounding command line
+// and error text intact.
+var sensitiveURIParams = regexp.MustCompile(`(?i)\b(pin-value|management-key|client-secret)=[^;&?\s"]*`)
+
+// redactSecrets replaces the values of sensitive KMS URI attributes in s with
+// "REDACTED", so that a command line or its output can be embedded in an error
+// message without disclosing PINs or other credentials.
+func redactSecrets(s string) string {
+	return sensitiveURIParams.ReplaceAllString(s, "${1}=REDACTED")
+}
+
 // exitError returns the error displayed on stderr after running the given
-// command.
+// command, with the values of sensitive KMS URI attributes redacted.
 func exitError(cmd *exec.Cmd, err error) error {
+	command := redactSecrets(cmd.String())
 	var ee *exec.ExitError
 	if errors.As(err, &ee) {
-		return fmt.Errorf("command %q failed with:\n%s", cmd.String(), ee.Stderr)
+		return fmt.Errorf("command %q failed with:\n%s", command, redactSecrets(string(ee.Stderr)))
 	}
-	return fmt.Errorf("command %q failed with: %w", cmd.String(), err)
+	return fmt.Errorf("command %q failed with: %w", command, err)
 }
 
 // newKMSSigner creates a signer using `step-kms-plugin` as the signer.

--- a/internal/cryptoutil/cryptoutil_test.go
+++ b/internal/cryptoutil/cryptoutil_test.go
@@ -1,0 +1,95 @@
+package cryptoutil
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExitErrorRedactsCommandLine(t *testing.T) {
+	cmd := exec.Command("step-kms-plugin", "sign", "--format", "base64",
+		"--kms", "yubikey:serial=7654321;pin-value=123456;management-key=010203040506070801020304050607080102030405060708",
+		"yubikey:slot-id=9c;pin-value=positional-pin")
+	ee := &exec.ExitError{
+		ProcessState: &os.ProcessState{},
+		Stderr:       []byte("Error: command failed: smart card error 6982: security status not satisfied"),
+	}
+
+	err := exitError(cmd, ee)
+	require.Error(t, err)
+
+	s := err.Error()
+	assert.NotContains(t, s, "123456")
+	assert.NotContains(t, s, "010203040506070801020304050607080102030405060708")
+	// A secret can appear in a positional argument too: --attestation-uri is
+	// passed as both the --kms value and the positional key argument.
+	assert.NotContains(t, s, "positional-pin")
+	assert.Contains(t, s, "pin-value=REDACTED")
+	assert.Contains(t, s, "management-key=REDACTED")
+	assert.Contains(t, s, "serial=7654321")
+	assert.Contains(t, s, "slot-id=9c")
+	assert.Contains(t, s, "smart card error 6982")
+}
+
+func TestExitErrorRedactsStderr(t *testing.T) {
+	cmd := exec.Command("step-kms-plugin", "attest",
+		"--kms", "yubikey:serial=1;pin-value=secret123", "yubikey:slot-id=9c")
+	ee := &exec.ExitError{
+		ProcessState: &os.ProcessState{},
+		Stderr:       []byte("Error: yubikey:serial=1;pin-value=secret123 does not implement Attester"),
+	}
+
+	err := exitError(cmd, ee)
+	require.Error(t, err)
+
+	s := err.Error()
+	assert.NotContains(t, s, "secret123")
+	assert.Contains(t, s, "does not implement Attester")
+}
+
+func TestExitErrorRedactsWrappedError(t *testing.T) {
+	cmd := exec.Command("step-kms-plugin", "key",
+		"--kms", "pkcs11:token=smallstep?pin-value=badger", "pkcs11:id=7777")
+	sentinel := errors.New("something went wrong")
+
+	err := exitError(cmd, sentinel)
+	require.Error(t, err)
+	require.ErrorIs(t, err, sentinel)
+
+	s := err.Error()
+	assert.NotContains(t, s, "badger")
+	assert.Contains(t, s, "pin-value=REDACTED")
+	assert.Contains(t, s, "token=smallstep")
+}
+
+func TestRedactSecrets(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"yubikey pin-value mid-uri", "yubikey:serial=123;pin-value=secret;slot-id=9c", "yubikey:serial=123;pin-value=REDACTED;slot-id=9c"},
+		{"yubikey management-key", "yubikey:management-key=010203;pin-value=abc", "yubikey:management-key=REDACTED;pin-value=REDACTED"},
+		{"pkcs11 query attribute", "pkcs11:token=step?pin-value=pass&max-sessions=2", "pkcs11:token=step?pin-value=REDACTED&max-sessions=2"},
+		{"azurekms client-secret", "azurekms:name=k;vault=v?client-id=id&client-secret=hunter2&tenant-id=t", "azurekms:name=k;vault=v?client-id=id&client-secret=REDACTED&tenant-id=t"},
+		{"case-insensitive key", "yubikey:PIN-VALUE=abc", "yubikey:PIN-VALUE=REDACTED"},
+		{"value at end of string", "yubikey:serial=1;pin-value=xyz", "yubikey:serial=1;pin-value=REDACTED"},
+		{"empty value", "yubikey:pin-value=;slot-id=9a", "yubikey:pin-value=REDACTED;slot-id=9a"},
+		{"value containing equals and percent", "yubikey:pin-value=a=b%20c;slot-id=9a", "yubikey:pin-value=REDACTED;slot-id=9a"},
+		{"value with leading single quote", "yubikey:pin-value='q';slot-id=9c", "yubikey:pin-value=REDACTED;slot-id=9c"},
+		{"value with embedded single quote", "pkcs11:token=step?pin-value=my'pin&max-sessions=2", "pkcs11:token=step?pin-value=REDACTED&max-sessions=2"},
+		{"pin-source is a path, not a secret", "yubikey:pin-source=/etc/pin.txt;management-key-source=/etc/mk.txt", "yubikey:pin-source=/etc/pin.txt;management-key-source=/etc/mk.txt"},
+		{"uri quoted inside prose", `error parsing "yubikey:serial=1;pin-value=abc": invalid uri`, `error parsing "yubikey:serial=1;pin-value=REDACTED": invalid uri`},
+		{"multiple uris in one string", "--kms yubikey:pin-value=aaa yubikey:slot-id=9c;pin-value=bbb", "--kms yubikey:pin-value=REDACTED yubikey:slot-id=9c;pin-value=REDACTED"},
+		{"no secrets", "tpmkms:name=my-key;device=/dev/tpmrm0", "tpmkms:name=my-key;device=/dev/tpmrm0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, redactSecrets(tt.in))
+		})
+	}
+}


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

Redact KMS URI secrets (`pin-value`, `management-key`, `client-secret`) from the error
printed when a `step-kms-plugin` subprocess fails.


#### Pain or issue this feature alleviates:

When the plugin subprocess fails, `step` prints the full command line it ran — including
the KMS URI with any inline credential. A real ceremony on Windows (step 0.30.6,
step-kms-plugin 0.17.0, YubiKey 4) produced:

```
error creating certificate request: command "C:\\Users\\...\\step-kms-plugin.exe sign --format base64 --kms yubikey:serial=NNNNNNN;pin-value=<THE ACTUAL PIV PIN> yubikey:slot-id=9c" failed with:
Error: command failed: smart card error 6982: security status not satisfied
```

`pin-value=` is the documented way to supply the PIN non-interactively, so using the
feature as designed puts the secret on stderr on any failure. From there it lands in
console scrollback, session transcripts, CI logs — and GitHub issues, because pasting
exactly this error text is what users do when reporting bugs.

#### Why is this important to the project (if not answered above):

1. Secret disclosure through the documented mechanism, on the error path users hit most.
2. Error-paste amplification: the current design invites PIV PINs into public issue
   trackers and search indexes.
3. The fix is small and non-breaking: the command echo is genuinely useful for debugging
   and is kept — only the values of the three credential-carrying attributes across all
   KMS schemes (`pin-value` for yubikey/pkcs11/capi, `management-key` for yubikey,
   `client-secret` for azurekms) are replaced with `REDACTED`. The redaction runs over
   the whole rendered command line, so it also covers a secret that reaches the plugin
   as a positional argument — `--attestation-uri` is passed as both the `--kms` value
   and the positional key argument (`utils/cautils/acmeutils.go`).

The plugin's own stderr is scrubbed with the same expression before being embedded,
because step-kms-plugin echoes the URI itself on some paths (e.g.
`%s does not implement Attester` in `cmd/attest.go`), and `go.step.sm/crypto`'s
`uri.Parse` errors embed the raw URI as well.

Redaction stops the value at the next URI delimiter (`;`, `&`, `?`), whitespace, or a
double quote, so the surrounding command line and any Go-quoted error prose stay intact.
One residual limitation, inherent to string-level redaction: a value containing a raw,
non-percent-encoded space is only redacted up to that space. Such a URI is malformed
(a well-formed URI percent-encodes the space, which redacts fully); the fix trades a
rare partial leak for keeping the rest of the command readable, rather than
over-redacting every failure message.

#### Is there documentation on how to use this feature? If so, where?

No behavior to document: error output now shows `pin-value=REDACTED` in place of the
secret; everything else is unchanged.

#### In what environments or workflows is this feature supported?

Redact KMS URI secrets (`pin-value`, `management-key`, `client-secret`) from the error
printed when a `step-kms-plugin` subprocess fails.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

All platforms and all KMS schemes; the redaction is plain string processing in
`internal/cryptoutil` with hardware-free unit tests (the package's first).

#### Supporting links/other PRs/issues:

- Fixes #1668 (the bug report for this leak)


💔Thank you!
