### PR TITLE
Fail step context list when there are no contexts

### DIFF
--- a/command/context/list.go
+++ b/command/context/list.go
@@ -3,6 +3,7 @@ package context
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 
 	"github.com/smallstep/cli-utils/command"
@@ -37,12 +38,20 @@ ssh.beta
 func listAction(*cli.Context) error {
 	cs := step.Contexts()
 
+	contexts := cs.ListAlphabetical()
+	if len(contexts) == 0 {
+		// Printing nothing and exiting 0 is indistinguishable from a STEPPATH
+		// that has contexts but none of them listable, so say so and fail the
+		// way `step context current` does when there is nothing selected.
+		return errors.New("no contexts present")
+	}
+
 	cur := cs.GetCurrent()
 	if cur != nil {
 		fmt.Printf("▶ %s\n", cur.Name)
 	}
 
-	for _, v := range cs.ListAlphabetical() {
+	for _, v := range contexts {
 		if cur != nil && v.Name == cur.Name {
 			continue
 		}


### PR DESCRIPTION
Fixes #879.

Still reproduces on master:

```
$ export STEPPATH=/tmp/steppath   # empty
$ step context list
$ echo $?
0
$ step context current
no context selected
$ echo $?
1
```

`listAction` returns nil unconditionally, so an empty `STEPPATH` looks exactly like a successful listing that happened to have nothing in it. `step context current` already errors in the equivalent situation, which is what @jdoss ended up using as the workaround, so this makes `list` behave the same way.

After:

```
$ step context list
no contexts present
$ echo $?
1
```

The message goes to stderr (stdout is empty with `2>/dev/null`), which is what the issue asked for.

I checked the populated case too, since the listing loop now runs over a variable rather than calling `ListAlphabetical()` inline:

```
$ STEPPATH=/tmp/steppath2 step context list
▶ beta
alpha-one
$ echo $?
0
```

Byte-identical to master's output for the same STEPPATH.

No test here: `listAction` reads the package-level `step.Contexts()`, which needs `step.Init()` and a STEPPATH to be set up, and nothing under `command/` currently does that, so a test for this one command would have meant introducing global-state setup that has no precedent in the tree. Happy to add one if you would like it, and if you have a preferred way of standing up a STEPPATH in tests I would rather follow that than invent one.

`go build ./...`, `go vet ./command/context/` and `go test ./command/...` are clean.
