### PR TITLE
Remove KeyUsageCertSign requirement for X5C provisioner roots

### DIFF
--- a/command/ca/provisioner/add.go
+++ b/command/ca/provisioner/add.go
@@ -633,12 +633,6 @@ func createX5CDetails(ctx *cli.Context) (*linkedca.ProvisionerDetails, error) {
 	}
 	var rootBytes [][]byte
 	for _, r := range roots {
-		if r.KeyUsage&x509.KeyUsageCertSign == 0 {
-			return nil, errors.Errorf("error: certificate with common name '%s' cannot be "+
-				"used as an X5C root certificate.\n\n"+
-				"X5C provisioner root certificates must have the 'Certificate Sign' key "+
-				"usage extension.", r.Subject.CommonName)
-		}
 		rootBytes = append(rootBytes, pem.EncodeToMemory(&pem.Block{
 			Type:  "CERTIFICATE",
 			Bytes: r.Raw,

--- a/command/ca/provisioner/update.go
+++ b/command/ca/provisioner/update.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
-	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"net/url"
@@ -702,12 +701,6 @@ func updateX5CDetails(ctx *cli.Context, p *linkedca.Provisioner) error {
 		}
 		var rootBytes [][]byte
 		for _, r := range roots {
-			if r.KeyUsage&x509.KeyUsageCertSign == 0 {
-				return errors.Errorf("error: certificate with common name '%s' cannot be "+
-					"used as an X5C root certificate.\n\n"+
-					"X5C provisioner root certificates must have the 'Certificate Sign' key "+
-					"usage extension.", r.Subject.CommonName)
-			}
 			rootBytes = append(rootBytes, pem.EncodeToMemory(&pem.Block{
 				Type:  "CERTIFICATE",
 				Bytes: r.Raw,


### PR DESCRIPTION
Closes #1329

The CLI enforced that X5C root certificates must have the `KeyUsageCertSign` extension, but the step-ca API does not require this. A self-signed certificate without `KeyUsageCertSign` can successfully authenticate via `--x5c-cert`/`--x5c-key` flags, so the CLI should not reject it during provisioner creation.

This removes the `KeyUsageCertSign` check from both `createX5CDetails()` in `add.go` and `updateX5CDetails()` in `update.go`, aligning the CLI behavior with the API.

As noted in the issue: the only requirement from the API is that the client certificate has `Digital Signature` in its Key Usage so it can sign tokens. The root certificate validation during provisioner creation is overly strict compared to what the API actually enforces.