### PR TITLE
Remove colon from end of device auth URL

### DIFF
--- a/command/oauth/cmd.go
+++ b/command/oauth/cmd.go
@@ -915,7 +915,7 @@ func (o *oauth) DoDeviceAuthorization() (*token, error) {
 		fmt.Fprintf(os.Stderr, "Visit %s and enter the code:\n", idr.VerificationURI)
 		fmt.Fprintln(os.Stderr, idr.UserCode)
 	} else {
-		fmt.Fprintf(os.Stderr, "Visit %s:\n", idr.VerificationURI)
+		fmt.Fprintf(os.Stderr, "Visit %s\n", idr.VerificationURI)
 	}
 
 	// Poll the Token endpoint until the user completes the flow.


### PR DESCRIPTION
Removes the colon at the end of the URL that gets printed for device auth - on some terminals (I am using Ghostty on mac), when trying to click to follow the URL the colon is treated as part of the URL and results in getting sent to an error page.